### PR TITLE
ci: only trigger CI runs when pushing to `master` branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   static-analysis:
@@ -23,4 +27,3 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,10 @@
 name: Linux
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build-git:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Run once every day at 6:40AM UTC.
     - cron: "40 6 * * *"
+  push:
+    branches:
+      - master
 
 jobs:
   run-tests:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,10 @@
 name: Windows
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   run-tests:


### PR DESCRIPTION
Since this is my repository, I typically use its branches to open pull requests. But that means that each job gets run twice as a result. Instead, I'll just use the pull request workflow if I want to manually trigger a build.
