### PR TITLE
Don't reapply upstream commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `git move` now supports forcing an in-memory rebase with the `--in-memory` flag.
 - Added: The `reference-transaction` hook prints out which references were updated.
 - Added: `git restack` can now accept a list of commit hashes whose descendants should be restacked, rather than restacking every abandoned commit indiscriminately.
-- Fixed: `git move` preserves committer timestamps when `branchless.restack.preserveTimestamps` is set. The configuration key may change in the future.
+- Added: `git move` will skip applying commits which have already been applied upstream, and delete their corresponding branches.
 - Changed: More of the Git hooks installed by `git-branchless` display the affected objects, rather than just the number of affected objects.
 - Fixed: The output of `git` subcommands is streamed to stdout, rather than accumulated and dumped at the end.
 - Fixed: Commits rebased in-memory by `git move` are now marked as reachable by the Git garbage collector, so that they aren't collected prematurely.
 - Fixed: `git-branchless wrap` correctly relays the exit code of its subprocess.
 - Fixed: Some restack and move operations incorrectly created branches without the necessary `refs/heads/` prefix, which means they weren't considered local branches by Git.
 - Fixed: Some restack and move operations didn't relocate all commits and branches correctly, due to the experimental `git move` backend. The backend has been changed to use a constraint-solving approach rather than a greedy approach to fix this.
+- Fixed: `git move` preserves committer timestamps when `branchless.restack.preserveTimestamps` is set. The configuration key may change in the future.
 
 ## [0.3.3] - 2021-06-27
 

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -17,7 +17,7 @@ use fn_error_context::context;
 use crate::core::eventlog::{is_gc_ref, EventLogDb, EventReplayer};
 use crate::core::graph::{make_graph, BranchOids, CommitGraph, HeadOid, MainBranchOid};
 use crate::core::mergebase::MergeBaseDb;
-use crate::git::{Oid, Reference, Repo};
+use crate::git::{NonZeroOid, Reference, Repo};
 
 fn find_dangling_references<'repo>(
     repo: &'repo Repo,
@@ -49,7 +49,7 @@ fn find_dangling_references<'repo>(
 /// * `repo`: The Git repository.
 /// * `commit_oid`: The commit OID to mark as reachable.
 #[context("Marking commit reachable: {:?}", commit_oid)]
