### PR TITLE
Fix 'cannot spawn .git/hooks/post-rewrite' on Windows

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -485,12 +485,11 @@ mod tests {
                     .join(".git")
                     .join("hooks")
                     .join("post-rewrite"),
-                r#"
-#!/bin/sh
-# This won't work unless we're running the hook in the Git working copy.
-echo "Contents of test1.txt:"
-cat test1.txt
-"#,
+                r#"#!/bin/sh
+                   # This won't work unless we're running the hook in the Git working copy.
+                   echo "Contents of test1.txt:"
+                   cat test1.txt
+                   "#,
             )?;
 
             {


### PR DESCRIPTION
Following is happening:

'''
error: cannot spawn .git/hooks/post-rewrite: No such file or directory: No such file or directory
'''

because the first line of the stubbed post-rewrite is a new-line, which
is interpretted by mingw as "not a shell script".