### PR TITLE
Fix tests and execution on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,17 @@ jobs:
           toolchain: stable
       - name: Run Rust tests
         run: PATH_TO_GIT="$PWD"/git cargo test
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Run Rust tests
+        run: |
+          $env:PATH_TO_GIT='C:\Program Files\Git\cmd\git.exe'
+          cargo test

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -240,7 +240,11 @@ mod tests {
                 "branchless",
                 "wrap",
                 "--git-executable",
-                "/bin/echo",
+                if cfg!(target_os = "windows") {
+                    "echo"
+                } else {
+                    "/bin/echo"
+                },
                 "hello",
                 "world",
             ])?;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use crate::util::{wrap_git_error, GitExecutable, GitVersion};
+use crate::util::{get_sh, wrap_git_error, GitExecutable, GitVersion};
 use anyhow::Context;
 use fn_error_context::context;
 
@@ -99,11 +99,16 @@ impl Git {
             .git_executable
             .parent()
             .expect("Unable to find git path parent");
-        std::env::join_paths(vec![
+        let bash = get_sh().expect("bash missing?");
+        let bash_path = bash.parent().unwrap();
+        std::env::join_paths(
+            vec![
                 // For Git to be able to launch `git-branchless`.
                 branchless_path,
                 // For our hooks to be able to call back into `git`.
                 git_path,
+                // For branchless to manually invoke bash when needed.
+                bash_path,
             ]
             .iter()
             .map(|path| path.to_str().expect("Unable to decode path component")),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -99,16 +99,18 @@ impl Git {
             .git_executable
             .parent()
             .expect("Unable to find git path parent");
-        vec![
-            // For Git to be able to launch `git-branchless`.
-            branchless_path,
-            // For our hooks to be able to call back into `git`.
-            git_path,
-        ]
-        .iter()
-        .map(|path| path.to_str().expect("Unable to decode path component"))
-        .collect::<Vec<_>>()
-        .join(":")
+        std::env::join_paths(vec![
+                // For Git to be able to launch `git-branchless`.
+                branchless_path,
+                // For our hooks to be able to call back into `git`.
+                git_path,
+            ]
+            .iter()
+            .map(|path| path.to_str().expect("Unable to decode path component")),
+        )
+        .expect("joining paths")
+        .to_string_lossy()
+        .to_string()
     }
 
     /// Run a Git command.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -152,15 +152,9 @@ impl Git {
             // messages. Usually, we can set this with `git commit -m`, but we have
             // no such option for things such as `git rebase`, which may call `git
             // commit` later as a part of their execution.
-            ("GIT_EDITOR", {
-                // Some systems have `/bin/true` and others have
-                // `/usr/bin/true`. Pick whichever one we can find.
-                if Path::new("/bin/true").exists() {
-                    "/bin/true"
-                } else {
-                    "/usr/bin/true"
-                }
-            }),
+            //
+            // ":" is understood by `git` to skip editing.
+            ("GIT_EDITOR", ":"),
             (
                 "PATH_TO_GIT",
                 git_executable

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -126,7 +126,11 @@ impl Git {
             expected_exit_code,
         } = options;
 
-        let default_path = Path::new("/usr/bin/git");
+        let default_path = if cfg!(target_os = "windows") {
+            Path::new("C:\\Program Files\\Git\\bin\\git.exe")
+        } else {
+            Path::new("/usr/bin/git")
+        };
         let git_executable = if !use_system_git {
             &self.git_executable
         } else {

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -1,4 +1,6 @@
+use anyhow::Context;
 use branchless::testing::with_git;
+use branchless::util::get_sh;
 use std::process::Command;
 
 fn preprocess_stderr(stderr: String) -> String {
@@ -166,8 +168,11 @@ fn test_pre_auto_gc() -> anyhow::Result<()> {
         // `pre-auto-gc` hook to be invoked at all. We'll just invoke the hook
         // directly to make sure that it's installed properly.
         std::env::set_current_dir(&git.repo_path)?;
-        let hook_path = git.repo_path.join(".git").join("hooks").join("pre-auto-gc");
-        let output = Command::new(hook_path)
+        let output = Command::new(get_sh().context("bash needed to run pre-auto-gc")?)
+            .arg("-c")
+            // Always use a unix style path here, as we are handing it to bash (even on Windows).
+            .arg("./.git/hooks/pre-auto-gc")
+            .current_dir(&git.repo_path)
             .env("PATH", git.get_path_for_env())
             .output()?;
 

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -6,6 +6,8 @@ fn preprocess_stderr(stderr: String) -> String {
         // Interactive progress displays may update the same line multiple times
         // with a carriage return before emitting the final newline.
         .replace("\r", "\n")
+        // Window pseudo console may emit EL 'Erase in Line' VT sequences.
+        .replace("\x1b[K", "")
         .lines()
         .filter(|line| {
             !line.chars().all(|c| c.is_whitespace()) && !line.starts_with("branchless: processing")


### PR DESCRIPTION
This PR fixes various issues affecting execution of git-branchless commands and tests on Windows.

- Fixes handling of PATH environment variable (separator)
- Calls "echo" from PATH on Windows, as git-bash actually keeps it at /usr/bin/echo
- Strips EL VT sequence from test output (injected by git.exe or ConPTY?)
- Use ":" for GIT_EDITOR to have git skip commit editing (during test invocations)
- Provide a default git.exe path (for when use_system_git == true)
- Call hooks via execution of sh, using git-bash on Windows when found.

With these changes all tests pass and commands appear to work as intended.