-pub fn mark_commit_reachable(repo: &Repo, commit_oid: Oid) -> anyhow::Result<()> {
+pub fn mark_commit_reachable(repo: &Repo, commit_oid: NonZeroOid) -> anyhow::Result<()> {
     let ref_name = format!("refs/branchless/{}", commit_oid.to_string());
     anyhow::ensure!(
         Reference::is_valid_name(&ref_name),

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -73,7 +73,7 @@ use crate::core::rewrite::{
     execute_rebase_plan, find_abandoned_children, find_rewrite_target, move_branches,
     BuildRebasePlanOptions, ExecuteRebasePlanOptions, RebasePlanBuilder,
 };
-use crate::git::{GitRunInfo, Oid, Repo};
+use crate::git::{GitRunInfo, NonZeroOid, Repo};
 
 #[context("Restacking commits")]
 fn restack_commits(
@@ -82,7 +82,7 @@ fn restack_commits(
     git_run_info: &GitRunInfo,
     merge_base_db: &MergeBaseDb,
     event_log_db: &EventLogDb,
-    commits: Option<impl IntoIterator<Item = Oid>>,
+    commits: Option<impl IntoIterator<Item = NonZeroOid>>,
     build_options: &BuildRebasePlanOptions,
     execute_options: &ExecuteRebasePlanOptions,
 ) -> anyhow::Result<isize> {
@@ -103,10 +103,10 @@ fn restack_commits(
     )?;
 
     struct RebaseInfo {
-        dest_oid: Oid,
-        abandoned_child_oids: Vec<Oid>,
+        dest_oid: NonZeroOid,
+        abandoned_child_oids: Vec<NonZeroOid>,
     }
-    let commits: HashSet<Oid> = match commits {
+    let commits: HashSet<NonZeroOid> = match commits {
         Some(commits) => commits.into_iter().collect(),
         None => graph.keys().copied().collect(),
     };
@@ -239,7 +239,7 @@ pub fn restack(
             return Ok(1);
         }
     };
-    let commits: Option<HashSet<Oid>> = if commits.is_empty() {
+    let commits: Option<HashSet<NonZeroOid>> = if commits.is_empty() {
         None
     } else {
         Some(commits.into_iter().map(|commit| commit.get_oid()).collect())

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -20,7 +20,7 @@ use crate::core::metadata::{
     CommitOidProvider, DifferentialRevisionProvider, HiddenExplanationProvider,
     RelativeTimeProvider,
 };
-use crate::git::{Oid, Repo};
+use crate::git::{NonZeroOid, Repo};
 
 /// Split fully-independent subgraphs into multiple graphs.
 ///
@@ -33,15 +33,15 @@ fn split_commit_graph_by_roots(
     repo: &Repo,
     merge_base_db: &MergeBaseDb,
     graph: &CommitGraph,
-) -> Vec<Oid> {
-    let mut root_commit_oids: Vec<Oid> = graph
+) -> Vec<NonZeroOid> {
+    let mut root_commit_oids: Vec<NonZeroOid> = graph
         .iter()
         .filter(|(_oid, node)| node.parent.is_none())
         .map(|(oid, _node)| oid)
         .copied()
         .collect();
 
-    let compare = |lhs_oid: &Oid, rhs_oid: &Oid| -> Ordering {
+    let compare = |lhs_oid: &NonZeroOid, rhs_oid: &NonZeroOid| -> Ordering {
         let lhs_commit = repo.find_commit(*lhs_oid);
         let rhs_commit = repo.find_commit(*rhs_oid);
 
@@ -79,10 +79,10 @@ fn split_commit_graph_by_roots(
 fn get_child_output(
     glyphs: &Glyphs,
     graph: &CommitGraph,
-    root_oids: &[Oid],
+    root_oids: &[NonZeroOid],
     commit_metadata_providers: &mut [&mut dyn CommitMetadataProvider],
     head_oid: &HeadOid,
-    current_oid: Oid,
+    current_oid: NonZeroOid,
     last_child_line_char: Option<&str>,
 ) -> anyhow::Result<Vec<StyledString>> {
     let current_node = &graph[&current_oid];
@@ -185,7 +185,7 @@ fn get_output(
     graph: &CommitGraph,
     commit_metadata_providers: &mut [&mut dyn CommitMetadataProvider],
     head_oid: &HeadOid,
-    root_oids: &[Oid],
+    root_oids: &[NonZeroOid],
 ) -> anyhow::Result<Vec<StyledString>> {
     let mut lines = Vec::new();
 
@@ -194,7 +194,7 @@ fn get_output(
     // This returns `True` in strictly more cases than checking `graph`,
     // since there may be links between adjacent main branch commits which
     // are not reflected in `graph`.
-    let has_real_parent = |oid: Oid, parent_oid: Oid| -> bool {
+    let has_real_parent = |oid: NonZeroOid, parent_oid: NonZeroOid| -> bool {
         graph[&oid]
             .commit
             .get_parent_oids()

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -94,159 +94,127 @@ mod tests {
             .collect();
 
         insta::assert_debug_snapshot!(events, @r###"
-            [
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        1,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: None,
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
+        [
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    1,
+                ),
+                ref_name: "refs/heads/foo",
+                old_oid: 0000000000000000000000000000000000000000,
+                new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    2,
+                ),
+                ref_name: "HEAD",
+                old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    3,
+                ),
+                ref_name: "HEAD",
+                old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    3,
+                ),
+                ref_name: "refs/heads/foo",
+                old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                message: None,
+            },
+            CommitEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    4,
+                ),
+                commit_oid: NonZeroOid {
+                    inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
                 },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        2,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    5,
+                ),
+                ref_name: "HEAD",
+                old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    5,
+                ),
+                ref_name: "refs/heads/foo",
+                old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                message: None,
+            },
+            CommitEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    6,
+                ),
+                commit_oid: NonZeroOid {
+                    inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
                 },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        4,
-                    ),
-                    commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        5,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        5,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        6,
-                    ),
-                    commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        7,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: None,
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "refs/heads/master",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-            ]
-            "###);
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    7,
+                ),
+                ref_name: "HEAD",
+                old_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    8,
+                ),
+                ref_name: "HEAD",
+                old_oid: 0000000000000000000000000000000000000000,
+                new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    8,
+                ),
+                ref_name: "HEAD",
+                old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                message: None,
+            },
+            RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId(
+                    8,
+                ),
+                ref_name: "refs/heads/master",
+                old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                message: None,
+            },
+        ]
+        "###);
 
         Ok(())
     }

