### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          # Clippy panics on 1.54.0, see
+          # https://github.com/rust-lang/rust-clippy/issues/7523
+          toolchain: 1.53.0
           components: rustfmt, clippy
       - name: Run `cargo fmt`
         uses: actions-rs/cargo@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           command: fmt
           args: --all -- --check
       - name: Run `cargo clippy`
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings


### PR DESCRIPTION
- ci: use Rust 1.53.0 for lints
- ci: use `actions-rs/clippy-check` action
