### PR TITLE
docs(wrap): remove item about adding a feature to `git branchless wrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ As a result of this work, `git-branchless` also includes its own build of SQLite
 - EXPERIMENTAL: Created `git move` command, which rebases entire subtrees at once. Not currently stable.
 - Added: `git branchless init` now sets `advice.detachedHead false`, to reduce the incidence of scary messages.
 - Added: aliasing `git` to `git-branchless wrap` improves which commands are grouped together for `git undo`, and possibly enables more features in the future.
-- Added: The `git-branchless wrap` command can now take an explicit `--git-executable` parameter to indicate which program to run.
 - Added: `git-branchless` builds on Windows (#13, #20).
 - Fixed: Visible commits in the smartlog sometimes showed the reason that they were hidden, even though they were visible.
 - Fixed: The working copy was sometimes left dirty after a `git undo`, even if it was clean beforehand.


### PR DESCRIPTION
Since `git branchless wrap` was released in v0.3.2, it doesn't make sense to also include items in the changelog about how the feature has changed.