--- a/src/core/mergebase.rs
+++ b/src/core/mergebase.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use rusqlite::OptionalExtension;
 
-use crate::git::{Oid, Repo};
+use crate::git::{NonZeroOid, Repo};
 
 /// On-disk cache for merge-base queries.
 pub struct MergeBaseDb<'conn> {
@@ -66,9 +66,9 @@ impl<'conn> MergeBaseDb<'conn> {
     pub fn get_merge_base_oid(
         &self,
         repo: &Repo,
-        lhs_oid: Oid,
-        rhs_oid: Oid,
-    ) -> anyhow::Result<Option<Oid>> {
+        lhs_oid: NonZeroOid,
+        rhs_oid: NonZeroOid,
+    ) -> anyhow::Result<Option<NonZeroOid>> {
         let (lhs_oid, rhs_oid) = if lhs_oid < rhs_oid {
             (lhs_oid, rhs_oid)
         } else {
@@ -96,7 +96,7 @@ WHERE lhs_oid = :lhs_oid
         match merge_base_oid {
             // Cached and non-NULL.
             Some(Some(merge_base_oid)) => {
-                let merge_base_oid: Oid =
+                let merge_base_oid: NonZeroOid =
                     merge_base_oid.parse().context("Parsing merge-base OID")?;
                 Ok(Some(merge_base_oid))
             }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -20,7 +20,7 @@ use crate::core::config::{
     get_commit_metadata_branches, get_commit_metadata_differential_revision,
     get_commit_metadata_relative_time,
 };
-use crate::git::{CategorizedReferenceName, Commit, Oid, Repo};
+use crate::git::{CategorizedReferenceName, Commit, NonZeroOid, Repo};
 
 use super::eventlog::{Event, EventCursor, EventReplayer};
 use super::formatting::StyledStringBuilder;
@@ -162,14 +162,14 @@ impl<'a> CommitMetadataProvider for HiddenExplanationProvider<'a> {
 /// Display branches that point to a given commit.
 pub struct BranchesProvider<'a> {
     is_enabled: bool,
-    branch_oid_to_names: &'a HashMap<Oid, HashSet<OsString>>,
+    branch_oid_to_names: &'a HashMap<NonZeroOid, HashSet<OsString>>,
 }
 
 impl<'a> BranchesProvider<'a> {
     /// Constructor.
     pub fn new(
         repo: &Repo,
-        branch_oid_to_names: &'a HashMap<Oid, HashSet<OsString>>,
+        branch_oid_to_names: &'a HashMap<NonZeroOid, HashSet<OsString>>,
     ) -> anyhow::Result<Self> {
         let is_enabled = get_commit_metadata_branches(repo)?;
         Ok(BranchesProvider {

--- a/src/core/rewrite.rs
+++ b/src/core/rewrite.rs
@@ -1107,6 +1107,13 @@ fn rebase_on_disk(
             .with_context(|| "Writing `cdate_is_adate` option file")?;
     }
 
+    // Make sure we don't move around the current branch unintentionally. If it
+    // actually needs to be moved, then it will be moved as part of the
+    // post-rebase operations.
+    if head_info.oid.is_some() {
+        head_info.detach_head()?;
+    }
+
     progress.finish_and_clear();
     println!("Calling Git for on-disk rebase...");
     let result = git_run_info.run(Some(*event_tx_id), &["rebase", "--continue"])?;

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -367,6 +367,14 @@ impl Repo {
         })
     }
 
+    /// Set the `HEAD` reference directly to the provided `oid`. Does not touch
+    /// the working copy.
+    #[context("Setting `HEAD` to: {:?}", oid)]
+    pub fn set_head(&self, oid: NonZeroOid) -> anyhow::Result<()> {
+        self.inner.set_head_detached(oid.inner)?;
+        Ok(())
+    }
+
     /// Get the `Reference` for the main branch for the repository.
     pub fn get_main_branch_reference(&self) -> anyhow::Result<Reference> {
         let main_branch_name = get_main_branch_name(self)?;

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -866,6 +866,16 @@ impl<'repo> Commit<'repo> {
         )?;
         Ok(description)
     }
+
+    /// Determine if the current commit is empty (has no changes compared to its
+    /// parent).
+    pub fn is_empty(&self) -> bool {
+        match self.get_parents().as_slice() {
+            [] => false,
+            [parent_commit] => self.inner.tree_id() == parent_commit.inner.tree_id(),
+            _ => false,
+        }
+    }
 }
 
 /// Represents a reference to an object.

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,9 @@ enum Opts {
     HookRegisterExtraPostRewriteHook,
 
     /// Internal use.
+    HookDetectEmptyCommit { old_commit_oid: String },
+
+    /// Internal use.
     HookPostCheckout {
         previous_commit: String,
         current_commit: String,
@@ -287,6 +290,11 @@ fn main() -> anyhow::Result<()> {
 
         Opts::HookRegisterExtraPostRewriteHook => {
             branchless::commands::hooks::hook_register_extra_post_rewrite_hook()?;
+            0
+        }
+
+        Opts::HookDetectEmptyCommit { old_commit_oid } => {
+            branchless::commands::hooks::hook_drop_commit_if_empty(old_commit_oid)?;
             0
         }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use crate::git::{GitRunInfo, GitVersion, Oid, Repo};
+use crate::git::{GitRunInfo, GitVersion, NonZeroOid, Repo};
 use crate::util::get_sh;
 
 use anyhow::Context;
@@ -318,7 +318,7 @@ impl Git {
         name: &str,
         time: isize,
         contents: &str,
-    ) -> anyhow::Result<Oid> {
+    ) -> anyhow::Result<NonZeroOid> {
         self.write_file(name, contents)?;
         self.run(&["add", "."])?;
         self.run_with_options(
@@ -339,7 +339,7 @@ impl Git {
 
     /// Commit a file with default contents. The `time` argument is used to set
     /// the commit timestamp, which is factored into the commit hash.
-    pub fn commit_file(&self, name: &str, time: isize) -> anyhow::Result<Oid> {
+    pub fn commit_file(&self, name: &str, time: isize) -> anyhow::Result<NonZeroOid> {
         self.commit_file_with_contents(name, time, &format!("{} contents\n", name))
     }
 

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -214,7 +214,9 @@ fn test_main_branch_not_found_error_message() -> anyhow::Result<()> {
         )?;
         insta::assert_snapshot!(trim_lines(stderr), @r###"
         Error:
-        The main branch "master" could not be found in your repository.
+        The main branch "master" could not be found in your repository
+        at path: "<repo-path>/.git/".
+        These branches exist: []
         Either create it, or update the main branch setting by running:
 
             git config branchless.core.mainBranch <branch>

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -64,17 +64,25 @@ fn test_move_stick_in_memory() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                first_dest_oid: NonZeroOid {
+                    inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        commit_oid: NonZeroOid {
+                            inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        },
                     },
                     Pick {
-                        commit_oid: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
                     },
                     Pick {
-                        commit_oid: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        commit_oid: NonZeroOid {
+                            inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        },
                     },
                 ],
             },
@@ -247,17 +255,25 @@ fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                first_dest_oid: NonZeroOid {
+                    inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        commit_oid: NonZeroOid {
+                            inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        },
                     },
                     Pick {
-                        commit_oid: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
                     },
                     Pick {
-                        commit_oid: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        commit_oid: NonZeroOid {
+                            inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        },
                     },
                 ],
             },
@@ -313,14 +329,20 @@ fn test_move_merge_conflict() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: 202143f2fdfc785285ab097422f6a695ff1d93cb,
+                first_dest_oid: NonZeroOid {
+                    inner: 202143f2fdfc785285ab097422f6a695ff1d93cb,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: 202143f2fdfc785285ab097422f6a695ff1d93cb,
+                        commit_oid: NonZeroOid {
+                            inner: 202143f2fdfc785285ab097422f6a695ff1d93cb,
+                        },
                     },
                     Pick {
-                        commit_oid: e85d25c772a05b5c73ea8ec43881c12bbf588848,
+                        commit_oid: NonZeroOid {
+                            inner: e85d25c772a05b5c73ea8ec43881c12bbf588848,
+                        },
                     },
                 ],
             },
@@ -382,17 +404,25 @@ fn test_move_base() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                first_dest_oid: NonZeroOid {
+                    inner: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                        commit_oid: NonZeroOid {
+                            inner: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                        },
                     },
                     Pick {
-                        commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        commit_oid: NonZeroOid {
+                            inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        },
                     },
                     Pick {
-                        commit_oid: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
                     },
                 ],
             },
@@ -434,14 +464,20 @@ fn test_move_checkout_new_head() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                first_dest_oid: NonZeroOid {
+                    inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        commit_oid: NonZeroOid {
+                            inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                        },
                     },
                     Pick {
-                        commit_oid: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
+                        commit_oid: NonZeroOid {
+                            inner: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
+                        },
                     },
                 ],
             },
@@ -490,14 +526,20 @@ fn test_move_branch() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                first_dest_oid: NonZeroOid {
+                    inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        commit_oid: NonZeroOid {
+                            inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        },
                     },
                     Pick {
-                        commit_oid: 98b9119d16974f372e76cb64a3b77c528fc0b18b,
+                        commit_oid: NonZeroOid {
+                            inner: 98b9119d16974f372e76cb64a3b77c528fc0b18b,
+                        },
                     },
                 ],
             },
@@ -680,14 +722,20 @@ fn test_move_in_memory_gc() -> anyhow::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Rebase plan: Some(
             RebasePlan {
-                first_dest_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                first_dest_oid: NonZeroOid {
+                    inner: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                },
                 commands: [
                     RegisterExtraPostRewriteHook,
                     ResetToOid {
-                        commit_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                        commit_oid: NonZeroOid {
+                            inner: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+                        },
                     },
                     Pick {
-                        commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        commit_oid: NonZeroOid {
+                            inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        },
                     },
                 ],
             },

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -79,7 +79,17 @@ fn test_move_stick_in_memory() -> anyhow::Result<()> {
                             inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
                         },
                     },
+                    DetectEmptyCommit {
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
+                    },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
                         },
