### PR TITLE
Split CI workflows up for the OS badges

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,26 @@
+name: Static Analysis
+
+on: ["push", "pull_request"]
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Run `cargo fmt`
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Run `cargo clippy`
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Static Analysis
+name: Lint
 
 on: ["push", "pull_request"]
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,29 +1,8 @@
-name: CI
+name: Linux
 
 on: ["push", "pull_request"]
 
 jobs:
-  static-analysis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
-      - name: Run `cargo fmt`
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      - name: Run `cargo clippy`
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
   build-git:
     runs-on: ubuntu-latest
     strategy:
@@ -56,7 +35,7 @@ jobs:
           path: git.tar.gz
           if-no-files-found: error
 
-  test:
+  run-tests:
     runs-on: ubuntu-latest
     needs: build-git
     strategy:
@@ -78,16 +57,3 @@ jobs:
       - name: Run Rust tests
         run: PATH_TO_GIT="$PWD"/git cargo test
 
-  test-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - name: Run Rust tests
-        run: |
-          $env:PATH_TO_GIT='C:\Program Files\Git\cmd\git.exe'
-          cargo test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,9 @@
 name: macOS
 
-on: ["push", "pull_request"]
+on:
+  schedule:
+    # Run Mondays and Thursdays at 6:40AM UTC.
+    - cron: '40 6 * * 1,4'
 
 jobs:
   run-tests:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,18 @@
+name: macOS
+
+on: ["push", "pull_request"]
+
+jobs:
+  run-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Run tests
+        run: |
+          export PATH_TO_GIT=$(which git)
+          cargo test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,18 @@
+name: Windows
+
+on: ["push", "pull_request"]
+
+jobs:
+  run-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Run tests
+        run: |
+          $env:PATH_TO_GIT='C:\Program Files\Git\cmd\git.exe'
+          cargo test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Branchless workflow for Git
 
-[![CI](https://github.com/arxanas/git-branchless/workflows/CI/badge.svg)](https://github.com/arxanas/git-branchless/actions?query=workflow%3ACI+branch%3Amaster)
+[![Linux](https://github.com/arxanas/git-branchless/actions/workflows/linux.yml/badge.svg)](https://github.com/arxanas/git-branchless/actions/workflows/linux.yml)
+[![Windows](https://github.com/arxanas/git-branchless/actions/workflows/windows.yml/badge.svg)](https://github.com/arxanas/git-branchless/actions/worksflows/windows.yml)
+[![macOS](https://github.com/arxanas/git-branchless/actions/workflows/macos.yml/badge.svg)](https://github.com/arxanas/git-branchless/actions/workflows/macos.yml)
 [![crates.io](http://meritbadge.herokuapp.com/git-branchless)](https://crates.io/crates/git-branchless)
 
 `git-branchless` is a suite of tools to help you **visualize**, **navigate**, **manipulate**, and **repair** your commit history. It's based off of the branchless Mercurial workflows at large companies such as Google and Facebook.


### PR DESCRIPTION
Allows the reader to see that the project's CI supports their platform
at a glance.

Badge links format looks to have changed. Tested by pointing temporarily
at my own repo to see the badges in the rendered README.md.