### PR TITLE
`git move` improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          # Clippy panics on 1.54.0, see
+          # https://github.com/rust-lang/rust-clippy/issues/7523
+          toolchain: 1.53.0
           components: rustfmt, clippy
       - name: Run `cargo fmt`
         uses: actions-rs/cargo@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           command: fmt
           args: --all -- --check
       - name: Run `cargo clippy`
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Some restack and move operations didn't relocate all commits and branches correctly, due to the experimental `git move` backend. The backend has been changed to use a constraint-solving approach rather than a greedy approach to fix this.
 - Fixed: `git move` preserves committer timestamps when `branchless.restack.preserveTimestamps` is set. The configuration key may change in the future.
 - Fixed: If your currently-checked-out commit was rewritten during a `git move` operation, it now checks out the new version of the commit, rather than leaving you on an old, hidden commit.
+- Fixed: If your current stack had another stack branching off of it, and `git move --base` was passed a commit that other stack, it would fail with a cyclic dependency error. It now clips off the unique part of the branch and moves it.
 
 ## [0.3.3] - 2021-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `git restack` can now accept a list of commit hashes whose descendants should be restacked, rather than restacking every abandoned commit indiscriminately.
 - Added: `git move` will skip applying commits which have already been applied upstream, and delete their corresponding branches.
 - Changed: More of the Git hooks installed by `git-branchless` display the affected objects, rather than just the number of affected objects.
+- Changed: `git move` with no `--source` or `--base` option now defaults to `--base HEAD` rather than `--source HEAD`.
 - Fixed: The output of `git` subcommands is streamed to stdout, rather than accumulated and dumped at the end.
 - Fixed: Commits rebased in-memory by `git move` are now marked as reachable by the Git garbage collector, so that they aren't collected prematurely.
 - Fixed: `git-branchless wrap` correctly relays the exit code of its subprocess.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: `git move` preserves committer timestamps when `branchless.restack.preserveTimestamps` is set. The configuration key may change in the future.
 - Fixed: If your currently-checked-out commit was rewritten during a `git move` operation, it now checks out the new version of the commit, rather than leaving you on an old, hidden commit.
 - Fixed: If your current stack had another stack branching off of it, and `git move --base` was passed a commit that other stack, it would fail with a cyclic dependency error. It now clips off the unique part of the branch and moves it.
+- Fixed: If an on-disk rebase would occur (such as the result of `git move` or `git restack`), but you have uncommitted changes in your working copy, the rebase is aborted and a warning is printed, rather than potentially clobbering your changes.
 
 ## [0.3.3] - 2021-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Some restack and move operations incorrectly created branches without the necessary `refs/heads/` prefix, which means they weren't considered local branches by Git.
 - Fixed: Some restack and move operations didn't relocate all commits and branches correctly, due to the experimental `git move` backend. The backend has been changed to use a constraint-solving approach rather than a greedy approach to fix this.
 - Fixed: `git move` preserves committer timestamps when `branchless.restack.preserveTimestamps` is set. The configuration key may change in the future.
+- Fixed: If your currently-checked-out commit was rewritten during a `git move` operation, it now checks out the new version of the commit, rather than leaving you on an old, hidden commit.
 
 ## [0.3.3] - 2021-06-27
 

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -69,7 +69,7 @@ pub fn r#move(
                     return Ok(1);
                 }
             };