@@ -270,7 +280,17 @@ fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
                             inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
                         },
                     },
+                    DetectEmptyCommit {
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
+                    },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: 355e173bf9c5d2efac2e451da0cdad3fb82b869a,
                         },
@@ -340,6 +360,11 @@ fn test_move_merge_conflict() -> anyhow::Result<()> {
                         },
                     },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: e85d25c772a05b5c73ea8ec43881c12bbf588848,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: e85d25c772a05b5c73ea8ec43881c12bbf588848,
                         },
@@ -419,7 +444,17 @@ fn test_move_base() -> anyhow::Result<()> {
                             inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
                         },
                     },
+                    DetectEmptyCommit {
+                        commit_oid: NonZeroOid {
+                            inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        },
+                    },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: 70deb1e28791d8e7dd5a1f0c871a51b91282562f,
                         },
@@ -475,6 +510,11 @@ fn test_move_checkout_new_head() -> anyhow::Result<()> {
                         },
                     },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
                         },
@@ -537,6 +577,11 @@ fn test_move_branch() -> anyhow::Result<()> {
                         },
                     },
                     Pick {
+                        commit_oid: NonZeroOid {
+                            inner: 98b9119d16974f372e76cb64a3b77c528fc0b18b,
+                        },
+                    },
+                    DetectEmptyCommit {
                         commit_oid: NonZeroOid {
                             inner: 98b9119d16974f372e76cb64a3b77c528fc0b18b,
                         },
@@ -737,6 +782,11 @@ fn test_move_in_memory_gc() -> anyhow::Result<()> {
                             inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
                         },
                     },
