### PR TITLE
Attempt to fix flaky undo tests (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `git branchless init --uninstall` will uninstall `git-branchless` from the repository.
 - Fixed: The version number in `git-branchless --help` was fixed at `0.2.0`. It now reflects the version of the package.
 - Fixed:  `git branchless wrap` no longer fails to run if there is no Git repository in the current directory.
+- Fixed: User hooks which are invoked by `git-branchless` are now invoked in the correct working directory.
 
 ## [0.3.2] - 2021-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "insta",
  "lazy_static",
  "log",
+ "os_str_bytes",
  "regex",
  "rusqlite",
  "simple_logger",
@@ -815,6 +816,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "os_str_bytes"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
 name = "owning_ref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ git2 = {version = "0.13.17", default-features = false}
 indicatif = "0.16.2"
 lazy_static = "1.4.0"
 log = "0.4.14"
+os_str_bytes = "3.1.0"
 regex = "1.4.4"
 rusqlite = {version = "0.24.2", features = ["bundled"]}
 simple_logger = "1.11.0"

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -12,7 +12,7 @@ use crate::core::mergebase::MergeBaseDb;
 use crate::core::rewrite::{execute_rebase_plan, make_rebase_plan};
 use crate::util::get_main_branch_oid;
 use crate::util::{
-    get_branch_oid_to_names, get_db_conn, get_head_oid, get_repo, resolve_commits, GitExecutable,
+    get_branch_oid_to_names, get_db_conn, get_head_oid, get_repo, resolve_commits, GitRunInfo,
     ResolveCommitsResult,
 };
 
@@ -36,7 +36,7 @@ fn resolve_base_commit(graph: &CommitGraph, oid: git2::Oid) -> git2::Oid {
 
 /// Move a subtree from one place to another.
 pub fn r#move(
-    git_executable: &GitExecutable,
+    git_run_info: &GitRunInfo,
     source: Option<String>,
     dest: Option<String>,
     base: Option<String>,
@@ -115,7 +115,7 @@ pub fn r#move(
     )?;
     let result = execute_rebase_plan(
         &glyphs,
-        git_executable,
+        git_run_info,
         &repo,
         event_tx_id,
         &rebase_plan,

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -14,15 +14,15 @@ use crate::core::mergebase::MergeBaseDb;
 use crate::core::metadata::{render_commit_metadata, CommitMessageProvider, CommitOidProvider};
 use crate::util::{
     get_branch_oid_to_names, get_db_conn, get_head_oid, get_main_branch_oid, get_repo, run_git,
-    GitExecutable,
+    GitRunInfo,
 };
 
 /// Go back a certain number of commits.
-pub fn prev(git_executable: &GitExecutable, num_commits: Option<isize>) -> anyhow::Result<isize> {
+pub fn prev(git_run_info: &GitRunInfo, num_commits: Option<isize>) -> anyhow::Result<isize> {
     let exit_code = match num_commits {
-        None => run_git(git_executable, None, &["checkout", "HEAD^"])?,
+        None => run_git(git_run_info, None, &["checkout", "HEAD^"])?,
         Some(num_commits) => run_git(
-            git_executable,
+            git_run_info,
             None,
             &["checkout", &format!("HEAD~{}", num_commits)],
         )?,
@@ -134,7 +134,7 @@ fn advance_towards_own_commit(
 
 /// Go forward a certain number of commits.
 pub fn next(
-    git_executable: &GitExecutable,
+    git_run_info: &GitRunInfo,
     num_commits: Option<isize>,
     towards: Option<Towards>,
 ) -> anyhow::Result<isize> {
@@ -178,11 +178,7 @@ pub fn next(
         Some(current_oid) => current_oid,
     };
 
-    let result = run_git(
-        git_executable,
-        None,
-        &["checkout", &current_oid.to_string()],
-    )?;
+    let result = run_git(git_run_info, None, &["checkout", &current_oid.to_string()])?;
     if result != 0 {
         return Ok(result);
     }

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -25,7 +25,7 @@ use crate::core::metadata::{
 };
 use crate::core::tui::{with_siv, SingletonView};
 use crate::declare_views;
-use crate::util::{get_db_conn, get_repo, run_git, GitExecutable};
+use crate::util::{get_db_conn, get_repo, run_git, GitRunInfo};
 
 fn render_cursor_smartlog(
     glyphs: &Glyphs,
@@ -608,7 +608,7 @@ fn undo_events(
     out: &mut impl Write,
     glyphs: &Glyphs,
     repo: &git2::Repository,
-    git_executable: &GitExecutable,
+    git_run_info: &GitRunInfo,
     event_log_db: &mut EventLogDb,
     event_replayer: &EventReplayer,
     event_cursor: EventCursor,
@@ -696,7 +696,7 @@ fn undo_events(
                 // dirty working copy). The `Git` command will update the event
                 // log appropriately, as it will invoke our hooks.
                 run_git(
-                    git_executable,
+                    git_run_info,
                     Some(event_tx_id),
                     &["checkout", "--detach", &new_ref],
                 )
@@ -767,7 +767,7 @@ fn undo_events(
 }
 
 /// Restore the repository to a previous state interactively.
-pub fn undo(git_executable: &GitExecutable) -> anyhow::Result<isize> {
+pub fn undo(git_run_info: &GitRunInfo) -> anyhow::Result<isize> {
     let glyphs = Glyphs::detect();
     let repo = get_repo()?;
     let conn = get_db_conn(&repo)?;
@@ -790,7 +790,7 @@ pub fn undo(git_executable: &GitExecutable) -> anyhow::Result<isize> {
         &mut stdout().lock(),
         &glyphs,
         &repo,
-        &git_executable,
+        &git_run_info,
         &mut event_log_db,
         &event_replayer,
         event_cursor,
@@ -807,7 +807,7 @@ pub mod testing {
     use crate::core::eventlog::{EventCursor, EventLogDb, EventReplayer};
     use crate::core::formatting::Glyphs;
     use crate::core::mergebase::MergeBaseDb;
-    use crate::util::GitExecutable;
+    use crate::util::GitRunInfo;
 
     pub fn select_past_event(
         siv: CursiveRunner<CursiveRunnable>,
@@ -824,7 +824,7 @@ pub mod testing {
         out: &mut impl Write,
         glyphs: &Glyphs,
         repo: &git2::Repository,
-        git_executable: &GitExecutable,
+        git_run_info: &GitRunInfo,
         event_log_db: &mut EventLogDb,
         event_replayer: &EventReplayer,
         event_cursor: EventCursor,
@@ -834,7 +834,7 @@ pub mod testing {
             out,
             glyphs,
             repo,
-            git_executable,
+            git_run_info,
             event_log_db,
             event_replayer,
             event_cursor,

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -8,14 +8,14 @@ use std::time::SystemTime;
 use anyhow::Context;
 
 use crate::core::eventlog::{EventLogDb, EventTransactionId, BRANCHLESS_TRANSACTION_ID_ENV_VAR};
-use crate::util::{get_db_conn, get_repo, GitExecutable};
+use crate::util::{get_db_conn, get_repo, GitRunInfo};
 
 fn pass_through_git_command<S: AsRef<str> + std::fmt::Debug>(
-    git_executable: &GitExecutable,
+    git_run_info: &GitRunInfo,
     args: &[S],
     event_tx_id: Option<EventTransactionId>,
 ) -> anyhow::Result<isize> {
-    let GitExecutable(program) = git_executable;
+    let GitRunInfo(program) = git_run_info;
     let mut command = Command::new(program);
     command.args(args.iter().map(|arg| arg.as_ref()));
     if let Some(event_tx_id) = event_tx_id {
@@ -44,14 +44,14 @@ fn make_event_tx_id<S: AsRef<str> + std::fmt::Debug>(
 
 /// Run the provided Git command, but wrapped in an event transaction.
 pub fn wrap<S: AsRef<str> + std::fmt::Debug>(
-    git_executable: &GitExecutable,
+    git_run_info: &GitRunInfo,
     args: &[S],
 ) -> anyhow::Result<isize> {
     // We may not be able to make an event transaction ID (such as if there is
     // no repository in the current directory). Ignore the error in that case.
     let event_tx_id = make_event_tx_id(args).ok();
 
-    let exit_code = pass_through_git_command(git_executable, args, event_tx_id)?;
+    let exit_code = pass_through_git_command(git_run_info, args, event_tx_id)?;
     Ok(exit_code)
 }
 

--- a/src/core/rewrite.rs
+++ b/src/core/rewrite.rs
@@ -379,6 +379,7 @@ fn rebase_in_memory(
 }
 
 fn move_branches<'a>(
+    git_run_info: &GitRunInfo,
     repo: &'a git2::Repository,
     event_tx_id: EventTransactionId,
     rewritten_oids_map: &'a HashMap<git2::Oid, git2::Oid>,
@@ -424,6 +425,7 @@ fn move_branches<'a>(
         })
         .collect();
     run_hook(
+        git_run_info,
         repo,
         "reference-transaction",
         event_tx_id,
@@ -456,7 +458,7 @@ fn post_rebase_in_memory(
     // a lot of changes in the working copy.
     repo.set_head_detached(head_oid)?;
 
-    move_branches(repo, event_tx_id, &rewritten_oids_map)?;
+    move_branches(git_run_info, repo, event_tx_id, &rewritten_oids_map)?;
 
     // Call the `post-rewrite` hook only after moving branches so that we don't
     // produce a spurious abandoned-branch warning.
@@ -465,6 +467,7 @@ fn post_rebase_in_memory(
         .map(|(old_oid, new_oid)| format!("{} {}\n", old_oid.to_string(), new_oid.to_string()))
         .collect();
     run_hook(
+        git_run_info,
         repo,
         "post-rewrite",
         event_tx_id,

--- a/src/util.rs
+++ b/src/util.rs
@@ -485,12 +485,11 @@ mod tests {
                     .join(".git")
                     .join("hooks")
                     .join("post-rewrite"),
-                r#"
-#!/bin/sh
-# This won't work unless we're running the hook in the Git working copy.
-echo "Contents of test1.txt:"
-cat test1.txt
-"#,
+                r#"#!/bin/sh
+                   # This won't work unless we're running the hook in the Git working copy.
+                   echo "Contents of test1.txt:"
+                   cat test1.txt
+                   "#,
             )?;
 
             {

--- a/tests/command/test_smartlog.rs
+++ b/tests/command/test_smartlog.rs
@@ -1,5 +1,5 @@
-use branchless::testing::{get_git_executable, with_git, Git, GitInitOptions, GitRunOptions};
-use branchless::util::GitExecutable;
+use branchless::testing::{get_path_to_git, with_git, Git, GitInitOptions, GitRunOptions};
+use branchless::util::GitRunInfo;
 
 #[test]
 fn test_init_smartlog() -> anyhow::Result<()> {
@@ -303,14 +303,14 @@ fn test_custom_main_branch() -> anyhow::Result<()> {
 
 #[test]
 fn test_main_remote_branch() -> anyhow::Result<()> {
-    let git_executable = get_git_executable()?;
-    let git_executable = GitExecutable(git_executable);
+    let path_to_git = get_path_to_git()?;
+    let git_run_info = GitRunInfo(path_to_git);
     let temp_dir = tempfile::tempdir()?;
     let original_repo_path = temp_dir.path().join("original");
     std::fs::create_dir(&original_repo_path)?;
-    let original_repo = Git::new(original_repo_path, git_executable.clone());
+    let original_repo = Git::new(original_repo_path, git_run_info.clone());
     let cloned_repo_path = temp_dir.path().join("cloned");
-    let cloned_repo = Git::new(cloned_repo_path, git_executable);
+    let cloned_repo = Git::new(cloned_repo_path, git_run_info);
 
     {
         std::env::set_current_dir(&original_repo.repo_path)?;

--- a/tests/command/test_undo.rs
+++ b/tests/command/test_undo.rs
@@ -12,7 +12,7 @@ use branchless::core::tui::testing::{
     screen_to_string, CursiveTestingBackend, CursiveTestingEvent,
 };
 use branchless::testing::{with_git, Git};
-use branchless::util::{get_db_conn, GitExecutable};
+use branchless::util::{get_db_conn, GitRunInfo};
 
 use cursive::event::Key;
 use cursive::CursiveRunnable;
@@ -71,7 +71,7 @@ fn run_undo_events(git: &Git, event_cursor: EventCursor) -> anyhow::Result<Strin
         &mut out,
         &glyphs,
         &repo,
-        &GitExecutable(git.git_executable.clone()),
+        &GitRunInfo(git.path_to_git.clone()),
         &mut event_log_db,
         &event_replayer,
         event_cursor,

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -167,7 +167,6 @@ fn test_pre_auto_gc() -> anyhow::Result<()> {
         // See https://stackoverflow.com/q/3433653/344643, it's hard to get the
         // `pre-auto-gc` hook to be invoked at all. We'll just invoke the hook
         // directly to make sure that it's installed properly.
-        std::env::set_current_dir(&git.repo_path)?;
         let output = Command::new(get_sh().context("bash needed to run pre-auto-gc")?)
             .arg("-c")
             // Always use a unix style path here, as we are handing it to bash (even on Windows).

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -172,6 +172,7 @@ fn test_pre_auto_gc() -> anyhow::Result<()> {
             // Always use a unix style path here, as we are handing it to bash (even on Windows).
             .arg("./.git/hooks/pre-auto-gc")
             .current_dir(&git.repo_path)
+            .env_clear()
             .env("PATH", git.get_path_for_env())
             .output()?;
 


### PR DESCRIPTION
- refactor(util): rename `GitExecutable` to `GitRunInfo`
- refactor(util): store more environment information in `GitRunInfo`