-            (source_oid.to_string(), false)
+            (source_oid.to_string(), true)
         }
     };
     let dest = match dest {

--- a/src/core/formatting.rs
+++ b/src/core/formatting.rs
@@ -155,7 +155,7 @@ impl Glyphs {
             commit_main_hidden: "✕",
             commit_main_hidden_head: "❖",
             bullet_point: "•",
-            cycle_arrow: "→",
+            cycle_arrow: "ᐅ",
             cycle_horizontal_line: "─",
             cycle_vertical_line: "│",
             cycle_upper_left_corner: "┌",

--- a/src/core/rewrite/execute.rs
+++ b/src/core/rewrite/execute.rs
@@ -464,7 +464,7 @@ mod in_memory {
         if head_info.oid.is_some() {
             // Avoid moving the branch which HEAD points to, or else the index will show
             // a lot of changes in the working copy.
-            head_info.detach_head()?;
+            repo.detach_head(&head_info)?;
         }
 
         move_branches(git_run_info, repo, *event_tx_id, &rewritten_oids_map)?;
@@ -702,7 +702,7 @@ mod on_disk {
         // actually needs to be moved, then it will be moved as part of the
         // post-rebase operations.
         if head_info.oid.is_some() {
-            head_info.detach_head()?;
+            repo.detach_head(&head_info)?;
         }
 
         progress.finish_and_clear();

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,9 +1,13 @@
 //! Tools for interfacing with the Git repository.
 
 mod config;
+mod oid;
 mod repo;
 mod run;
 
-pub use config::*;
-pub use repo::*;
-pub use run::*;
+pub use config::{Config, ConfigValue};
+pub use oid::{MaybeZeroOid, NonZeroOid};
+pub use repo::{
+    Branch, CategorizedReferenceName, Commit, GitVersion, PatchId, Reference, ReferenceTarget, Repo,
+};
+pub use run::GitRunInfo;

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use fn_error_context::context;
 
-use super::wrap_git_error;
+use super::repo::wrap_git_error;
 
 /// Wrapper around the config values stored on disk for Git.
 pub struct Config {

--- a/src/git/oid.rs
+++ b/src/git/oid.rs
@@ -1,0 +1,170 @@
+use std::convert::{TryFrom, TryInto};
+use std::ffi::{OsStr, OsString};
+use std::fmt::Display;
+use std::str::FromStr;
+
+use anyhow::Context;
+
+use crate::git::repo::wrap_git_error;
+
+/// Represents the ID of a Git object.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct NonZeroOid {
+    pub(super) inner: git2::Oid,
+}
+
+impl Display for NonZeroOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl TryFrom<MaybeZeroOid> for NonZeroOid {
+    type Error = anyhow::Error;
+
+    fn try_from(value: MaybeZeroOid) -> Result<Self, Self::Error> {
+        match value {
+            MaybeZeroOid::NonZero(non_zero_oid) => Ok(non_zero_oid),
+            MaybeZeroOid::Zero => anyhow::bail!("Expected a non-zero OID"),
+        }
+    }
+}
+
+impl TryFrom<OsString> for NonZeroOid {
+    type Error = anyhow::Error;
+
+    fn try_from(value: OsString) -> Result<Self, Self::Error> {
+        let value: &OsStr = &value;
+        value.try_into()
+    }
+}
+
+impl TryFrom<&OsStr> for NonZeroOid {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &OsStr) -> Result<Self, Self::Error> {
+        let oid: MaybeZeroOid = value.try_into()?;
+        match oid {
+            MaybeZeroOid::Zero => anyhow::bail!("OID was zero, but expected to be non-zero"),
+            MaybeZeroOid::NonZero(oid) => Ok(oid),
+        }
+    }
+}
+
+impl FromStr for NonZeroOid {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let oid: MaybeZeroOid = value.parse()?;
+        match oid {
+            MaybeZeroOid::NonZero(non_zero_oid) => Ok(non_zero_oid),
+            MaybeZeroOid::Zero => anyhow::bail!("Expected a non-zero OID, but got: {:?}", value),
+        }
+    }
+}
+
+pub(super) fn make_non_zero_oid(oid: git2::Oid) -> NonZeroOid {
+    assert_ne!(oid, git2::Oid::zero());
+    NonZeroOid { inner: oid }
+}
+
+/// Represents an OID which may be zero or non-zero. This exists because Git
+/// often represents the absence of an object using the zero OID. We want to
+/// statically check for those cases by using a more descriptive type.
+///
+/// This type is isomorphic to `Option<NonZeroOid>`. It should be used primarily
+/// when converting to and from string representations of OID values.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MaybeZeroOid {
+    /// The zero OID (i.e. 40 `0`s).
+    Zero,
+
+    /// A non-zero OID.
+    NonZero(NonZeroOid),
+}
+
+impl std::fmt::Debug for MaybeZeroOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl Display for MaybeZeroOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let zero = git2::Oid::zero();
+        write!(
+            f,
+            "{:?}",
+            match self {
+                MaybeZeroOid::NonZero(NonZeroOid { inner }) => inner,
+                MaybeZeroOid::Zero => &zero,
+            }
+        )
+    }
+}
+
+impl FromStr for MaybeZeroOid {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse() {
+            Ok(oid) if oid == git2::Oid::zero() => Ok(MaybeZeroOid::Zero),
+            Ok(oid) => Ok(MaybeZeroOid::NonZero(NonZeroOid { inner: oid })),
+            Err(err) => Err(wrap_git_error(err))
+                .with_context(|| format!("Could not parse OID from string: {:?}", s)),
+        }
+    }
+}
+
+impl From<git2::Oid> for MaybeZeroOid {
+    fn from(oid: git2::Oid) -> Self {
+        if oid.is_zero() {
+            Self::Zero
+        } else {
+            Self::NonZero(make_non_zero_oid(oid))
+        }
+    }
+}
+
+impl TryFrom<&OsStr> for MaybeZeroOid {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &OsStr) -> Result<Self, Self::Error> {
+        match value.to_str() {
+            None => anyhow::bail!("OID value was not a simple ASCII value: {:?}", value),
+            Some(value) => value.parse(),
+        }
+    }
+}
+
+impl TryFrom<OsString> for MaybeZeroOid {
+    type Error = anyhow::Error;
+
+    fn try_from(value: OsString) -> Result<Self, Self::Error> {
+        MaybeZeroOid::try_from(value.as_os_str())
+    }
+}
+
+impl From<NonZeroOid> for MaybeZeroOid {
+    fn from(oid: NonZeroOid) -> Self {
+        Self::NonZero(oid)
+    }
+}
+
+impl From<Option<NonZeroOid>> for MaybeZeroOid {
+    fn from(oid: Option<NonZeroOid>) -> Self {
+        match oid {
+            Some(oid) => MaybeZeroOid::NonZero(oid),
+            None => MaybeZeroOid::Zero,
+        }
+    }
+}
+
+impl From<MaybeZeroOid> for Option<NonZeroOid> {
+    fn from(oid: MaybeZeroOid) -> Self {
+        match oid {
+            MaybeZeroOid::Zero => None,
+            MaybeZeroOid::NonZero(oid) => Some(oid),
+        }
+    }
+}

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -11,9 +11,8 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::ffi::{OsStr, OsString};
-use std::fmt::Display;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -28,176 +27,13 @@ use os_str_bytes::{OsStrBytes, OsStringBytes};
 
 use crate::core::config::get_main_branch_name;
 use crate::core::metadata::{render_commit_metadata, CommitMessageProvider, CommitOidProvider};
