### PR TITLE
refactor(tests): `with_git` -> `make_git`

### DIFF
--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -382,7 +382,7 @@ pub fn hook_reference_transaction(transaction_state: &str) -> anyhow::Result<()>
 
 #[cfg(test)]
 mod tests {
-    use crate::testing::{with_git, GitRunOptions};
+    use crate::testing::{make_git, GitRunOptions};
 
     use super::*;
 
@@ -417,24 +417,24 @@ mod tests {
 
     #[test]
     fn test_is_rebase_underway() -> anyhow::Result<()> {
-        with_git(|git| {
-            git.init_repo()?;
-            let repo = git.get_repo()?;
-            assert!(!is_rebase_underway(&repo)?);
+        let git = make_git()?;
 
-            let oid1 = git.commit_file_with_contents("test", 1, "foo")?;
-            git.run(&["checkout", "HEAD^"])?;
-            git.commit_file_with_contents("test", 1, "bar")?;
-            git.run_with_options(
-                &["rebase", &oid1.to_string()],
-                &GitRunOptions {
-                    expected_exit_code: 1,
-                    ..Default::default()
-                },
-            )?;
-            assert!(is_rebase_underway(&repo)?);
+        git.init_repo()?;
+        let repo = git.get_repo()?;
+        assert!(!is_rebase_underway(&repo)?);
 
-            Ok(())
-        })
+        let oid1 = git.commit_file_with_contents("test", 1, "foo")?;
+        git.run(&["checkout", "HEAD^"])?;
+        git.commit_file_with_contents("test", 1, "bar")?;
+        git.run_with_options(
+            &["rebase", &oid1.to_string()],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        assert!(is_rebase_underway(&repo)?);
+
+        Ok(())
     }
 }

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -378,9 +378,20 @@ pub fn make_graph<'repo>(
     Ok(graph)
 }
 
-#[test]
-fn test_find_path_to_merge_base_stop_early() -> anyhow::Result<()> {
-    crate::testing::with_git(|git| {
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+
+    use std::collections::HashSet;
+
+    use crate::core::mergebase::MergeBaseDb;
+    use crate::testing::make_git;
+
+    #[test]
+    fn test_find_path_to_merge_base_stop_early() -> anyhow::Result<()> {
+        let git = make_git()?;
+
         git.init_repo()?;
         let test1_oid = git.commit_file("test1", 1)?;
         let test2_oid = git.commit_file("test2", 2)?;
@@ -404,5 +415,5 @@ fn test_find_path_to_merge_base_stop_early() -> anyhow::Result<()> {
         assert!(!seen_oids.contains(&test1_oid));
 
         Ok(())
-    })
+    }
 }

--- a/tests/command/test_hide.rs
+++ b/tests/command/test_hide.rs
@@ -1,259 +1,260 @@
-use branchless::testing::{with_git, GitRunOptions};
+use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
 fn test_hide_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.run(&["checkout", "master"])?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.run(&["checkout", "master"])?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |\
             | o 62fc20d2 create test1.txt
             |
             @ fe65c1fe create test2.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Hid commit: 62fc20d2 create test1.txt
             To unhide this commit, run: git unhide 62fc20d2
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             @ fe65c1fe create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_hide_bad_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run_with_options(
-                &["hide", "abc123"],
-                &GitRunOptions {
-                    expected_exit_code: 1,
-                    ..Default::default()
-                },
-            )?;
-            insta::assert_snapshot!(stdout, @"Commit not found: abc123");
-        }
+    git.init_repo()?;
 
-        Ok(())
-    })
+    {
+        let (stdout, _stderr) = git.run_with_options(
+            &["hide", "abc123"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @"Commit not found: abc123");
+    }
+
+    Ok(())
 }
 
 #[test]
 fn test_hide_already_hidden_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        let test1_oid = git.commit_file("test1", 1)?;
+    let git = make_git()?;
 
-        git.run(&["hide", &test1_oid.to_string()])?;
-        {
-            let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+
+    git.run(&["hide", &test1_oid.to_string()])?;
+    {
+        let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Hid commit: 62fc20d2 create test1.txt
             (It was already hidden, so this operation had no effect.)
             To unhide this commit, run: git unhide 62fc20d2
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_hide_current_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test", 1)?;
-        git.run(&["hide", "HEAD"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test", 1)?;
+    git.run(&["hide", "HEAD"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             % 3df4b935 (manually hidden) create test.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_hidden_commit_with_head_as_child() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        let test2_oid = git.commit_file("test2", 2)?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.run(&["checkout", &test2_oid.to_string()])?;
+    let git = make_git()?;
 
-        git.run(&["hide", &test1_oid.to_string()])?;
-        git.run(&["hide", &test3_oid.to_string()])?;
+    git.init_repo()?;
+    git.detach_head()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.run(&["checkout", &test2_oid.to_string()])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.run(&["hide", &test1_oid.to_string()])?;
+    git.run(&["hide", &test3_oid.to_string()])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             x 62fc20d2 (manually hidden) create test1.txt
             |
             @ 96d1c37a create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_hide_master_commit_with_hidden_children() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.detach_head()?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test4", 4)?;
-        git.commit_file("test5", 5)?;
+    let git = make_git()?;
 
-        git.run(&["hide", &test3_oid.to_string()])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test4", 4)?;
+    git.commit_file("test5", 5)?;
+
+    git.run(&["hide", &test3_oid.to_string()])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             @ 20230db7 (master) create test5.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_branches_always_visible() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["branch", "test"])?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        git.run(&["hide", "test", "test^"])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["branch", "test"])?;
+    git.run(&["checkout", "master"])?;
+
+    git.run(&["hide", "test", "test^"])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             x 62fc20d2 (manually hidden) create test1.txt
             |
             x 96d1c37a (manually hidden) (test) create test2.txt
             "###);
-        }
+    }
 
-        git.run(&["branch", "-D", "test"])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @"@ f777ecc9 (master) create initial.txt
+    git.run(&["branch", "-D", "test"])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @"@ f777ecc9 (master) create initial.txt
 ");
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_unhide() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        let test2_oid = git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Unhid commit: 96d1c37a create test2.txt
             (It was not hidden, so this operation had no effect.)
             To hide this commit, run: git hide 96d1c37a
             "###);
-        }
+    }
 
