### PR TITLE
Fix `git wrap` when there is no repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: `git branchless init` will attempt to detect the correct main branch name to use for the repository. If not automatically detected, it will prompt for the branch name.
 - Fixed: The version number in `git-branchless --help` was fixed at `0.2.0`. It now reflects the version of the package.
+- Fixed:  `git branchless wrap` no longer fails to run if there is no Git repository in the current directory.
 
 ## [0.3.2] - 2021-06-23
 

--- a/tests/command/test_wrap.rs
+++ b/tests/command/test_wrap.rs
@@ -1,0 +1,210 @@
+use branchless::core::eventlog::testing::{get_event_replayer_events, redact_event_timestamp};
+use branchless::core::eventlog::{Event, EventLogDb, EventReplayer};
+use branchless::testing::with_git;
+use branchless::util::get_db_conn;
+
+#[test]
+fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
+    with_git(|git| {
+        if !git.supports_reference_transactions()? {
+            return Ok(());
+        }
+
+        git.init_repo()?;
+        git.run(&["checkout", "-b", "foo"])?;
+        git.commit_file("test1", 1)?;
+        git.commit_file("test2", 2)?;
+        git.run(&["checkout", "master"])?;
+
+        git.run(&["branchless", "wrap", "rebase", "foo"])?;
+
+        let repo = git.get_repo()?;
+        let conn = get_db_conn(&repo)?;
+        let event_log_db = EventLogDb::new(&conn)?;
+        let event_replayer = EventReplayer::from_event_log_db(&event_log_db)?;
+        let events: Vec<Event> = get_event_replayer_events(&event_replayer)
+            .iter()
+            .map(|event| redact_event_timestamp(event.clone()))
+            .collect();
+
+        insta::assert_debug_snapshot!(events, @r###"
+            [
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        1,
+                    ),
+                    ref_name: "refs/heads/foo",
+                    old_ref: None,
+                    new_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        2,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    new_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        3,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    new_ref: Some(
+                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        3,
+                    ),
+                    ref_name: "refs/heads/foo",
+                    old_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    new_ref: Some(
+                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
+                    ),
+                    message: None,
+                },
+                CommitEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        4,
+                    ),
+                    commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        5,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: Some(
+                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
+                    ),
+                    new_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        5,
+                    ),
+                    ref_name: "refs/heads/foo",
+                    old_ref: Some(
+                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
+                    ),
+                    new_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    message: None,
+                },
+                CommitEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        6,
+                    ),
+                    commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        7,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    new_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        8,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: None,
+                    new_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        8,
+                    ),
+                    ref_name: "HEAD",
+                    old_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    new_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    message: None,
+                },
+                RefUpdateEvent {
+                    timestamp: 0.0,
+                    event_tx_id: EventTransactionId(
+                        8,
+                    ),
+                    ref_name: "refs/heads/master",
+                    old_ref: Some(
+                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
+                    ),
+                    new_ref: Some(
+                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
+                    ),
+                    message: None,
+                },
+            ]
+            "###);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_wrap_explicit_git_executable() -> anyhow::Result<()> {
+    with_git(|git| {
+        git.init_repo()?;
+        let (stdout, _stderr) = git.run(&[
+            "branchless",
+            "wrap",
+            "--git-executable",
+            // Don't use a hardcoded executable like `echo` here (see
+            // https://github.com/arxanas/git-branchless/issues/26). We also
+            // don't want to use `git`, since that's the default value for
+            // this argument, so we wouldn't be able to tell if it was
+            // working. But we're certain to have `git-branchless` on
+            // `PATH`!
+            "git-branchless",
+            "--",
+            "--help",
+        ])?;
+        assert!(stdout.contains("Branchless workflow for Git."));
+        Ok(())
+    })
+}

--- a/tests/command/test_wrap.rs
+++ b/tests/command/test_wrap.rs
@@ -208,3 +208,15 @@ fn test_wrap_explicit_git_executable() -> anyhow::Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn test_wrap_without_repo() -> anyhow::Result<()> {
+    with_git(|git| {
+        let (stdout, stderr) = git.run(&["branchless", "wrap", "status"])?;
+        insta::assert_snapshot!(stderr, @"fatal: not a git repository (or any of the parent directories): .git
+");
+        insta::assert_snapshot!(stdout, @"");
+
+        Ok(())
+    })
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,4 +14,5 @@ mod command {
     mod test_restack;
     mod test_smartlog;
     mod test_undo;
+    mod test_wrap;
 }


### PR DESCRIPTION
- refactor(wrap): move test cases out of source module
- fix(wrap): don't fail if no Git repository is available