-
-use super::Config;
+use crate::git::config::Config;
+use crate::git::oid::{make_non_zero_oid, MaybeZeroOid, NonZeroOid};
 
 /// Convert a `git2::Error` into an `anyhow::Error` with an auto-generated message.
-pub fn wrap_git_error(error: git2::Error) -> anyhow::Error {
+pub(super) fn wrap_git_error(error: git2::Error) -> anyhow::Error {
     anyhow::anyhow!("Git error {:?}: {}", error.code(), error.message())
 }
-
-/// Represents the ID of a Git object.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct NonZeroOid {
-    inner: git2::Oid,
-}
-
-impl Display for NonZeroOid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.inner)
-    }
-}
-
-impl TryFrom<MaybeZeroOid> for NonZeroOid {
-    type Error = anyhow::Error;
-
-    fn try_from(value: MaybeZeroOid) -> Result<Self, Self::Error> {
-        match value {
-            MaybeZeroOid::NonZero(non_zero_oid) => Ok(non_zero_oid),
-            MaybeZeroOid::Zero => anyhow::bail!("Expected a non-zero OID"),
-        }
-    }
-}
-
-impl TryFrom<OsString> for NonZeroOid {
-    type Error = anyhow::Error;
-
-    fn try_from(value: OsString) -> Result<Self, Self::Error> {
-        let value: &OsStr = &value;
-        value.try_into()
-    }
-}
-
-impl TryFrom<&OsStr> for NonZeroOid {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &OsStr) -> Result<Self, Self::Error> {
-        let oid: MaybeZeroOid = value.try_into()?;
-        match oid {
-            MaybeZeroOid::Zero => anyhow::bail!("OID was zero, but expected to be non-zero"),
-            MaybeZeroOid::NonZero(oid) => Ok(oid),
-        }
-    }
-}
-
-impl FromStr for NonZeroOid {
-    type Err = anyhow::Error;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let oid: MaybeZeroOid = value.parse()?;
-        match oid {
-            MaybeZeroOid::NonZero(non_zero_oid) => Ok(non_zero_oid),
-            MaybeZeroOid::Zero => anyhow::bail!("Expected a non-zero OID, but got: {:?}", value),
-        }
-    }
-}
-
-fn make_non_zero_oid(oid: git2::Oid) -> NonZeroOid {
-    assert_ne!(oid, git2::Oid::zero());
-    NonZeroOid { inner: oid }
-}
-
-/// Represents an OID which may be zero or non-zero. This exists because Git
-/// often represents the absence of an object using the zero OID. We want to
-/// statically check for those cases by using a more descriptive type.
-///
-/// This type is isomorphic to `Option<NonZeroOid>`. It should be used primarily
-/// when converting to and from string representations of OID values.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum MaybeZeroOid {
-    /// The zero OID (i.e. 40 `0`s).
-    Zero,
-
-    /// A non-zero OID.
-    NonZero(NonZeroOid),
-}
-
-impl std::fmt::Debug for MaybeZeroOid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl Display for MaybeZeroOid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let zero = git2::Oid::zero();
-        write!(
-            f,
-            "{:?}",
-            match self {
-                MaybeZeroOid::NonZero(NonZeroOid { inner }) => inner,
-                MaybeZeroOid::Zero => &zero,
-            }
-        )
-    }
-}
-
-impl FromStr for MaybeZeroOid {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse() {
-            Ok(oid) if oid == git2::Oid::zero() => Ok(MaybeZeroOid::Zero),
-            Ok(oid) => Ok(MaybeZeroOid::NonZero(NonZeroOid { inner: oid })),
-            Err(err) => Err(wrap_git_error(err))
-                .with_context(|| format!("Could not parse OID from string: {:?}", s)),
-        }
-    }
-}
-
-impl From<git2::Oid> for MaybeZeroOid {
-    fn from(oid: git2::Oid) -> Self {
-        if oid.is_zero() {
-            Self::Zero
-        } else {
-            Self::NonZero(make_non_zero_oid(oid))
-        }
-    }
-}
-
-impl TryFrom<&OsStr> for MaybeZeroOid {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &OsStr) -> Result<Self, Self::Error> {
-        match value.to_str() {
-            None => anyhow::bail!("OID value was not a simple ASCII value: {:?}", value),
-            Some(value) => value.parse(),
-        }
-    }
-}
-
-impl TryFrom<OsString> for MaybeZeroOid {
-    type Error = anyhow::Error;
-
-    fn try_from(value: OsString) -> Result<Self, Self::Error> {
-        MaybeZeroOid::try_from(value.as_os_str())
-    }
-}
-
-impl From<NonZeroOid> for MaybeZeroOid {
-    fn from(oid: NonZeroOid) -> Self {
-        Self::NonZero(oid)
-    }
-}
-
-impl From<Option<NonZeroOid>> for MaybeZeroOid {
-    fn from(oid: Option<NonZeroOid>) -> Self {
-        match oid {
-            Some(oid) => MaybeZeroOid::NonZero(oid),
-            None => MaybeZeroOid::Zero,
-        }
-    }
-}
-
-impl From<MaybeZeroOid> for Option<NonZeroOid> {
-    fn from(oid: MaybeZeroOid) -> Self {
-        match oid {
-            MaybeZeroOid::Zero => None,
-            MaybeZeroOid::NonZero(oid) => Some(oid),
-        }
-    }
-}
-
 /// A snapshot of information about the current `HEAD` of the repository. If
 /// `HEAD` is updated after a `HeadInfo` value is obtained, then it is not
 /// reflected in the value.

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -36,11 +36,6 @@ pub fn wrap_git_error(error: git2::Error) -> anyhow::Error {
     anyhow::anyhow!("Git error {:?}: {}", error.code(), error.message())
 }
 