+                    DetectEmptyCommit {
+                        commit_oid: NonZeroOid {
+                            inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+                        },
+                    },
                 ],
             },
         )
@@ -896,10 +946,13 @@ fn test_move_branches_after_move_on_disk() -> anyhow::Result<()> {
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: 4838e49b create test3.txt
+        Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: a2482074 create test4.txt
+        Executing: git branchless hook-detect-empty-commit 355e173bf9c5d2efac2e451da0cdad3fb82b869a
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: 566e4341 create test5.txt
+        Executing: git branchless hook-detect-empty-commit f81d55c0d520ff8d02ef9294d95156dcb78a5255
         branchless: processing 3 rewritten commits
         branchless: processing 2 updates: branch bar, branch foo
         Successfully rebased and updated detached HEAD.
@@ -982,6 +1035,60 @@ fn test_move_no_reapply_upstream_commits_in_memory() -> anyhow::Result<()> {
         branchless: processing 2 rewritten commits
         branchless: <git-executable> checkout fa46633239bfa767036e41a77b67258286e4ddb9
         In-memory rebase succeeded.
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 047b7ad7 (master) create test1.txt
+        |
+        @ fa466332 create test2.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_no_reapply_upstream_commits_on_disk() -> anyhow::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+
+    git.init_repo()?;
+    git.run(&["config", "branchless.restack.preserveTimestamps", "true"])?;
+
+    git.detach_head()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.run(&["branch", "should-be-deleted"])?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+    git.run(&["cherry-pick", &test1_oid.to_string()])?;
+    git.run(&["checkout", &test2_oid.to_string()])?;
+
+    {
+        let (stdout, stderr) = git.run(&["move", "--on-disk", "-b", "HEAD", "-d", "master"])?;
+        insta::assert_snapshot!(stderr, @r###"
+        Executing: git branchless hook-register-extra-post-rewrite-hook
+        branchless: processing 1 update: ref HEAD
+        branchless: processing 1 update: ref HEAD
+        branchless: processed commit: cfea32a9 create test1.txt
+        Executing: git branchless hook-detect-empty-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: processing 1 update: ref HEAD
+        branchless: processed commit: fa466332 create test2.txt
+        Executing: git branchless hook-detect-empty-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: processing 4 rewritten commits
+        branchless: processing 1 update: branch should-be-deleted
+        Successfully rebased and updated detached HEAD.
+        "###);
+        insta::assert_snapshot!(stdout, @r###"
+        Calling Git for on-disk rebase...
+        branchless: <git-executable> rebase --continue
+        Skipping empty commit: cfea32a9 create test1.txt
         "###);
     }
 

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -1068,10 +1068,10 @@ fn test_move_no_reapply_upstream_commits_on_disk() -> anyhow::Result<()> {
     let test2_oid = git.commit_file("test2", 2)?;
     git.run(&["checkout", "master"])?;
     git.run(&["cherry-pick", &test1_oid.to_string()])?;
-    git.run(&["checkout", &test2_oid.to_string()])?;
+    // git.run(&["checkout", &test2_oid.to_string()])?;
 
     {
-        let (stdout, stderr) = git.run(&["move", "--on-disk", "-b", "HEAD", "-d", "master"])?;
+        let (stdout, stderr) = git.run(&["move", "--on-disk", "-b", &test2_oid.to_string()])?;
         insta::assert_snapshot!(stderr, @r###"
         Executing: git branchless hook-register-extra-post-rewrite-hook
         branchless: processing 1 update: ref HEAD
@@ -1083,7 +1083,7 @@ fn test_move_no_reapply_upstream_commits_on_disk() -> anyhow::Result<()> {
         Executing: git branchless hook-detect-empty-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
         branchless: processing 4 rewritten commits
         branchless: processing 1 update: branch should-be-deleted
-        Successfully rebased and updated detached HEAD.
+        Successfully rebased and updated master.
         "###);
         insta::assert_snapshot!(stdout, @r###"
         Calling Git for on-disk rebase...

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -329,6 +329,7 @@ fn test_restack_single_of_many_commits() -> anyhow::Result<()> {
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: bb7d4b2a create test3.txt
+        Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         branchless: processing 1 rewritten commit
         Successfully rebased and updated detached HEAD.
         Previous HEAD position was bb7d4b2 create test3.txt

--- a/tests/command/test_wrap.rs
+++ b/tests/command/test_wrap.rs
@@ -28,159 +28,127 @@ fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
         .collect();
 
     insta::assert_debug_snapshot!(events, @r###"
-            [
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        1,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: None,
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        2,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        4,
-                    ),
-                    commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        5,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        5,
-                    ),
-                    ref_name: "refs/heads/foo",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        6,
-                    ),
-                    commit_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        7,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: None,
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    ref_name: "refs/heads/master",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "96d1c37a3d4363611c49f7e52186e189a04c531f",
-                    ),
-                    message: None,
-                },
-            ]
-            "###);
+    [
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                1,
+            ),
+            ref_name: "refs/heads/foo",
+            old_oid: 0000000000000000000000000000000000000000,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                2,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                3,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                3,
+            ),
+            ref_name: "refs/heads/foo",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            message: None,
+        },
+        CommitEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                4,
+            ),
+            commit_oid: NonZeroOid {
+                inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            },
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                5,
+            ),
+            ref_name: "HEAD",
+            old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                5,
+            ),
+            ref_name: "refs/heads/foo",
+            old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            message: None,
+        },
+        CommitEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                6,
+            ),
+            commit_oid: NonZeroOid {
+                inner: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            },
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                7,
+            ),
+            ref_name: "HEAD",
+            old_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                8,
+            ),
+            ref_name: "HEAD",
+            old_oid: 0000000000000000000000000000000000000000,
+            new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                8,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                8,
+            ),
+            ref_name: "refs/heads/master",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f,
+            message: None,
+        },
+    ]
+    "###);
 
     Ok(())
 }