-        git.run(&["hide", &test2_oid.to_string()])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.run(&["hide", &test2_oid.to_string()])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 create test1.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Unhid commit: 96d1c37a create test2.txt
             To hide this commit, run: git hide 96d1c37a
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 create test1.txt
             |
             o 96d1c37a create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_hide_recursive() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        let test2_oid = git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "master"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 create test1.txt
@@ -262,40 +263,40 @@ fn test_hide_recursive() -> anyhow::Result<()> {
             |
             o 70deb1e2 create test3.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["hide", "-r", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["hide", "-r", &test2_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Hid commit: 96d1c37a create test2.txt
             To unhide this commit, run: git unhide 96d1c37a
             Hid commit: 70deb1e2 create test3.txt
             To unhide this commit, run: git unhide 70deb1e2
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 create test1.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["unhide", "-r", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["unhide", "-r", &test2_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Unhid commit: 96d1c37a create test2.txt
             To hide this commit, run: git hide 96d1c37a
             Unhid commit: 70deb1e2 create test3.txt
             To hide this commit, run: git hide 70deb1e2
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 create test1.txt
@@ -304,8 +305,7 @@ fn test_hide_recursive() -> anyhow::Result<()> {
             |
             o 70deb1e2 create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -1,4 +1,4 @@
-use branchless::testing::{with_git, Git, GitRunOptions};
+use branchless::testing::{make_git, Git, GitRunOptions};
 use branchless::util::GitVersion;
 
 /// Git v2.24 produces this message on `git move` tests:
@@ -16,30 +16,31 @@ fn has_git_v2_24_bug(git: &Git) -> anyhow::Result<bool> {
 
 #[test]
 fn test_move_stick_on_disk() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        git.detach_head()?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        git.run(&[
-            "move",
-            "--on-disk",
-            "-s",
-            &test3_oid.to_string(),
-            "-d",
-            &test1_oid.to_string(),
-        ])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    git.run(&[
+        "move",
+        "--on-disk",
+        "-s",
+        &test3_oid.to_string(),
+        "-d",
+        &test1_oid.to_string(),
+    ])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -49,46 +50,46 @@ fn test_move_stick_on_disk() -> anyhow::Result<()> {
             |
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_stick_in_memory() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        git.detach_head()?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        {
-            let (stdout, _stderr) = git.run(&[
-                "move",
-                "-s",
-                &test3_oid.to_string(),
-                "-d",
-                &test1_oid.to_string(),
-            ])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    {
+        let (stdout, _stderr) = git.run(&[
+            "move",
+            "-s",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             branchless: processing 2 rewritten commits
             branchless: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b
             In-memory rebase succeeded.
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -98,40 +99,40 @@ fn test_move_stick_in_memory() -> anyhow::Result<()> {
             |
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_tree_on_disk() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        git.detach_head()?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
-        git.run(&["checkout", &test3_oid.to_string()])?;
-        git.commit_file("test5", 5)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        git.run(&[
-            "move",
-            "--on-disk",
-            "-s",
-            &test3_oid.to_string(),
-            "-d",
-            &test1_oid.to_string(),
-        ])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+    git.run(&["checkout", &test3_oid.to_string()])?;
+    git.commit_file("test5", 5)?;
+
+    git.run(&[
+        "move",
+        "--on-disk",
+        "-s",
+        &test3_oid.to_string(),
+        "-d",
+        &test1_oid.to_string(),
+    ])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -143,39 +144,39 @@ fn test_move_tree_on_disk() -> anyhow::Result<()> {
             |
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_tree_in_memory() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        git.detach_head()?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
-        git.run(&["checkout", &test3_oid.to_string()])?;
-        git.commit_file("test5", 5)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        git.run(&[
-            "move",
-            "-s",
-            &test3_oid.to_string(),
-            "-d",
-            &test1_oid.to_string(),
-        ])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+    git.run(&["checkout", &test3_oid.to_string()])?;
+    git.commit_file("test5", 5)?;
+
+    git.run(&[
+        "move",
+        "-s",
+        &test3_oid.to_string(),
+        "-d",
+        &test1_oid.to_string(),
+    ])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -187,37 +188,37 @@ fn test_move_tree_in_memory() -> anyhow::Result<()> {
             |
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_with_source_not_in_smartlog_on_disk() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        git.run(&[
-            "move",
-            "--on-disk",
-            "-s",
-            &test3_oid.to_string(),
-            "-d",
-            &test1_oid.to_string(),
-        ])?;
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    git.run(&[
+        "move",
+        "--on-disk",
+        "-s",
+        &test3_oid.to_string(),
+        "-d",
+        &test1_oid.to_string(),
+    ])?;
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -225,46 +226,46 @@ fn test_move_with_source_not_in_smartlog_on_disk() -> anyhow::Result<()> {
             :
             @ 5bb72580 (master) create test4.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let test1_oid = git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
 
-        {
-            let (stdout, _stderr) = git.run(&[
-                "move",
-                "-s",
-                &test3_oid.to_string(),
-                "-d",
-                &test1_oid.to_string(),
-            ])?;
-            insta::assert_snapshot!(stdout, @r###"
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    {
+        let (stdout, _stderr) = git.run(&[
+            "move",
+            "-s",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             branchless: processing 1 update to a branch/ref
             branchless: processing 2 rewritten commits
             branchless: <git-executable> checkout master
             In-memory rebase succeeded.
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -272,55 +273,55 @@ fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
             :
             @ a2482074 (master) create test4.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_merge_conflict() -> anyhow::Result<()> {
-    with_git(|git| {
-        if has_git_v2_24_bug(&git)? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        let base_oid = git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        let other_oid = git.commit_file_with_contents("conflict", 2, "conflict 1\n")?;
-        git.run(&["checkout", &base_oid.to_string()])?;
-        git.commit_file_with_contents("conflict", 2, "conflict 2\n")?;
+    if has_git_v2_24_bug(&git)? {
+        return Ok(());
+    }
 
-        {
-            let (stdout, _stderr) = git.run_with_options(
-                &["move", "-s", &other_oid.to_string()],
-                &GitRunOptions {
-                    expected_exit_code: 1,
-                    ..Default::default()
-                },
-            )?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    let base_oid = git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    let other_oid = git.commit_file_with_contents("conflict", 2, "conflict 1\n")?;
+    git.run(&["checkout", &base_oid.to_string()])?;
+    git.commit_file_with_contents("conflict", 2, "conflict 2\n")?;
+
+    {
+        let (stdout, _stderr) = git.run_with_options(
+            &["move", "-s", &other_oid.to_string()],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             Merge conflict, falling back to rebase on-disk. The conflicting commit was: e85d25c7 create conflict.txt
             branchless: <git-executable> rebase --continue
             CONFLICT (add/add): Merge conflict in conflict.txt
             Auto-merging conflict.txt
             "###);
-        }
+    }
 
-        git.resolve_file("conflict", "resolved")?;
-        {
-            let (stdout, _stderr) = git.run(&["rebase", "--continue"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.resolve_file("conflict", "resolved")?;
+    {
+        let (stdout, _stderr) = git.run(&["rebase", "--continue"])?;
+        insta::assert_snapshot!(stdout, @r###"
             [detached HEAD 244e2bd] create conflict.txt
              1 file changed, 1 insertion(+), 1 deletion(-)
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 (master) create test1.txt
             |
@@ -328,35 +329,35 @@ fn test_move_merge_conflict() -> anyhow::Result<()> {
             |
             @ 244e2bd1 create conflict.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_base() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
-        let test3_oid = git.commit_file("test3", 3)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test4", 4)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["move", "--base", &test3_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test4", 4)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["move", "--base", &test3_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             branchless: processing 2 rewritten commits
             In-memory rebase succeeded.
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             @ bf0d52a6 (master) create test4.txt
             |
@@ -364,81 +365,80 @@ fn test_move_base() -> anyhow::Result<()> {
             |
             o cf5eb244 create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_checkout_new_head() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.run(&["prev"])?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["move", "-d", "master"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["prev"])?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["move", "-d", "master"])?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             branchless: processing 1 rewritten commit
             branchless: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
             In-memory rebase succeeded.
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 (master) create test1.txt
             |
             @ 96d1c37a create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_branch() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        let test2_oid = git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        git.commit_file("test3", 3)?;
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["move", "-d", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.commit_file("test3", 3)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["move", "-d", &test2_oid.to_string()])?;
+        insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
             branchless: processing 1 update to a branch/ref
             branchless: processing 1 rewritten commit
             branchless: <git-executable> checkout master
             In-memory rebase succeeded.
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             @ 70deb1e2 (master) create test3.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["branch", "--show-current"])?;
-            assert_eq!(stdout, "master\n");
-        }
+    {
+        let (stdout, _stderr) = git.run(&["branch", "--show-current"])?;
+        assert_eq!(stdout, "master\n");
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 // TODO: implement restack in terms of move

--- a/tests/command/test_navigation.rs
+++ b/tests/command/test_navigation.rs
@@ -1,72 +1,73 @@
-use branchless::testing::{with_git, GitRunOptions};
+use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
 fn test_prev() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["prev"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["prev"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout HEAD^
             @ f777ecc9 create initial.txt
             |
             O 62fc20d2 (master) create test1.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, stderr) = git.run_with_options(
-                &["prev"],
-                &GitRunOptions {
-                    expected_exit_code: 1,
-                    ..Default::default()
-                },
-            )?;
-            insta::assert_snapshot!(stdout, @"branchless: <git-executable> checkout HEAD^
+    {
+        let (stdout, stderr) = git.run_with_options(
+            &["prev"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @"branchless: <git-executable> checkout HEAD^
 ");
-            insta::assert_snapshot!(stderr, @"error: pathspec 'HEAD^' did not match any file(s) known to git
+        insta::assert_snapshot!(stderr, @"error: pathspec 'HEAD^' did not match any file(s) known to git
 ");
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_prev_multiple() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["prev", "2"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["prev", "2"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout HEAD~2
             @ f777ecc9 create initial.txt
             :
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_next_multiple() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["next", "2"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["next", "2"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
             O f777ecc9 (master) create initial.txt
             |
@@ -74,46 +75,46 @@ fn test_next_multiple() -> anyhow::Result<()> {
             |
             @ 96d1c37a create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_next_ambiguous() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "master"])?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
-        git.detach_head()?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "master"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run_with_options(
-                &["next"],
-                &GitRunOptions {
-                    expected_exit_code: 1,
-                    ..Default::default()
-                },
-            )?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "master"])?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+    git.detach_head()?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "master"])?;
+
+    {
+        let (stdout, _stderr) = git.run_with_options(
+            &["next"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
             Found multiple possible next commits to go to after traversing 0 children:
               - 62fc20d2 create test1.txt (oldest)
               - fe65c1fe create test2.txt
               - 98b9119d create test3.txt (newest)
             (Pass --oldest (-o) or --newest (-n) to select between ambiguous next commits)
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["next", "--oldest"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["next", "--oldest"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             O f777ecc9 (master) create initial.txt
             |\
@@ -123,12 +124,12 @@ fn test_next_ambiguous() -> anyhow::Result<()> {
             |
             o 98b9119d create test3.txt
             "###);
-        }
+    }
 
-        git.run(&["checkout", "master"])?;
-        {
-            let (stdout, _stderr) = git.run(&["next", "--newest"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.run(&["checkout", "master"])?;
+    {
+        let (stdout, _stderr) = git.run(&["next", "--newest"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout 98b9119d16974f372e76cb64a3b77c528fc0b18b
             O f777ecc9 (master) create initial.txt
             |\
@@ -138,50 +139,50 @@ fn test_next_ambiguous() -> anyhow::Result<()> {
             |
             @ 98b9119d create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_next_on_master() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.detach_head()?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "HEAD^^"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["next", "2"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.detach_head()?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^^"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["next", "2"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
             :
             O 96d1c37a (master) create test2.txt
             |
             @ 70deb1e2 create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_next_on_master2() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "HEAD^"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["next"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["next"])?;
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
             :
             O 62fc20d2 (master) create test1.txt
@@ -190,8 +191,7 @@ fn test_next_on_master2() -> anyhow::Result<()> {
             |
             @ 70deb1e2 create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -1,4 +1,4 @@
-use branchless::testing::{with_git, GitRunOptions};
+use branchless::testing::{make_git, GitRunOptions};
 
 /// Remove some of the output from `git rebase`, as it seems to be
 /// non-deterministic as to whether or not it appears.
@@ -12,20 +12,21 @@ fn remove_rebase_lines(output: String) -> String {
 
 #[test]
 fn test_restack_amended_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+    let git = make_git()?;
 
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "HEAD^^"])?;
-        git.run(&["commit", "--amend", "-m", "amend test1.txt"])?;
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^^"])?;
+    git.run(&["commit", "--amend", "-m", "amend test1.txt"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |\
             | @ 024c35ce amend test1.txt
@@ -36,12 +37,12 @@ fn test_restack_amended_commit() -> anyhow::Result<()> {
             |
             o 70deb1e2 create test3.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["restack"])?;
-            let stdout = remove_rebase_lines(stdout);
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["restack"])?;
+        let stdout = remove_rebase_lines(stdout);
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> rebase 62fc20d2a290daea0d52bdc2ed2ad4be6491010e 96d1c37a3d4363611c49f7e52186e189a04c531f --onto 024c35ce32dae6b12e981963465ee8a62b7eff9b --committer-date-is-author-date
             branchless: <git-executable> rebase 96d1c37a3d4363611c49f7e52186e189a04c531f 70deb1e28791d8e7dd5a1f0c871a51b91282562f --onto 8cd7de680cafaba911d09f430d2bafb1169d6e65 --committer-date-is-author-date
             branchless: no more abandoned commits to restack
@@ -55,30 +56,30 @@ fn test_restack_amended_commit() -> anyhow::Result<()> {
             |
             o b9a0491a create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_restack_consecutive_rewrites() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+    let git = make_git()?;
 
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.run(&["checkout", "HEAD^^"])?;
-        git.run(&["commit", "--amend", "-m", "amend test1.txt v1"])?;
-        git.run(&["commit", "--amend", "-m", "amend test1.txt v2"])?;
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["restack"])?;
-            let stdout = remove_rebase_lines(stdout);
-            insta::assert_snapshot!(stdout, @r###"
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^^"])?;
+    git.run(&["commit", "--amend", "-m", "amend test1.txt v1"])?;
+    git.run(&["commit", "--amend", "-m", "amend test1.txt v2"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["restack"])?;
+        let stdout = remove_rebase_lines(stdout);
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> rebase 62fc20d2a290daea0d52bdc2ed2ad4be6491010e 96d1c37a3d4363611c49f7e52186e189a04c531f --onto 662b451fb905b92404787e024af717ced49e3045 --committer-date-is-author-date
             branchless: <git-executable> rebase 96d1c37a3d4363611c49f7e52186e189a04c531f 70deb1e28791d8e7dd5a1f0c871a51b91282562f --onto 8e9bbde339899eaabf48cf0d8b89d52144db94e1 --committer-date-is-author-date
             branchless: no more abandoned commits to restack
@@ -92,27 +93,27 @@ fn test_restack_consecutive_rewrites() -> anyhow::Result<()> {
             |
             o 9dc6dd07 create test3.txt
             "###)
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_move_abandoned_branch() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+    let git = make_git()?;
 
-        git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        git.run(&["commit", "--amend", "-m", "amend test1.txt v1"])?;
-        git.run(&["commit", "--amend", "-m", "amend test1.txt v2"])?;
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["restack"])?;
-            let stdout = remove_rebase_lines(stdout);
-            insta::assert_snapshot!(stdout, @r###"
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.run(&["commit", "--amend", "-m", "amend test1.txt v1"])?;
+    git.run(&["commit", "--amend", "-m", "amend test1.txt v2"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["restack"])?;
+        let stdout = remove_rebase_lines(stdout);
+        insta::assert_snapshot!(stdout, @r###"
             branchless: no more abandoned commits to restack
             branchless: <git-executable> branch -f master 662b451fb905b92404787e024af717ced49e3045
             branchless: no more abandoned branches to restack
@@ -120,37 +121,37 @@ fn test_move_abandoned_branch() -> anyhow::Result<()> {
             :
             @ 662b451f (master) amend test1.txt v2
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_amended_initial_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+    let git = make_git()?;
 
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "HEAD^"])?;
-        git.run(&["commit", "--amend", "-m", "new initial commit"])?;
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.run(&["commit", "--amend", "-m", "new initial commit"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             @ 9a9f929a new initial commit
 
             X f777ecc9 (rewritten as 9a9f929a) create initial.txt
             |
             O 62fc20d2 (master) create test1.txt
             "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["restack"])?;
-            let stdout = remove_rebase_lines(stdout);
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["restack"])?;
+        let stdout = remove_rebase_lines(stdout);
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> rebase f777ecc9b0db5ed372b2615695191a8a17f79f24 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --onto 9a9f929a0d4f052ff5d58bedd97b2f761120f8ed --committer-date-is-author-date
             branchless: no more abandoned commits to restack
             branchless: <git-executable> branch -f master 6d85943be6d6e5941d5479f1059d02ebf1c8e307
@@ -160,28 +161,28 @@ fn test_amended_initial_commit() -> anyhow::Result<()> {
             |
             O 6d85943b (master) create test1.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_restack_amended_master() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+    let git = make_git()?;
 
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.detach_head()?;
-        git.run(&["checkout", "HEAD^"])?;
-        git.run(&["commit", "--amend", "-m", "amended test1"])?;
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
 
-        {
-            let (stdout, _stderr) = git.run(&["restack"])?;
-            let stdout = remove_rebase_lines(stdout);
-            insta::assert_snapshot!(stdout, @r###"
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.detach_head()?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.run(&["commit", "--amend", "-m", "amended test1"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["restack"])?;
+        let stdout = remove_rebase_lines(stdout);
+        insta::assert_snapshot!(stdout, @r###"
             branchless: <git-executable> rebase 62fc20d2a290daea0d52bdc2ed2ad4be6491010e 96d1c37a3d4363611c49f7e52186e189a04c531f --onto ae94dc2a748bc0965c88fcf3edac2e30074ff7e2 --committer-date-is-author-date
             branchless: no more abandoned commits to restack
             branchless: <git-executable> branch -f master 51452b55e09488387e59770a9f44d999eba27864
@@ -192,32 +193,31 @@ fn test_restack_amended_master() -> anyhow::Result<()> {
             |
             O 51452b55 (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_restack_aborts_during_rebase_conflict() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["branch", "foo"])?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["prev"])?;
+    let git = make_git()?;
 
-        git.write_file("test2", "conflicting test2 contents")?;
-        git.run(&["add", "."])?;
-        git.run(&["commit", "--amend", "-m", "amend test1 with test2 conflict"])?;
-        git.run_with_options(
-            &["restack"],
-            &GitRunOptions {
-                expected_exit_code: 1,
-                ..Default::default()
-            },
-        )?;
+    git.init_repo()?;
+    git.run(&["branch", "foo"])?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["prev"])?;
 
-        Ok(())
-    })
+    git.write_file("test2", "conflicting test2 contents")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "--amend", "-m", "amend test1 with test2 conflict"])?;
+    git.run_with_options(
+        &["restack"],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
 }

--- a/tests/command/test_smartlog.rs
+++ b/tests/command/test_smartlog.rs
@@ -1,133 +1,134 @@
-use branchless::testing::{get_path_to_git, with_git, Git, GitInitOptions, GitRunOptions};
+use branchless::testing::{get_path_to_git, make_git, Git, GitInitOptions, GitRunOptions};
 use branchless::util::GitRunInfo;
 
 #[test]
 fn test_init_smartlog() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @"@ f777ecc9 (master) create initial.txt
+    git.init_repo()?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @"@ f777ecc9 (master) create initial.txt
 ");
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_show_reachable_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "initial-branch", "master"])?;
-        git.commit_file("test", 1)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "initial-branch", "master"])?;
+    git.commit_file("test", 1)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             @ 3df4b935 (initial-branch) create test.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_tree() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.run(&["branch", "initial"])?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "initial"])?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.run(&["branch", "initial"])?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "initial"])?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |\
             | o 62fc20d2 create test1.txt
             |
             @ fe65c1fe (initial) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_rebase() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "test1", "master"])?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "master"])?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
-        git.run(&["rebase", "test1"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "test1", "master"])?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "master"])?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    git.run(&["rebase", "test1"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             o 62fc20d2 (test1) create test1.txt
             |
             @ f8d9985b create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_sequential_master_commits() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             @ 70deb1e2 (master) create test3.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_merge_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "test1", "master"])?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "-b", "test2and3", "master"])?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.run_with_options(
-            &["merge", "test1"],
-            &GitRunOptions {
-                time: 4,
-                ..Default::default()
-            },
-        )?;
+    let git = make_git()?;
 
-        {
-            // Rendering here is arbitrary and open to change.
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "test1", "master"])?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "-b", "test2and3", "master"])?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run_with_options(
+        &["merge", "test1"],
+        &GitRunOptions {
+            time: 4,
+            ..Default::default()
+        },
+    )?;
+
+    {
+        // Rendering here is arbitrary and open to change.
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |\
             | o 62fc20d2 (test1) create test1.txt
@@ -140,62 +141,62 @@ fn test_merge_commit() -> anyhow::Result<()> {
             |
             @ fa4e4e1a (test2and3) Merge branch 'test1' into test2and3
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_rebase_conflict() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "branch1", "master"])?;
-        git.commit_file_with_contents("test", 1, "contents 1\n")?;
-        git.run(&["checkout", "-b", "branch2", "master"])?;
-        git.commit_file_with_contents("test", 2, "contents 2\n")?;
+    let git = make_git()?;
 
-        // Should produce a conflict.
-        git.run_with_options(
-            &["rebase", "branch1"],
-            &GitRunOptions {
-                expected_exit_code: 1,
-                ..Default::default()
-            },
-        )?;
-        git.resolve_file("test", "contents resolved\n")?;
-        git.run(&["rebase", "--continue"])?;
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "branch1", "master"])?;
+    git.commit_file_with_contents("test", 1, "contents 1\n")?;
+    git.run(&["checkout", "-b", "branch2", "master"])?;
+    git.commit_file_with_contents("test", 2, "contents 2\n")?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    // Should produce a conflict.
+    git.run_with_options(
+        &["rebase", "branch1"],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    )?;
+    git.resolve_file("test", "contents resolved\n")?;
+    git.run(&["rebase", "--continue"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 (master) create initial.txt
             |
             o 88646b56 (branch1) create test.txt
             |
             @ 4549af33 (branch2) create test.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_non_adjacent_commits() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
-        git.detach_head()?;
-        git.commit_file("test4", 4)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.detach_head()?;
+    git.commit_file("test4", 4)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 create initial.txt
             |\
             : o 62fc20d2 create test1.txt
@@ -204,28 +205,28 @@ fn test_non_adjacent_commits() -> anyhow::Result<()> {
             |
             @ 8e62740b create test4.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_non_adjacent_commits2() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test3", 3)?;
-        git.commit_file("test4", 4)?;
-        git.detach_head()?;
-        git.commit_file("test5", 5)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+    git.detach_head()?;
+    git.commit_file("test5", 5)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 create initial.txt
             |\
             : o 62fc20d2 create test1.txt
@@ -236,30 +237,30 @@ fn test_non_adjacent_commits2() -> anyhow::Result<()> {
             |
             @ 13932989 create test5.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_non_adjacent_commits3() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test3", 3)?;
-        git.detach_head()?;
-        git.commit_file("test4", 4)?;
-        git.run(&["checkout", "master"])?;
-        git.commit_file("test5", 5)?;
-        git.commit_file("test6", 6)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test3", 3)?;
+    git.detach_head()?;
+    git.commit_file("test4", 4)?;
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test5", 5)?;
+    git.commit_file("test6", 6)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 create test1.txt
             |\
@@ -271,34 +272,33 @@ fn test_non_adjacent_commits3() -> anyhow::Result<()> {
             :
             @ 500c9b3e (master) create test6.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_custom_main_branch() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.run(&["branch", "-m", "master", "main"])?;
-        git.run(&["config", "branchless.core.mainBranch", "main"])?;
-        git.commit_file("test1", 1)?;
-        git.detach_head()?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.run(&["branch", "-m", "master", "main"])?;
+    git.run(&["config", "branchless.core.mainBranch", "main"])?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             :
             O 62fc20d2 (main) create test1.txt
             |
             @ 96d1c37a create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
@@ -365,17 +365,18 @@ fn test_main_remote_branch() -> anyhow::Result<()> {
 
 #[test]
 fn test_show_rewritten_commit_hash() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["prev"])?;
-        git.run(&["commit", "--amend", "-m", "test1 version 1"])?;
-        git.run(&["commit", "--amend", "-m", "test1 version 2"])?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["prev"])?;
+    git.run(&["commit", "--amend", "-m", "test1 version 1"])?;
+    git.run(&["commit", "--amend", "-m", "test1 version 2"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
             O f777ecc9 create initial.txt
             |\
             | @ 2ebe0950 test1 version 2
@@ -384,8 +385,7 @@ fn test_show_rewritten_commit_hash() -> anyhow::Result<()> {
             |
             O 96d1c37a (master) create test2.txt
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/command/test_wrap.rs
+++ b/tests/command/test_wrap.rs
@@ -1,33 +1,34 @@
 use branchless::core::eventlog::testing::{get_event_replayer_events, redact_event_timestamp};
 use branchless::core::eventlog::{Event, EventLogDb, EventReplayer};
-use branchless::testing::with_git;
+use branchless::testing::make_git;
 use branchless::util::get_db_conn;
 
 #[test]
 fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
-    with_git(|git| {
-        if !git.supports_reference_transactions()? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "foo"])?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "master"])?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
 
-        git.run(&["branchless", "wrap", "rebase", "foo"])?;
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "foo"])?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
 
-        let repo = git.get_repo()?;
-        let conn = get_db_conn(&repo)?;
-        let event_log_db = EventLogDb::new(&conn)?;
-        let event_replayer = EventReplayer::from_event_log_db(&event_log_db)?;
-        let events: Vec<Event> = get_event_replayer_events(&event_replayer)
-            .iter()
-            .map(|event| redact_event_timestamp(event.clone()))
-            .collect();
+    git.run(&["branchless", "wrap", "rebase", "foo"])?;
 
-        insta::assert_debug_snapshot!(events, @r###"
+    let repo = git.get_repo()?;
+    let conn = get_db_conn(&repo)?;
+    let event_log_db = EventLogDb::new(&conn)?;
+    let event_replayer = EventReplayer::from_event_log_db(&event_log_db)?;
+    let events: Vec<Event> = get_event_replayer_events(&event_replayer)
+        .iter()
+        .map(|event| redact_event_timestamp(event.clone()))
+        .collect();
+
+    insta::assert_debug_snapshot!(events, @r###"
             [
                 RefUpdateEvent {
                     timestamp: 0.0,
@@ -182,41 +183,40 @@ fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
             ]
             "###);
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_wrap_explicit_git_executable() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        let (stdout, _stderr) = git.run(&[
-            "branchless",
-            "wrap",
-            "--git-executable",
-            // Don't use a hardcoded executable like `echo` here (see
-            // https://github.com/arxanas/git-branchless/issues/26). We also
-            // don't want to use `git`, since that's the default value for
-            // this argument, so we wouldn't be able to tell if it was
-            // working. But we're certain to have `git-branchless` on
-            // `PATH`!
-            "git-branchless",
-            "--",
-            "--help",
-        ])?;
-        assert!(stdout.contains("Branchless workflow for Git."));
-        Ok(())
-    })
+    let git = make_git()?;
+
+    git.init_repo()?;
+    let (stdout, _stderr) = git.run(&[
+        "branchless",
+        "wrap",
+        "--git-executable",
+        // Don't use a hardcoded executable like `echo` here (see
+        // https://github.com/arxanas/git-branchless/issues/26). We also
+        // don't want to use `git`, since that's the default value for
+        // this argument, so we wouldn't be able to tell if it was
+        // working. But we're certain to have `git-branchless` on
+        // `PATH`!
+        "git-branchless",
+        "--",
+        "--help",
+    ])?;
+    assert!(stdout.contains("Branchless workflow for Git."));
+    Ok(())
 }
 
 #[test]
 fn test_wrap_without_repo() -> anyhow::Result<()> {
-    with_git(|git| {
-        let (stdout, stderr) = git.run(&["branchless", "wrap", "status"])?;
-        insta::assert_snapshot!(stderr, @"fatal: not a git repository (or any of the parent directories): .git
-");
-        insta::assert_snapshot!(stdout, @"");
+    let git = make_git()?;
 
-        Ok(())
-    })
+    let (stdout, stderr) = git.run(&["branchless", "wrap", "status"])?;
+    insta::assert_snapshot!(stderr, @"fatal: not a git repository (or any of the parent directories): .git
+");
+    insta::assert_snapshot!(stdout, @"");
+
+    Ok(())
 }

--- a/tests/core/test_eventlog.rs
+++ b/tests/core/test_eventlog.rs
@@ -1,32 +1,33 @@
 use branchless::core::eventlog::testing::{get_event_replayer_events, redact_event_timestamp};
 use branchless::core::eventlog::{Event, EventLogDb, EventReplayer};
-use branchless::testing::with_git;
+use branchless::testing::make_git;
 use branchless::util::get_db_conn;
 
 #[test]
 fn test_git_v2_31_events() -> anyhow::Result<()> {
-    with_git(|git| {
-        if !git.supports_reference_transactions()? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        git.run(&["checkout", "-b", "test1"])?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "HEAD^"])?;
-        git.commit_file("test2", 2)?;
-        git.run(&["hide", "test1"])?;
-        git.run(&["branch", "-D", "test1"])?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
 
-        let conn = get_db_conn(&git.get_repo()?)?;
-        let event_log_db = EventLogDb::new(&conn)?;
-        let event_replayer = EventReplayer::from_event_log_db(&event_log_db)?;
-        let events: Vec<Event> = get_event_replayer_events(&event_replayer)
-            .iter()
-            .cloned()
-            .map(redact_event_timestamp)
-            .collect();
-        insta::assert_debug_snapshot!(events, @r###"
+    git.init_repo()?;
+    git.run(&["checkout", "-b", "test1"])?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.commit_file("test2", 2)?;
+    git.run(&["hide", "test1"])?;
+    git.run(&["branch", "-D", "test1"])?;
+
+    let conn = get_db_conn(&git.get_repo()?)?;
+    let event_log_db = EventLogDb::new(&conn)?;
+    let event_replayer = EventReplayer::from_event_log_db(&event_log_db)?;
+    let events: Vec<Event> = get_event_replayer_events(&event_replayer)
+        .iter()
+        .cloned()
+        .map(redact_event_timestamp)
+        .collect();
+    insta::assert_debug_snapshot!(events, @r###"
             [
                 RefUpdateEvent {
                     timestamp: 0.0,
@@ -158,6 +159,5 @@ fn test_git_v2_31_events() -> anyhow::Result<()> {
             ]
             "###);
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use branchless::testing::with_git;
+use branchless::testing::make_git;
 use branchless::util::get_sh;
 use std::process::Command;
 
@@ -21,24 +21,25 @@ fn preprocess_stderr(stderr: String) -> String {
 
 #[test]
 fn test_abandoned_commit_message() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
+    let git = make_git()?;
 
-        {
-            let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
-            let stderr = preprocess_stderr(stderr);
-            assert_eq!(stderr, "");
-        }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
 
-        git.commit_file("test2", 2)?;
-        git.run(&["checkout", "HEAD^"])?;
-        git.run(&["branch", "-f", "master"])?;
+    {
+        let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
+        let stderr = preprocess_stderr(stderr);
+        assert_eq!(stderr, "");
+    }
 
-        {
-            let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1 again"])?;
-            let stderr = preprocess_stderr(stderr);
-            insta::assert_snapshot!(stderr, @r###"
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.run(&["branch", "-f", "master"])?;
+
+    {
+        let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1 again"])?;
+        let stderr = preprocess_stderr(stderr);
+        insta::assert_snapshot!(stderr, @r###"
             branchless: This operation abandoned 1 commit and 1 branch (master)!
             branchless: Consider running one of the following:
             branchless:   - git restack: re-apply the abandoned commits/branches
@@ -48,24 +49,24 @@ fn test_abandoned_commit_message() -> anyhow::Result<()> {
             branchless:   - git undo: undo the operation
             branchless:   - git config branchless.restack.warnAbandoned false: suppress this message
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_abandoned_branch_message() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.run(&["branch", "abc"])?;
-        git.detach_head()?;
+    let git = make_git()?;
 
-        {
-            let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
-            let stderr = preprocess_stderr(stderr);
-            insta::assert_snapshot!(stderr, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["branch", "abc"])?;
+    git.detach_head()?;
+
+    {
+        let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
+        let stderr = preprocess_stderr(stderr);
+        insta::assert_snapshot!(stderr, @r###"
             branchless: This operation abandoned 2 branches (abc, master)!
             branchless: Consider running one of the following:
             branchless:   - git restack: re-apply the abandoned commits/branches
@@ -75,54 +76,54 @@ fn test_abandoned_branch_message() -> anyhow::Result<()> {
             branchless:   - git undo: undo the operation
             branchless:   - git config branchless.restack.warnAbandoned false: suppress this message
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_fixup_no_abandoned_commit_message() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
-        git.run(&["commit", "--amend", "-m", "fixup! create test1.txt"])?;
-        git.commit_file("test3", 3)?;
-        git.run(&["commit", "--amend", "-m", "fixup! create test1.txt"])?;
+    let git = make_git()?;
 
-        {
-            let (_stdout, stderr) = git.run(&["rebase", "-i", "master", "--autosquash"])?;
-            let stderr = preprocess_stderr(stderr);
-            insta::assert_snapshot!(stderr, @r###"
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["commit", "--amend", "-m", "fixup! create test1.txt"])?;
+    git.commit_file("test3", 3)?;
+    git.run(&["commit", "--amend", "-m", "fixup! create test1.txt"])?;
+
+    {
+        let (_stdout, stderr) = git.run(&["rebase", "-i", "master", "--autosquash"])?;
+        let stderr = preprocess_stderr(stderr);
+        insta::assert_snapshot!(stderr, @r###"
             Rebasing (2/3)
             Rebasing (3/3)
             Successfully rebased and updated detached HEAD.
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_rebase_individual_commit() -> anyhow::Result<()> {
-    with_git(|git| {
-        if !git.supports_reference_transactions()? {
-            return Ok(());
-        }
+    let git = make_git()?;
 
-        git.init_repo()?;
-        git.commit_file("test1", 1)?;
-        git.run(&["checkout", "HEAD^"])?;
-        git.commit_file("test2", 2)?;
-        git.commit_file("test3", 3)?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
 
-        {
-            let (_stdout, stderr) = git.run(&["rebase", "master", "HEAD^"])?;
-            let stderr = preprocess_stderr(stderr);
-            insta::assert_snapshot!(stderr, @r###"
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+
+    {
+        let (_stdout, stderr) = git.run(&["rebase", "master", "HEAD^"])?;
+        let stderr = preprocess_stderr(stderr);
+        insta::assert_snapshot!(stderr, @r###"
             Rebasing (1/1)
             branchless: This operation abandoned 1 commit!
             branchless: Consider running one of the following:
@@ -134,64 +135,63 @@ fn test_rebase_individual_commit() -> anyhow::Result<()> {
             branchless:   - git config branchless.restack.warnAbandoned false: suppress this message
             Successfully rebased and updated detached HEAD.
             "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_interactive_rebase_noop() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
-        git.detach_head()?;
-        git.commit_file("test1", 1)?;
-        git.commit_file("test2", 2)?;
+    let git = make_git()?;
 
-        {
-            let (_stdout, stderr) = git.run(&["rebase", "-i", "master"])?;
-            let stderr = preprocess_stderr(stderr);
-            insta::assert_snapshot!(stderr, @"Successfully rebased and updated detached HEAD.
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    {
+        let (_stdout, stderr) = git.run(&["rebase", "-i", "master"])?;
+        let stderr = preprocess_stderr(stderr);
+        insta::assert_snapshot!(stderr, @"Successfully rebased and updated detached HEAD.
 ");
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
 fn test_pre_auto_gc() -> anyhow::Result<()> {
-    with_git(|git| {
-        git.init_repo()?;
+    let git = make_git()?;
 
-        // See https://stackoverflow.com/q/3433653/344643, it's hard to get the
-        // `pre-auto-gc` hook to be invoked at all. We'll just invoke the hook
-        // directly to make sure that it's installed properly.
-        let output = Command::new(get_sh().context("bash needed to run pre-auto-gc")?)
-            .arg("-c")
-            // Always use a unix style path here, as we are handing it to bash (even on Windows).
-            .arg("./.git/hooks/pre-auto-gc")
-            .current_dir(&git.repo_path)
-            .env_clear()
-            .env("PATH", git.get_path_for_env())
-            .output()?;
+    git.init_repo()?;
 
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
-        assert!(
-            output.status.success(),
-            "Pre-auto-gc hook failed with exit code {:?}:
+    // See https://stackoverflow.com/q/3433653/344643, it's hard to get the
+    // `pre-auto-gc` hook to be invoked at all. We'll just invoke the hook
+    // directly to make sure that it's installed properly.
+    let output = Command::new(get_sh().context("bash needed to run pre-auto-gc")?)
+        .arg("-c")
+        // Always use a unix style path here, as we are handing it to bash (even on Windows).
+        .arg("./.git/hooks/pre-auto-gc")
+        .current_dir(&git.repo_path)
+        .env_clear()
+        .env("PATH", git.get_path_for_env())
+        .output()?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        output.status.success(),
+        "Pre-auto-gc hook failed with exit code {:?}:
             Stdout:
             {}
             Stderr:
             {}",
-            output.status.code(),
-            stdout,
-            stderr
-        );
-        insta::assert_snapshot!(stdout, @"branchless: collecting garbage
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    insta::assert_snapshot!(stdout, @"branchless: collecting garbage
 ");
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/test_branchless.rs
+++ b/tests/test_branchless.rs
@@ -1,52 +1,54 @@
+use branchless::testing::make_git;
+
 #[test]
 fn test_commands() -> anyhow::Result<()> {
-    branchless::testing::with_git(|git| {
-        git.init_repo()?;
-        git.commit_file("test", 1)?;
+    let git = make_git()?;
 
-        {
-            let (stdout, _stderr) = git.run(&["smartlog"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    git.init_repo()?;
+    git.commit_file("test", 1)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
 :
 @ 3df4b935 (master) create test.txt
 "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["hide", "3df4b935"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["hide", "3df4b935"])?;
+        insta::assert_snapshot!(stdout, @r###"
 Hid commit: 3df4b935 create test.txt
 To unhide this commit, run: git unhide 3df4b935
 "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["unhide", "3df4b935"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["unhide", "3df4b935"])?;
+        insta::assert_snapshot!(stdout, @r###"
 Unhid commit: 3df4b935 create test.txt
 To hide this commit, run: git hide 3df4b935
 "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["prev"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["prev"])?;
+        insta::assert_snapshot!(stdout, @r###"
 branchless: <git-executable> checkout HEAD^
 @ f777ecc9 create initial.txt
 |
 O 3df4b935 (master) create test.txt
 "###);
-        }
+    }
 
-        {
-            let (stdout, _stderr) = git.run(&["next"])?;
-            insta::assert_snapshot!(stdout, @r###"
+    {
+        let (stdout, _stderr) = git.run(&["next"])?;
+        insta::assert_snapshot!(stdout, @r###"
 branchless: <git-executable> checkout 3df4b9355b3b072aa6c50c6249bf32e289b3a661
 :
 @ 3df4b935 (master) create test.txt
 "###);
-        }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }


### PR DESCRIPTION
Using `Drop` is probably more idiomatic Rust than wrapping the function body in a lambda.