-/// Wrapper around `git2::Repository`.
-pub struct Repo {
-    inner: git2::Repository,
-}
-
 /// Represents the ID of a Git object.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct NonZeroOid {
@@ -269,6 +264,11 @@ impl FromStr for GitVersion {
             _ => anyhow::bail!("Could not parse Git version string: {}", version_str),
         }
     }
+}
+
+/// Wrapper around `git2::Repository`.
+pub struct Repo {
+    inner: git2::Repository,
 }
 
 impl Repo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,12 +78,16 @@ enum Opts {
 
     /// Move a subtree of commits from one location to another.
     ///
+    /// By default, `git move` tries to move the entire current stack if you
+    /// don't pass a `--source` or `--base` option (equivalent to writing
+    /// `--base HEAD`).
+    ///
     /// By default, `git move` attempts to rebase all commits in-memory. If you
     /// want to force an on-disk rebase, pass the `--on-disk` flag. Note that
     /// `post-commit` hooks are not called during in-memory rebases.
     Move {
         /// The source commit to move. This commit, and all of its descendants,
-        /// will be moved. If not provided, defaults to the current commit.
+        /// will be moved.
         #[structopt(short = "-s", long = "--source")]
         source: Option<String>,
 

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -817,6 +817,8 @@ fn test_move_in_memory_gc() -> anyhow::Result<()> {
         let (stdout, stderr) = git.run(&[
             "move",
             "--debug-dump-rebase-plan",
+            "-s",
+            "HEAD",
             "-d",
             "master",
             "--in-memory",

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -331,8 +331,12 @@ fn test_restack_single_of_many_commits() -> anyhow::Result<()> {
         branchless: processed commit: bb7d4b2a create test3.txt
         Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         branchless: processing 1 rewritten commit
-        Successfully rebased and updated detached HEAD.
+        branchless: <git-executable> checkout 3bd716d57489779ab1daf446f80e66e90b56ead7
         Previous HEAD position was bb7d4b2 create test3.txt
+        branchless: processing 1 update: ref HEAD
+        HEAD is now at 3bd716d updated test4
+        branchless: processing checkout
+        Successfully rebased and updated detached HEAD.
         branchless: processing 1 update: ref HEAD
         HEAD is now at 3bd716d updated test4
         branchless: processing checkout

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -47,6 +47,7 @@ fn test_restack_amended_commit() -> anyhow::Result<()> {
         let (stdout, _stderr) = git.run(&["restack"])?;
         let stdout = remove_rebase_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.
@@ -89,6 +90,7 @@ fn test_restack_consecutive_rewrites() -> anyhow::Result<()> {
         let stdout = remove_rebase_lines(stdout);
 
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.
@@ -165,6 +167,7 @@ fn test_amended_initial_commit() -> anyhow::Result<()> {
         let (stdout, _stderr) = git.run(&["restack"])?;
         let stdout = remove_rebase_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.
@@ -200,6 +203,7 @@ fn test_restack_amended_master() -> anyhow::Result<()> {
         let (stdout, _stderr) = git.run(&["restack"])?;
         let stdout = remove_rebase_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.
@@ -259,6 +263,7 @@ fn test_restack_multiple_amended() -> anyhow::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["restack"])?;
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.
@@ -342,6 +347,7 @@ fn test_restack_single_of_many_commits() -> anyhow::Result<()> {
         branchless: processing checkout
         "###);
         insta::assert_snapshot!(stdout, @r###"
+        branchless: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: <git-executable> rebase --continue
         Finished restacking commits.


### PR DESCRIPTION
- ci: use Rust 1.53.0 for lints
- ci: use `actions-rs/clippy-check` action
- fix(rewrite): check out rewritten version of commit after `git move`
- fix(rewrite): calculate correct source commit for `git move --base`
- feat(rewrite): change dependency cycle arrowhead glyph
- feat(move): default to `--base HEAD`
- refactor(repo): move `HeadInfo::detach_head` into `Repo`
- cleanup(repo): move `struct Repo`
- refactor(repo): create `oid` module
- feat(move): abort on-disk rebase when there are uncommitted changes