--- a/tests/core/test_eventlog.rs
+++ b/tests/core/test_eventlog.rs
@@ -28,136 +28,116 @@ fn test_git_v2_31_events() -> anyhow::Result<()> {
         .map(redact_event_timestamp)
         .collect();
     insta::assert_debug_snapshot!(events, @r###"
-            [
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        1,
-                    ),
-                    ref_name: "refs/heads/test1",
-                    old_ref: None,
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        2,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        3,
-                    ),
-                    ref_name: "refs/heads/test1",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        4,
-                    ),
-                    commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        5,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: None,
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        6,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    message: None,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        7,
-                    ),
-                    ref_name: "HEAD",
-                    old_ref: Some(
-                        "f777ecc9b0db5ed372b2615695191a8a17f79f24",
-                    ),
-                    new_ref: Some(
-                        "fe65c1fe15584744e649b2c79d4cf9b0d878f92e",
-                    ),
-                    message: None,
-                },
-                CommitEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        8,
-                    ),
-                    commit_oid: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
-                },
-                HideEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        9,
-                    ),
-                    commit_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                },
-                RefUpdateEvent {
-                    timestamp: 0.0,
-                    event_tx_id: EventTransactionId(
-                        10,
-                    ),
-                    ref_name: "refs/heads/test1",
-                    old_ref: Some(
-                        "62fc20d2a290daea0d52bdc2ed2ad4be6491010e",
-                    ),
-                    new_ref: None,
-                    message: None,
-                },
-            ]
-            "###);
+    [
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                1,
+            ),
+            ref_name: "refs/heads/test1",
+            old_oid: 0000000000000000000000000000000000000000,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                2,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                3,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                3,
+            ),
+            ref_name: "refs/heads/test1",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            message: None,
+        },
+        CommitEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                4,
+            ),
+            commit_oid: NonZeroOid {
+                inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            },
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                5,
+            ),
+            ref_name: "HEAD",
+            old_oid: 0000000000000000000000000000000000000000,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                6,
+            ),
+            ref_name: "HEAD",
+            old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            new_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            message: None,
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                7,
+            ),
+            ref_name: "HEAD",
+            old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24,
+            new_oid: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
+            message: None,
+        },
+        CommitEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                8,
+            ),
+            commit_oid: NonZeroOid {
+                inner: fe65c1fe15584744e649b2c79d4cf9b0d878f92e,
+            },
+        },
+        HideEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                9,
+            ),
+            commit_oid: NonZeroOid {
+                inner: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            },
+        },
+        RefUpdateEvent {
+            timestamp: 0.0,
+            event_tx_id: EventTransactionId(
+                10,
+            ),
+            ref_name: "refs/heads/test1",
+            old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+            new_oid: 0000000000000000000000000000000000000000,
+            message: None,
+        },
+    ]
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
- refactor(repo): create separate `NonZeroOid` and `MaybeZeroOid` types
- feat(rewrite): don't reapply upstream commits for in-memory rebases
- feat(rewrite): don't rebase upstream commits for on-disk rebases
