### PR TITLE
Tracing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # Clippy panics on 1.54.0, see
-          # https://github.com/rust-lang/rust-clippy/issues/7523
-          toolchain: 1.53.0
+          toolchain: stable
           components: rustfmt, clippy
       - name: Run `cargo fmt`
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,12 +51,6 @@ checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "arrayref"
@@ -85,6 +94,21 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backtrace"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -179,14 +203,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.9.3"
+name = "color-eyre"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
 dependencies = [
- "atty",
- "lazy_static",
- "winapi",
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -412,6 +452,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,14 +512,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
 name = "git-branchless"
 version = "0.3.3"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "clippy",
+ "color-eyre",
  "console",
  "cursive",
+ "eyre",
  "git2",
  "indicatif",
  "insta",
@@ -478,7 +535,6 @@ dependencies = [
  "os_str_bytes",
  "regex",
  "rusqlite",
- "simple_logger",
  "structopt",
  "tempfile",
  "tracing",
@@ -549,6 +605,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indicatif"
@@ -694,6 +756,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +894,12 @@ checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parking_lot"
@@ -1057,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1205,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,19 +1248,6 @@ name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
-
-[[package]]
-name = "simple_logger"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
-dependencies = [
- "atty",
- "chrono",
- "colored",
- "log",
- "winapi",
-]
 
 [[package]]
 name = "smallvec"
@@ -1264,6 +1353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1416,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,13 +487,13 @@ dependencies = [
  "insta",
  "itertools",
  "lazy_static",
- "log",
  "os_str_bytes",
  "regex",
  "rusqlite",
  "simple_logger",
  "structopt",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -856,6 +856,12 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pkg-config"
@@ -1293,6 +1299,38 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "treeline"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,17 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "filedescriptor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71e83755e51aa52b9034f1986173783789e8e7d79c3c774adbbb63fb554f2cb"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
-]
-
-[[package]]
 name = "fn-error-context"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,16 +448,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "gag"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
-dependencies = [
- "filedescriptor",
- "tempfile",
 ]
 
 [[package]]
@@ -503,7 +482,6 @@ dependencies = [
  "console",
  "cursive",
  "fn-error-context",
- "gag",
  "git2",
  "indicatif",
  "insta",
@@ -1289,26 +1267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +193,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -538,6 +547,8 @@ dependencies = [
  "structopt",
  "tempfile",
  "tracing",
+ "tracing-error",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -741,6 +752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1100,6 +1120,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1429,14 +1452,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,9 +625,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.17.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "500f7e5a63596852b9bf7583fe86f9ad08e0df9b4eb58d12e9729071cb4952ca"
 dependencies = [
  "console",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,17 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fn-error-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbe237cce37ed07377a50ccd977c78ee936f0f64b731caaab25ea5553b2d149"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +470,6 @@ dependencies = [
  "clippy",
  "console",
  "cursive",
- "fn-error-context",
  "git2",
  "indicatif",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,4 @@ tempfile = "3.2.0"
 
 [dev-dependencies]
 clippy = "0.0.302"
-gag = "1.0.0"
 insta = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ git2 = {version = "0.13.17", default-features = false}
 indicatif = "0.16.2"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
-log = "0.4.14"
 os_str_bytes = "3.1.0"
 regex = "1.4.4"
 rusqlite = {version = "0.24.2", features = ["bundled"]}
 simple_logger = "1.11.0"
 structopt = "0.3.21"
 tempfile = "3.2.0"
+tracing = "0.1.26"
 
 [dev-dependencies]
 clippy = "0.0.302"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ version = "0.3.3"
 name = "branchless"
 
 [dependencies]
-anyhow = "1.0.38"
 assert_cmd = "1.0.3"
+color-eyre = "0.5.11"
 console = "0.14.0"
 cursive = {version = "0.17.0-alpha.0", default-features = false, features = ["crossterm-backend"]}
+eyre = "0.6.5"
 git2 = {version = "0.13.17", default-features = false}
 indicatif = "0.16.2"
 itertools = "0.10.1"
@@ -28,7 +29,6 @@ lazy_static = "1.4.0"
 os_str_bytes = "3.1.0"
 regex = "1.4.4"
 rusqlite = {version = "0.24.2", features = ["bundled"]}
-simple_logger = "1.11.0"
 structopt = "0.3.21"
 tempfile = "3.2.0"
 tracing = "0.1.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ console = "0.14.0"
 cursive = {version = "0.17.0-alpha.0", default-features = false, features = ["crossterm-backend"]}
 eyre = "0.6.5"
 git2 = {version = "0.13.17", default-features = false}
-indicatif = "0.16.2"
+indicatif = "0.17.0-beta.1"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
 os_str_bytes = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ anyhow = "1.0.38"
 assert_cmd = "1.0.3"
 console = "0.14.0"
 cursive = {version = "0.17.0-alpha.0", default-features = false, features = ["crossterm-backend"]}
-fn-error-context = "0.1.1"
 git2 = {version = "0.13.17", default-features = false}
 indicatif = "0.16.2"
 itertools = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ rusqlite = {version = "0.24.2", features = ["bundled"]}
 structopt = "0.3.21"
 tempfile = "3.2.0"
 tracing = "0.1.26"
+tracing-error = "0.1.2"
+tracing-subscriber = "0.2.19"
 
 [dev-dependencies]
 clippy = "0.0.302"

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -82,6 +82,7 @@ pub fn gc(output: &mut Output) -> eyre::Result<()> {
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
 
     let graph = make_graph(
+        output,
         &repo,
         &merge_base_db,
         &event_replayer,

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -10,6 +10,7 @@
 //! visible.
 
 use std::ffi::OsStr;
+use std::fmt::Write;
 
 use eyre::Context;
 use tracing::instrument;
@@ -18,6 +19,7 @@ use crate::core::eventlog::{is_gc_ref, EventLogDb, EventReplayer};
 use crate::core::graph::{make_graph, BranchOids, CommitGraph, HeadOid, MainBranchOid};
 use crate::core::mergebase::MergeBaseDb;
 use crate::git::{NonZeroOid, Reference, Repo};
+use crate::tui::Output;
 
 fn find_dangling_references<'repo>(
     repo: &'repo Repo,
@@ -69,7 +71,7 @@ pub fn mark_commit_reachable(repo: &Repo, commit_oid: NonZeroOid) -> eyre::Resul
 ///
 /// Frees any references to commits which are no longer visible in the smartlog.
 #[instrument]
-pub fn gc() -> eyre::Result<()> {
+pub fn gc(output: &mut Output) -> eyre::Result<()> {
     let repo = Repo::from_current_dir()?;
     let conn = repo.get_db_conn()?;
     let merge_base_db = MergeBaseDb::new(&conn)?;
@@ -90,7 +92,7 @@ pub fn gc() -> eyre::Result<()> {
         true,
     )?;
 
-    println!("branchless: collecting garbage");
+    writeln!(output, "branchless: collecting garbage")?;
     let dangling_references = find_dangling_references(&repo, &graph)?;
     for mut reference in dangling_references.into_iter() {
         reference

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -12,7 +12,7 @@
 use std::ffi::OsStr;
 
 use anyhow::Context;
-use fn_error_context::context;
+use tracing::instrument;
 
 use crate::core::eventlog::{is_gc_ref, EventLogDb, EventReplayer};
 use crate::core::graph::{make_graph, BranchOids, CommitGraph, HeadOid, MainBranchOid};
@@ -48,7 +48,7 @@ fn find_dangling_references<'repo>(
 /// Args:
 /// * `repo`: The Git repository.
 /// * `commit_oid`: The commit OID to mark as reachable.
-#[context("Marking commit reachable: {:?}", commit_oid)]
+#[instrument]
 pub fn mark_commit_reachable(repo: &Repo, commit_oid: NonZeroOid) -> anyhow::Result<()> {
     let ref_name = format!("refs/branchless/{}", commit_oid.to_string());
     anyhow::ensure!(
@@ -68,7 +68,7 @@ pub fn mark_commit_reachable(repo: &Repo, commit_oid: NonZeroOid) -> anyhow::Res
 /// Run branchless's garbage collection.
 ///
 /// Frees any references to commits which are no longer visible in the smartlog.
-#[context("Running garbage-collection")]
+#[instrument]
 pub fn gc() -> anyhow::Result<()> {
     let repo = Repo::from_current_dir()?;
     let conn = repo.get_db_conn()?;

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -4,6 +4,8 @@
 use std::collections::HashSet;
 use std::time::SystemTime;
 
+use tracing::instrument;
+
 use crate::core::eventlog::{CommitVisibility, Event};
 use crate::core::eventlog::{EventLogDb, EventReplayer};
 use crate::core::formatting::{printable_styled_string, Glyphs};
@@ -83,6 +85,7 @@ fn recurse_on_commits<'repo, F: Fn(&Node) -> bool>(
 ///   commits as well.
 ///
 /// Returns: exit code (0 denotes successful exit).
+#[instrument]
 pub fn hide(hashes: Vec<String>, recursive: bool) -> eyre::Result<isize> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();
@@ -153,6 +156,7 @@ pub fn hide(hashes: Vec<String>, recursive: bool) -> eyre::Result<isize> {
 ///   commits as well.
 ///
 /// Returns: exit code (0 denotes successful exit).
+#[instrument]
 pub fn unhide(hashes: Vec<String>, recursive: bool) -> eyre::Result<isize> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -36,7 +36,7 @@ fn recurse_on_commits_helper<
     };
 
     for child_oid in node.children.iter() {
-        let child_commit = &graph[&child_oid].commit;
+        let child_commit = &graph[child_oid].commit;
         recurse_on_commits_helper(graph, condition, child_commit, callback)
     }
 }

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -42,6 +42,7 @@ fn recurse_on_commits_helper<
 }
 
 fn recurse_on_commits<'repo, F: Fn(&Node) -> bool>(
+    output: &mut Output,
     repo: &'repo Repo,
     merge_base_db: &MergeBaseDb,
     event_replayer: &EventReplayer,
@@ -52,6 +53,7 @@ fn recurse_on_commits<'repo, F: Fn(&Node) -> bool>(
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
+        output,
         repo,
         merge_base_db,
         event_replayer,
@@ -106,9 +108,14 @@ pub fn hide(output: &mut Output, hashes: Vec<String>, recursive: bool) -> eyre::
         }
     };
     let commits = if recursive {
-        recurse_on_commits(&repo, &merge_base_db, &event_replayer, commits, |node| {
-            node.is_visible
-        })?
+        recurse_on_commits(
+            output,
+            &repo,
+            &merge_base_db,
+            &event_replayer,
+            commits,
+            |node| node.is_visible,
+        )?
     } else {
         commits
     };
@@ -182,9 +189,14 @@ pub fn unhide(output: &mut Output, hashes: Vec<String>, recursive: bool) -> eyre
         }
     };
     let commits = if recursive {
-        recurse_on_commits(&repo, &merge_base_db, &event_replayer, commits, |node| {
-            !node.is_visible
-        })?
+        recurse_on_commits(
+            output,
+            &repo,
+            &merge_base_db,
+            &event_replayer,
+            commits,
+            |node| !node.is_visible,
+        )?
     } else {
         commits
     };

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -43,7 +43,7 @@ fn recurse_on_commits<'repo, F: Fn(&Node) -> bool>(
     event_replayer: &EventReplayer,
     commits: Vec<Commit<'repo>>,
     condition: F,
-) -> anyhow::Result<Vec<Commit<'repo>>> {
+) -> eyre::Result<Vec<Commit<'repo>>> {
     let head_oid = repo.get_head_info()?.oid;
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
@@ -83,7 +83,7 @@ fn recurse_on_commits<'repo, F: Fn(&Node) -> bool>(
 ///   commits as well.
 ///
 /// Returns: exit code (0 denotes successful exit).
-pub fn hide(hashes: Vec<String>, recursive: bool) -> anyhow::Result<isize> {
+pub fn hide(hashes: Vec<String>, recursive: bool) -> eyre::Result<isize> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;
@@ -153,7 +153,7 @@ pub fn hide(hashes: Vec<String>, recursive: bool) -> anyhow::Result<isize> {
 ///   commits as well.
 ///
 /// Returns: exit code (0 denotes successful exit).
-pub fn unhide(hashes: Vec<String>, recursive: bool) -> anyhow::Result<isize> {
+pub fn unhide(hashes: Vec<String>, recursive: bool) -> eyre::Result<isize> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -65,6 +65,7 @@ pub fn hook_post_checkout(
 /// Handle Git's `post-commit` hook.
 ///
 /// See the man-page for `githooks(5)`.
+#[instrument]
 pub fn hook_post_commit() -> eyre::Result<()> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();
@@ -108,6 +109,7 @@ pub fn hook_post_commit() -> eyre::Result<()> {
     Ok(())
 }
 
+#[instrument]
 fn parse_reference_transaction_line(
     line: &[u8],
     now: SystemTime,

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -13,10 +13,9 @@ use std::io::{stdin, BufRead, Cursor};
 use std::time::SystemTime;
 
 use anyhow::Context;
-use fn_error_context::context;
 use itertools::Itertools;
 use os_str_bytes::OsStringBytes;
-use tracing::{error, warn};
+use tracing::{error, instrument, warn};
 
 use crate::commands::gc::mark_commit_reachable;
 use crate::core::eventlog::{should_ignore_ref_updates, Event, EventLogDb, EventTransactionId};
@@ -31,7 +30,7 @@ pub use crate::core::rewrite::hooks::{
 /// Handle Git's `post-checkout` hook.
 ///
 /// See the man-page for `githooks(5)`.
-#[context("Processing post-checkout hook")]
+#[instrument]
 pub fn hook_post_checkout(
     previous_head_oid: &str,
     current_head_oid: &str,
@@ -158,7 +157,7 @@ fn parse_reference_transaction_line(
 /// Handle Git's `reference-transaction` hook.
 ///
 /// See the man-page for `githooks(5)`.
-#[context("Processing reference-transaction hook")]
+#[instrument]
 pub fn hook_reference_transaction(transaction_state: &str) -> anyhow::Result<()> {
     if transaction_state != "committed" {
         return Ok(());

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -16,6 +16,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use itertools::Itertools;
 use os_str_bytes::OsStringBytes;
+use tracing::{error, warn};
 
 use crate::commands::gc::mark_commit_reachable;
 use crate::core::eventlog::{should_ignore_ref_updates, Event, EventLogDb, EventTransactionId};
@@ -76,7 +77,7 @@ pub fn hook_post_commit() -> anyhow::Result<()> {
         Some(commit_oid) => commit_oid,
         None => {
             // A strange situation, but technically possible.
-            log::warn!("`post-commit` hook called, but could not determine the OID of `HEAD`");
+            warn!("`post-commit` hook called, but could not determine the OID of `HEAD`");
             return Ok(());
         }
     };
@@ -180,7 +181,7 @@ pub fn hook_reference_transaction(transaction_state: &str) -> anyhow::Result<()>
             match parse_reference_transaction_line(line.as_slice(), now, event_tx_id) {
                 Ok(event) => event,
                 Err(err) => {
-                    log::error!("Could not parse reference-transaction-line: {:?}", err);
+                    error!(?err, "Could not parse reference-transaction-line");
                     None
                 }
             }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use console::style;
 use fn_error_context::context;
-use log::warn;
+use tracing::warn;
 
 use crate::core::config::get_core_hooks_path;
 use crate::git::{Config, ConfigValue, GitRunInfo, GitVersion, Repo};

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -109,6 +109,7 @@ pub fn r#move(
     let event_replayer = EventReplayer::from_event_log_db(&repo, &event_log_db)?;
     let event_cursor = event_replayer.make_default_cursor();
     let graph = make_graph(
+        output,
         &repo,
         &merge_base_db,
         &event_replayer,
@@ -120,7 +121,8 @@ pub fn r#move(
     )?;
 
     let source_oid = if should_resolve_base_commit {
-        let merge_base_oid = merge_base_db.get_merge_base_oid(&repo, source_oid, dest_oid)?;
+        let merge_base_oid =
+            merge_base_db.get_merge_base_oid(output, &repo, source_oid, dest_oid)?;
         resolve_base_commit(&graph, merge_base_oid, source_oid)
     } else {
         source_oid

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -6,6 +6,8 @@
 use std::io::stdout;
 use std::time::SystemTime;
 
+use tracing::instrument;
+
 use crate::core::config::get_restack_preserve_timestamps;
 use crate::core::eventlog::{EventLogDb, EventReplayer};
 use crate::core::formatting::Glyphs;
@@ -19,6 +21,7 @@ use crate::core::rewrite::{
 };
 use crate::git::{GitRunInfo, NonZeroOid, Repo};
 
+#[instrument]
 fn resolve_base_commit(
     graph: &CommitGraph,
     merge_base_oid: Option<NonZeroOid>,
@@ -42,6 +45,7 @@ fn resolve_base_commit(
 }
 
 /// Move a subtree from one place to another.
+#[instrument]
 pub fn r#move(
     git_run_info: &GitRunInfo,
     source: Option<String>,

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -51,7 +51,7 @@ pub fn r#move(
     force_on_disk: bool,
     dump_rebase_constraints: bool,
     dump_rebase_plan: bool,
-) -> anyhow::Result<isize> {
+) -> eyre::Result<isize> {
     let repo = Repo::from_current_dir()?;
     let head_oid = repo.get_head_info()?.oid;
     let (source, should_resolve_base_commit) = match (source, base) {
@@ -85,7 +85,7 @@ pub fn r#move(
     let (source_oid, dest_oid) = match resolve_commits(&repo, vec![source, dest])? {
         ResolveCommitsResult::Ok { commits } => match &commits.as_slice() {
             [source_commit, dest_commit] => (source_commit.get_oid(), dest_commit.get_oid()),
-            _ => anyhow::bail!("Unexpected number of returns values from resolve_commits"),
+            _ => eyre::bail!("Unexpected number of returns values from resolve_commits"),
         },
         ResolveCommitsResult::CommitNotFound { commit } => {
             println!("Commit not found: {}", commit);

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -12,7 +12,7 @@ use crate::core::mergebase::MergeBaseDb;
 use crate::git::{GitRunInfo, NonZeroOid, Repo};
 
 /// Go back a certain number of commits.
-pub fn prev(git_run_info: &GitRunInfo, num_commits: Option<isize>) -> anyhow::Result<isize> {
+pub fn prev(git_run_info: &GitRunInfo, num_commits: Option<isize>) -> eyre::Result<isize> {
     let exit_code = match num_commits {
         None => git_run_info.run(None, &["checkout", "HEAD^"])?,
         Some(num_commits) => {
@@ -44,7 +44,7 @@ fn advance_towards_main_branch(
     graph: &CommitGraph,
     current_oid: NonZeroOid,
     main_branch_oid: &MainBranchOid,
-) -> anyhow::Result<(isize, NonZeroOid)> {
+) -> eyre::Result<(isize, NonZeroOid)> {
     let MainBranchOid(main_branch_oid) = main_branch_oid;
     let path = find_path_to_merge_base(repo, merge_base_db, *main_branch_oid, current_oid)?;
     let path = match path {
@@ -73,7 +73,7 @@ fn advance_towards_own_commit(
     current_oid: NonZeroOid,
     num_commits: isize,
     towards: Option<Towards>,
-) -> anyhow::Result<Option<NonZeroOid>> {
+) -> eyre::Result<Option<NonZeroOid>> {
     let mut current_oid = current_oid;
     for i in 0..num_commits {
         let children = &graph[&current_oid].children;
@@ -124,7 +124,7 @@ pub fn next(
     git_run_info: &GitRunInfo,
     num_commits: Option<isize>,
     towards: Option<Towards>,
-) -> anyhow::Result<isize> {
+) -> eyre::Result<isize> {
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;
     let conn = repo.get_db_conn()?;
@@ -134,7 +134,7 @@ pub fn next(
 
     let head_oid = match repo.get_head_info()?.oid {
         Some(head_oid) => head_oid,
-        None => anyhow::bail!("No HEAD present; cannot calculate next commit"),
+        None => eyre::bail!("No HEAD present; cannot calculate next commit"),
     };
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -50,6 +50,7 @@ pub enum Towards {
 
 #[instrument]
 fn advance_towards_main_branch(
+    output: &mut Output,
     repo: &Repo,
     merge_base_db: &MergeBaseDb,
     graph: &CommitGraph,
@@ -57,7 +58,7 @@ fn advance_towards_main_branch(
     main_branch_oid: &MainBranchOid,
 ) -> eyre::Result<(isize, NonZeroOid)> {
     let MainBranchOid(main_branch_oid) = main_branch_oid;
-    let path = find_path_to_merge_base(repo, merge_base_db, *main_branch_oid, current_oid)?;
+    let path = find_path_to_merge_base(output, repo, merge_base_db, *main_branch_oid, current_oid)?;
     let path = match path {
         None => return Ok((0, current_oid)),
         Some(path) if path.len() == 1 => {
@@ -155,6 +156,7 @@ pub fn next(
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
+        output,
         &repo,
         &merge_base_db,
         &event_replayer,
@@ -167,6 +169,7 @@ pub fn next(
 
     let num_commits = num_commits.unwrap_or(1);
     let (num_commits_traversed_towards_main_branch, current_oid) = advance_towards_main_branch(
+        output,
         &repo,
         &merge_base_db,
         &graph,

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -1,6 +1,6 @@
 //! Convenience commands to help the user move through a stack of commits.
 
-use log::warn;
+use tracing::warn;
 
 use crate::commands::smartlog::smartlog;
 use crate::core::eventlog::{EventLogDb, EventReplayer};

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -1,6 +1,6 @@
 //! Convenience commands to help the user move through a stack of commits.
 
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use crate::commands::smartlog::smartlog;
 use crate::core::eventlog::{EventLogDb, EventReplayer};
@@ -12,6 +12,7 @@ use crate::core::mergebase::MergeBaseDb;
 use crate::git::{GitRunInfo, NonZeroOid, Repo};
 
 /// Go back a certain number of commits.
+#[instrument]
 pub fn prev(git_run_info: &GitRunInfo, num_commits: Option<isize>) -> eyre::Result<isize> {
     let exit_code = match num_commits {
         None => git_run_info.run(None, &["checkout", "HEAD^"])?,
@@ -38,6 +39,7 @@ pub enum Towards {
     Oldest,
 }
 
+#[instrument]
 fn advance_towards_main_branch(
     repo: &Repo,
     merge_base_db: &MergeBaseDb,
@@ -66,6 +68,7 @@ fn advance_towards_main_branch(
     Ok((0, current_oid))
 }
 
+#[instrument]
 fn advance_towards_own_commit(
     glyphs: &Glyphs,
     repo: &Repo,
@@ -120,6 +123,7 @@ fn advance_towards_own_commit(
 }
 
 /// Go forward a certain number of commits.
+#[instrument]
 pub fn next(
     git_run_info: &GitRunInfo,
     num_commits: Option<isize>,

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -264,7 +264,7 @@ pub fn restack(
     let result = restack_commits(
         output,
         &repo,
-        &git_run_info,
+        git_run_info,
         &merge_base_db,
         &event_log_db,
         commits,
@@ -278,7 +278,7 @@ pub fn restack(
     let result = restack_branches(
         output,
         &repo,
-        &git_run_info,
+        git_run_info,
         &merge_base_db,
         &event_log_db,
         &execute_options,

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -59,8 +59,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::stdout;
 use std::time::SystemTime;
 
-use fn_error_context::context;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use crate::commands::smartlog::smartlog;
 use crate::core::config::get_restack_preserve_timestamps;
@@ -76,7 +75,7 @@ use crate::core::rewrite::{
 };
 use crate::git::{GitRunInfo, NonZeroOid, Repo};
 
-#[context("Restacking commits")]
+#[instrument(skip(commits))]
 fn restack_commits(
     glyphs: &Glyphs,
     repo: &Repo,
@@ -156,7 +155,7 @@ fn restack_commits(
     }
 }
 
-#[context("Restacking branches")]
+#[instrument]
 fn restack_branches(
     repo: &Repo,
     git_run_info: &GitRunInfo,
@@ -217,7 +216,7 @@ fn restack_branches(
 /// Restack all abandoned commits.
 ///
 /// Returns an exit code (0 denotes successful exit).
-#[context("Restacking commits and branches")]
+#[instrument]
 pub fn restack(
     git_run_info: &GitRunInfo,
     commits: Vec<String>,

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -60,6 +60,7 @@ use std::io::stdout;
 use std::time::SystemTime;
 
 use fn_error_context::context;
+use tracing::warn;
 
 use crate::commands::smartlog::smartlog;
 use crate::core::config::get_restack_preserve_timestamps;
@@ -183,9 +184,9 @@ fn restack_branches(
         let branch_target = match branch.get_oid()? {
             Some(branch_target) => branch_target,
             None => {
-                log::warn!(
-                    "Branch {:?} was not a direct reference, could not resolve target",
-                    branch.into_reference().get_name()
+                warn!(
+                    branch_name = ?branch.into_reference().get_name(),
+                    "Branch was not a direct reference, could not resolve target"
                 );
                 continue;
             }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -92,6 +92,7 @@ fn restack_commits(
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
+        output,
         repo,
         merge_base_db,
         &event_replayer,
@@ -169,6 +170,7 @@ fn restack_branches(
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
+        output,
         repo,
         merge_base_db,
         &event_replayer,

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -85,7 +85,7 @@ fn restack_commits(
     commits: Option<impl IntoIterator<Item = NonZeroOid>>,
     build_options: &BuildRebasePlanOptions,
     execute_options: &ExecuteRebasePlanOptions,
-) -> anyhow::Result<isize> {
+) -> eyre::Result<isize> {
     let event_replayer = EventReplayer::from_event_log_db(repo, event_log_db)?;
     let event_cursor = event_replayer.make_default_cursor();
     let head_oid = repo.get_head_info()?.oid;
@@ -162,7 +162,7 @@ fn restack_branches(
     merge_base_db: &MergeBaseDb,
     event_log_db: &EventLogDb,
     options: &ExecuteRebasePlanOptions,
-) -> anyhow::Result<isize> {
+) -> eyre::Result<isize> {
     let event_replayer = EventReplayer::from_event_log_db(repo, event_log_db)?;
     let head_oid = repo.get_head_info()?.oid;
     let main_branch_oid = repo.get_main_branch_oid()?;
@@ -222,7 +222,7 @@ pub fn restack(
     commits: Vec<String>,
     dump_rebase_constraints: bool,
     dump_rebase_plan: bool,
-) -> anyhow::Result<isize> {
+) -> eyre::Result<isize> {
     let now = SystemTime::now();
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 
 use cursive::theme::Effect;
 use cursive::utils::markup::StyledString;
-use fn_error_context::context;
+use tracing::instrument;
 
 use crate::core::eventlog::{EventLogDb, EventReplayer};
 use crate::core::formatting::set_effect;
@@ -75,7 +75,7 @@ fn split_commit_graph_by_roots(
     root_commit_oids
 }
 
-#[context("Getting child smartlog output for OID {:?}", &current_oid)]
+#[instrument(skip(commit_metadata_providers))]
 fn get_child_output(
     glyphs: &Glyphs,
     graph: &CommitGraph,
@@ -175,11 +175,7 @@ fn get_child_output(
 }
 
 /// Render a pretty graph starting from the given root OIDs in the given graph.
-#[context(
-    "Getting smartlog output for HEAD OID {:?}, root OIDs: {:?}",
-    head_oid,
-    root_oids
-)]
+#[instrument(skip(commit_metadata_providers))]
 fn get_output(
     glyphs: &Glyphs,
     graph: &CommitGraph,

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -75,7 +75,7 @@ fn split_commit_graph_by_roots(
     root_commit_oids
 }
 
-#[instrument(skip(commit_metadata_providers))]
+#[instrument(skip(commit_metadata_providers, graph))]
 fn get_child_output(
     glyphs: &Glyphs,
     graph: &CommitGraph,
@@ -175,7 +175,7 @@ fn get_child_output(
 }
 
 /// Render a pretty graph starting from the given root OIDs in the given graph.
-#[instrument(skip(commit_metadata_providers))]
+#[instrument(skip(commit_metadata_providers, graph))]
 fn get_output(
     glyphs: &Glyphs,
     graph: &CommitGraph,
@@ -242,7 +242,7 @@ fn get_output(
 }
 
 /// Render the smartlog graph and write it to the provided stream.
-#[instrument(skip(commit_metadata_providers))]
+#[instrument(skip(commit_metadata_providers, graph))]
 pub fn render_graph(
     glyphs: &Glyphs,
     repo: &Repo,

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -50,12 +50,12 @@ fn split_commit_graph_by_roots(
 
         let (lhs_commit, rhs_commit) = match (lhs_commit, rhs_commit) {
             (Ok(Some(lhs_commit)), Ok(Some(rhs_commit))) => (lhs_commit, rhs_commit),
-            _ => return lhs_oid.cmp(&rhs_oid),
+            _ => return lhs_oid.cmp(rhs_oid),
         };
 
         let merge_base_oid = merge_base_db.get_merge_base_oid(output, repo, *lhs_oid, *rhs_oid);
         let merge_base_oid = match merge_base_oid {
-            Err(_) => return lhs_oid.cmp(&rhs_oid),
+            Err(_) => return lhs_oid.cmp(rhs_oid),
             Ok(merge_base_oid) => merge_base_oid,
         };
 
@@ -69,7 +69,7 @@ fn split_commit_graph_by_roots(
             // and reasonable guess at the intended topological ordering.
             Some(_) | None => match lhs_commit.get_time().cmp(&rhs_commit.get_time()) {
                 result @ Ordering::Less | result @ Ordering::Greater => result,
-                Ordering::Equal => lhs_oid.cmp(&rhs_oid),
+                Ordering::Equal => lhs_oid.cmp(rhs_oid),
             },
         }
     };

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -84,7 +84,7 @@ fn get_child_output(
     head_oid: &HeadOid,
     current_oid: NonZeroOid,
     last_child_line_char: Option<&str>,
-) -> anyhow::Result<Vec<StyledString>> {
+) -> eyre::Result<Vec<StyledString>> {
     let current_node = &graph[&current_oid];
     let is_head = {
         let HeadOid(head_oid) = head_oid;
@@ -182,7 +182,7 @@ fn get_output(
     commit_metadata_providers: &mut [&mut dyn CommitMetadataProvider],
     head_oid: &HeadOid,
     root_oids: &[NonZeroOid],
-) -> anyhow::Result<Vec<StyledString>> {
+) -> eyre::Result<Vec<StyledString>> {
     let mut lines = Vec::new();
 
     // Determine if the provided OID has the provided parent OID as a parent.
@@ -249,7 +249,7 @@ pub fn render_graph(
     graph: &CommitGraph,
     head_oid: &HeadOid,
     commit_metadata_providers: &mut [&mut dyn CommitMetadataProvider],
-) -> anyhow::Result<Vec<StyledString>> {
+) -> eyre::Result<Vec<StyledString>> {
     let root_oids = split_commit_graph_by_roots(repo, merge_base_db, graph);
     let lines = get_output(
         glyphs,
@@ -262,7 +262,7 @@ pub fn render_graph(
 }
 
 /// Display a nice graph of commits you've recently worked on.
-pub fn smartlog() -> anyhow::Result<()> {
+pub fn smartlog() -> eyre::Result<()> {
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;
     let conn = repo.get_db_conn()?;

--- a/src/commands/smartlog.rs
+++ b/src/commands/smartlog.rs
@@ -242,6 +242,7 @@ fn get_output(
 }
 
 /// Render the smartlog graph and write it to the provided stream.
+#[instrument(skip(commit_metadata_providers))]
 pub fn render_graph(
     glyphs: &Glyphs,
     repo: &Repo,
@@ -262,6 +263,7 @@ pub fn render_graph(
 }
 
 /// Display a nice graph of commits you've recently worked on.
+#[instrument]
 pub fn smartlog() -> eyre::Result<()> {
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -25,9 +25,9 @@ use crate::core::metadata::{
     BranchesProvider, CommitMessageProvider, CommitOidProvider, DifferentialRevisionProvider,
     HiddenExplanationProvider, RelativeTimeProvider,
 };
-use crate::core::tui::{with_siv, SingletonView};
 use crate::declare_views;
 use crate::git::{CategorizedReferenceName, GitRunInfo, MaybeZeroOid, Repo};
+use crate::tui::{with_siv, SingletonView};
 
 fn render_cursor_smartlog(
     glyphs: &Glyphs,

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -14,6 +14,7 @@ use cursive::utils::markup::StyledString;
 use cursive::views::{Dialog, EditView, LinearLayout, OnEventView, ScrollView, TextView};
 use cursive::{Cursive, CursiveRunnable, CursiveRunner};
 use eyre::Context;
+use tracing::instrument;
 
 use crate::commands::smartlog::render_graph;
 use crate::core::eventlog::{Event, EventCursor, EventLogDb, EventReplayer, EventTransactionId};
@@ -307,6 +308,7 @@ fn describe_events_numbered(
     Ok(lines)
 }
 
+#[instrument(skip(siv))]
 fn select_past_event(
     mut siv: CursiveRunner<CursiveRunnable>,
     glyphs: &Glyphs,
@@ -612,6 +614,7 @@ fn optimize_inverse_events(events: Vec<Event>) -> Vec<Event> {
     optimized_events
 }
 
+#[instrument(skip(in_, out))]
 fn undo_events(
     in_: &mut impl Read,
     out: &mut impl Write,
@@ -780,6 +783,7 @@ fn undo_events(
 }
 
 /// Restore the repository to a previous state interactively.
+#[instrument]
 pub fn undo(git_run_info: &GitRunInfo) -> eyre::Result<isize> {
     let glyphs = Glyphs::detect();
     let repo = Repo::from_current_dir()?;

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,4 +7,3 @@ pub mod graph;
 pub mod mergebase;
 pub mod metadata;
 pub mod rewrite;
-pub mod tui;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -5,13 +5,13 @@ use std::path::PathBuf;
 use crate::git::Repo;
 
 /// Get the path where Git hooks are stored on disk.
-pub fn get_core_hooks_path(repo: &Repo) -> anyhow::Result<PathBuf> {
+pub fn get_core_hooks_path(repo: &Repo) -> eyre::Result<PathBuf> {
     repo.get_config()?
         .get_or_else("core.hooksPath", || repo.get_path().join("hooks"))
 }
 
 /// Get the configured name of the main branch.
-pub fn get_main_branch_name(repo: &Repo) -> anyhow::Result<String> {
+pub fn get_main_branch_name(repo: &Repo) -> eyre::Result<String> {
     let config = repo.get_config()?;
     let main_branch_name: Option<String> = config.get("branchless.core.mainBranch")?;
     let main_branch_name = match main_branch_name {
@@ -28,7 +28,7 @@ pub fn get_main_branch_name(repo: &Repo) -> anyhow::Result<String> {
 
 /// If `true`, when restacking a commit, do not update its timestamp to the
 /// current time.
-pub fn get_restack_preserve_timestamps(repo: &Repo) -> anyhow::Result<bool> {
+pub fn get_restack_preserve_timestamps(repo: &Repo) -> eyre::Result<bool> {
     repo.get_config()?
         .get_or("branchless.restack.preserveTimestamps", false)
 }
@@ -38,25 +38,25 @@ pub const RESTACK_WARN_ABANDONED_CONFIG_KEY: &str = "branchless.restack.warnAban
 
 /// If `true`, when a rewrite event happens which abandons commits, warn the user
 /// and tell them to run `git restack`.
-pub fn get_restack_warn_abandoned(repo: &Repo) -> anyhow::Result<bool> {
+pub fn get_restack_warn_abandoned(repo: &Repo) -> eyre::Result<bool> {
     repo.get_config()?
         .get_or(RESTACK_WARN_ABANDONED_CONFIG_KEY, true)
 }
 
 /// If `true`, show branches pointing to each commit in the smartlog.
-pub fn get_commit_metadata_branches(repo: &Repo) -> anyhow::Result<bool> {
+pub fn get_commit_metadata_branches(repo: &Repo) -> eyre::Result<bool> {
     repo.get_config()?
         .get_or("branchless.commitMetadata.branches", true)
 }
 
 /// If `true`, show associated Phabricator commits in the smartlog.
-pub fn get_commit_metadata_differential_revision(repo: &Repo) -> anyhow::Result<bool> {
+pub fn get_commit_metadata_differential_revision(repo: &Repo) -> eyre::Result<bool> {
     repo.get_config()?
         .get_or("branchless.commitMetadata.differentialRevision", true)
 }
 
 /// If `true`, show the age of each commit in the smartlog.
-pub fn get_commit_metadata_relative_time(repo: &Repo) -> anyhow::Result<bool> {
+pub fn get_commit_metadata_relative_time(repo: &Repo) -> eyre::Result<bool> {
     repo.get_config()?
         .get_or("branchless.commitMetadata.relativeTime", true)
 }

--- a/src/core/eventlog.rs
+++ b/src/core/eventlog.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
-use fn_error_context::context;
+use tracing::instrument;
 
 use crate::git::{CategorizedReferenceName, MaybeZeroOid, NonZeroOid, Repo};
 
@@ -361,7 +361,7 @@ fn try_from_row_helper(row: &Row) -> Result<Event, anyhow::Error> {
 impl TryFrom<Row> for Event {
     type Error = anyhow::Error;
 
-    #[context("Converting database result row into `Event`: {:?}", &row)]
+    #[instrument]
     fn try_from(row: Row) -> Result<Self, Self::Error> {
         try_from_row_helper(&row)
     }
@@ -372,7 +372,13 @@ pub struct EventLogDb<'conn> {
     conn: &'conn rusqlite::Connection,
 }
 
-#[context("Initializing `EventLogDb` tables")]
+impl std::fmt::Debug for EventLogDb<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<EventLogDb>")
+    }
+}
+
+#[instrument]
 fn init_tables(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     conn.execute(
         "
@@ -413,7 +419,7 @@ CREATE TABLE IF NOT EXISTS event_transactions (
 
 impl<'conn> EventLogDb<'conn> {
     /// Constructor.
-    #[context("Constructing `EventLogDb`")]
+    #[instrument]
     pub fn new(conn: &'conn rusqlite::Connection) -> anyhow::Result<Self> {
         init_tables(&conn)?;
         Ok(EventLogDb { conn })
@@ -423,7 +429,7 @@ impl<'conn> EventLogDb<'conn> {
     ///
     /// Args:
     /// * events: The events to add.
-    #[context("Adding events to event-log")]
+    #[instrument]
     pub fn add_events(&mut self, events: Vec<Event>) -> anyhow::Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         for event in events {
@@ -475,7 +481,7 @@ INSERT INTO event_log VALUES (
     /// Get all the events in the database.
     ///
     /// Returns: All the events in the database, ordered from oldest to newest.
-    #[context("Querying events from `EventLogDb`")]
+    #[instrument]
 
     pub fn get_events(&self) -> anyhow::Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(
@@ -512,7 +518,7 @@ ORDER BY rowid ASC
 
     /// Create a new event transaction ID to be used to insert subsequent
     /// `Event`s into the database.
-    #[context("Creating a new `EventTransactionId`")]
+    #[instrument(fields(message = message.as_ref()))]
     pub fn make_transaction_id(
         &self,
         now: SystemTime,

--- a/src/core/eventlog.rs
+++ b/src/core/eventlog.rs
@@ -426,7 +426,7 @@ impl<'conn> EventLogDb<'conn> {
     /// Constructor.
     #[instrument]
     pub fn new(conn: &'conn rusqlite::Connection) -> eyre::Result<Self> {
-        init_tables(&conn)?;
+        init_tables(conn)?;
         Ok(EventLogDb { conn })
     }
 
@@ -714,7 +714,7 @@ impl EventReplayer {
     pub fn process_event(&mut self, event: &Event) {
         // Drop non-meaningful ref-update events.
         if let Event::RefUpdateEvent { ref_name, .. } = event {
-            if should_ignore_ref_updates(&ref_name) {
+            if should_ignore_ref_updates(ref_name) {
                 return;
             }
         }

--- a/src/core/formatting.rs
+++ b/src/core/formatting.rs
@@ -164,6 +164,16 @@ impl Glyphs {
     }
 }
 
+impl std::fmt::Debug for Glyphs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "<Glyphs pretty={:?}>",
+            self.should_write_ansi_escape_codes
+        )
+    }
+}
+
 /// Helper to build `StyledString`s by combining multiple strings (both regular
 /// `String`s and `StyledString`s).
 pub struct StyledStringBuilder {

--- a/src/core/formatting.rs
+++ b/src/core/formatting.rs
@@ -39,6 +39,7 @@ impl<'a> ToString for Pluralize<'a> {
 }
 
 /// Glyphs to use for rendering the smartlog.
+#[derive(Clone)]
 pub struct Glyphs {
     /// Whether or not ANSI escape codes should be emitted (e.g. to render
     /// color).

--- a/src/core/formatting.rs
+++ b/src/core/formatting.rs
@@ -268,7 +268,7 @@ impl From<StyledStringBuilder> for StyledString {
     }
 }
 
-fn render_style_as_ansi(content: &str, style: Style) -> anyhow::Result<String> {
+fn render_style_as_ansi(content: &str, style: Style) -> eyre::Result<String> {
     let Style { effects, color } = style;
     let output = {
         use console::style;
@@ -276,10 +276,10 @@ fn render_style_as_ansi(content: &str, style: Style) -> anyhow::Result<String> {
         let output = content.to_string();
         match color.front {
             ColorType::Palette(_) => {
-                anyhow::bail!("Not implemented: using cursive palette colors")
+                eyre::bail!("Not implemented: using cursive palette colors")
             }
             ColorType::Color(Color::Rgb(..)) | ColorType::Color(Color::RgbLowRes(..)) => {
-                anyhow::bail!("Not implemented: using raw RGB colors")
+                eyre::bail!("Not implemented: using raw RGB colors")
             }
             ColorType::InheritParent | ColorType::Color(Color::TerminalDefault) => style(output),
             ColorType::Color(Color::Light(color)) => match color {
@@ -314,7 +314,7 @@ fn render_style_as_ansi(content: &str, style: Style) -> anyhow::Result<String> {
                 Effect::Reverse => output.reverse(),
                 Effect::Bold => output.bold(),
                 Effect::Italic => output.italic(),
-                Effect::Strikethrough => anyhow::bail!("Not implemented: Effect::Strikethrough"),
+                Effect::Strikethrough => eyre::bail!("Not implemented: Effect::Strikethrough"),
                 Effect::Underline => output.underlined(),
                 Effect::Blink => output.blink(),
             };
@@ -329,7 +329,7 @@ fn render_style_as_ansi(content: &str, style: Style) -> anyhow::Result<String> {
 /// style it.
 ///
 /// TODO: return something that implements `Display` instead of a `String`.
-pub fn printable_styled_string(glyphs: &Glyphs, string: StyledString) -> anyhow::Result<String> {
+pub fn printable_styled_string(glyphs: &Glyphs, string: StyledString) -> eyre::Result<String> {
     let result = string
         .spans()
         .map(|span| {
@@ -344,6 +344,6 @@ pub fn printable_styled_string(glyphs: &Glyphs, string: StyledString) -> anyhow:
                 Ok(content.to_string())
             }
         })
-        .collect::<anyhow::Result<String>>()?;
+        .collect::<eyre::Result<String>>()?;
     Ok(result)
 }

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -151,7 +151,7 @@ pub fn find_path_to_merge_base<'repo>(
 /// between it and the main branch, those intermediate commits should be shown
 /// (or else you won't get a good idea of the line of development that happened
 /// for this commit since the main branch).
-#[instrument]
+#[instrument(skip(commit_oids))]
 fn walk_from_commits<'repo>(
     repo: &'repo Repo,
     merge_base_db: &MergeBaseDb,

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -85,12 +85,12 @@ fn find_path_to_merge_base_internal<'repo>(
     commit_oid: NonZeroOid,
     target_oid: NonZeroOid,
     mut visited_commit_callback: impl FnMut(NonZeroOid),
-) -> anyhow::Result<Option<Vec<Commit<'repo>>>> {
+) -> eyre::Result<Option<Vec<Commit<'repo>>>> {
     let mut queue = VecDeque::new();
     visited_commit_callback(commit_oid);
     let first_commit = match repo.find_commit(commit_oid)? {
         Some(commit) => commit,
-        None => anyhow::bail!("Unable to find commit with OID: {:?}", commit_oid),
+        None => eyre::bail!("Unable to find commit with OID: {:?}", commit_oid),
     };
     queue.push_back(vec![first_commit]);
     let merge_base_oid = merge_base_db.get_merge_base_oid(repo, commit_oid, target_oid)?;
@@ -141,7 +141,7 @@ pub fn find_path_to_merge_base<'repo>(
     merge_base_db: &MergeBaseDb,
     commit_oid: NonZeroOid,
     target_oid: NonZeroOid,
-) -> anyhow::Result<Option<Vec<Commit<'repo>>>> {
+) -> eyre::Result<Option<Vec<Commit<'repo>>>> {
     find_path_to_merge_base_internal(repo, merge_base_db, commit_oid, target_oid, |_commit| {})
 }
 
@@ -159,7 +159,7 @@ fn walk_from_commits<'repo>(
     event_cursor: EventCursor,
     main_branch_oid: &MainBranchOid,
     commit_oids: &CommitOids,
-) -> anyhow::Result<CommitGraph<'repo>> {
+) -> eyre::Result<CommitGraph<'repo>> {
     let mut graph: CommitGraph = Default::default();
 
     for commit_oid in &commit_oids.0 {
@@ -381,7 +381,7 @@ pub fn make_graph<'repo>(
     main_branch_oid: &MainBranchOid,
     branch_oids: &BranchOids,
     remove_commits: bool,
-) -> anyhow::Result<CommitGraph<'repo>> {
+) -> eyre::Result<CommitGraph<'repo>> {
     let mut commit_oids: HashSet<NonZeroOid> = event_replayer
         .get_cursor_active_oids(event_cursor)
         .into_iter()
@@ -417,7 +417,7 @@ mod tests {
     use crate::testing::make_git;
 
     #[test]
-    fn test_find_path_to_merge_base_stop_early() -> anyhow::Result<()> {
+    fn test_find_path_to_merge_base_stop_early() -> eyre::Result<()> {
         let git = make_git()?;
 
         git.init_repo()?;
@@ -467,7 +467,7 @@ pub enum ResolveCommitsResult<'repo> {
 /// - Short OIDs.
 /// - Reference names.
 #[instrument]
-pub fn resolve_commits(repo: &Repo, hashes: Vec<String>) -> anyhow::Result<ResolveCommitsResult> {
+pub fn resolve_commits(repo: &Repo, hashes: Vec<String>) -> eyre::Result<ResolveCommitsResult> {
     let mut commits = Vec::new();
     for hash in hashes {
         let commit = match repo.revparse_single_commit(&hash)? {

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -456,7 +456,6 @@ mod tests {
             })?;
         assert!(path.is_none());
 
-        println!("Seen OIDs is {:?}", &seen_oids);
         assert!(seen_oids.contains(&test2_oid));
         assert!(!seen_oids.contains(&test3_oid));
         assert!(!seen_oids.contains(&test1_oid));

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -4,8 +4,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use fn_error_context::context;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use crate::core::eventlog::{CommitVisibility, Event, EventCursor, EventReplayer};
 use crate::core::mergebase::MergeBaseDb;
@@ -136,7 +135,7 @@ fn find_path_to_merge_base_internal<'repo>(
 /// Returns: A path of commits from `commit_oid` through parents to `target_oid`.
 /// The path includes `commit_oid` at the beginning and `target_oid` at the end.
 /// If there is no such path, returns `None`.
-#[context("Finding path from {:?} to {:?}", commit_oid, target_oid)]
+#[instrument]
 pub fn find_path_to_merge_base<'repo>(
     repo: &'repo Repo,
     merge_base_db: &MergeBaseDb,
@@ -152,7 +151,7 @@ pub fn find_path_to_merge_base<'repo>(
 /// between it and the main branch, those intermediate commits should be shown
 /// (or else you won't get a good idea of the line of development that happened
 /// for this commit since the main branch).
-#[context("Walking from commits: {:?}", commit_oids)]
+#[instrument]
 fn walk_from_commits<'repo>(
     repo: &'repo Repo,
     merge_base_db: &MergeBaseDb,
@@ -372,7 +371,7 @@ fn do_remove_commits(graph: &mut CommitGraph, head_oid: &HeadOid, branch_oids: &
 /// be set to `True` for most display-related purposes.
 ///
 /// Returns: A tuple of the head OID and the commit graph.
-#[context("Creating commit graph")]
+#[instrument]
 pub fn make_graph<'repo>(
     repo: &'repo Repo,
     merge_base_db: &MergeBaseDb,
@@ -467,7 +466,7 @@ pub enum ResolveCommitsResult<'repo> {
 /// - Full OIDs.
 /// - Short OIDs.
 /// - Reference names.
-#[context("Resolving commits")]
+#[instrument]
 pub fn resolve_commits(repo: &Repo, hashes: Vec<String>) -> anyhow::Result<ResolveCommitsResult> {
     let mut commits = Vec::new();
     for hash in hashes {

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -5,7 +5,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use fn_error_context::context;
-use log::warn;
+use tracing::warn;
 
 use crate::core::eventlog::{CommitVisibility, Event, EventCursor, EventReplayer};
 use crate::core::mergebase::MergeBaseDb;
@@ -190,8 +190,8 @@ fn walk_from_commits<'repo>(
                 match path_to_merge_base {
                     None => {
                         warn!(
-                            "No path to merge-base for commit {}",
-                            current_commit.get_oid()
+                            current_commit_oid = ?current_commit.get_oid(),
+                            "No path to merge-base for commit",
                         );
                         continue;
                     }
@@ -237,7 +237,7 @@ fn walk_from_commits<'repo>(
 
         if let Some(merge_base_oid) = merge_base_oid {
             if !graph.contains_key(&merge_base_oid) {
-                warn!("Could not find merge base OID {}", merge_base_oid);
+                warn!(?merge_base_oid, "Could not find merge base OID");
             }
         }
     }

--- a/src/core/mergebase.rs
+++ b/src/core/mergebase.rs
@@ -53,7 +53,7 @@ impl<'conn> MergeBaseDb<'conn> {
     /// Constructor.
     #[instrument]
     pub fn new(conn: &'conn rusqlite::Connection) -> eyre::Result<Self> {
-        init_tables(&conn).wrap_err("Initializing tables")?;
+        init_tables(conn).wrap_err("Initializing tables")?;
         Ok(MergeBaseDb { conn })
     }
 

--- a/src/core/mergebase.rs
+++ b/src/core/mergebase.rs
@@ -19,6 +19,7 @@ use rusqlite::OptionalExtension;
 use tracing::instrument;
 
 use crate::git::{NonZeroOid, Repo};
+use crate::tui::Output;
 
 /// On-disk cache for merge-base queries.
 pub struct MergeBaseDb<'conn> {
@@ -71,10 +72,13 @@ impl<'conn> MergeBaseDb<'conn> {
     #[instrument]
     pub fn get_merge_base_oid(
         &self,
+        output: &Output,
         repo: &Repo,
         lhs_oid: NonZeroOid,
         rhs_oid: NonZeroOid,
     ) -> eyre::Result<Option<NonZeroOid>> {
+        let _progress = output.start_operation(crate::tui::OperationType::GetMergeBase);
+
         let (lhs_oid, rhs_oid) = if lhs_oid < rhs_oid {
             (lhs_oid, rhs_oid)
         } else {

--- a/src/core/mergebase.rs
+++ b/src/core/mergebase.rs
@@ -15,8 +15,8 @@
 //! examine it.
 
 use anyhow::Context;
-use fn_error_context::context;
 use rusqlite::OptionalExtension;
+use tracing::instrument;
 
 use crate::git::{NonZeroOid, Repo};
 
@@ -25,7 +25,13 @@ pub struct MergeBaseDb<'conn> {
     conn: &'conn rusqlite::Connection,
 }
 
-#[context("Initializing tables for `MergeBaseDb`")]
+impl std::fmt::Debug for MergeBaseDb<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<MergeBaseDb>")
+    }
+}
+
+#[instrument]
 fn init_tables(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     conn.execute(
         "
@@ -44,7 +50,7 @@ CREATE TABLE IF NOT EXISTS merge_base_oids (
 
 impl<'conn> MergeBaseDb<'conn> {
     /// Constructor.
-    #[context("Constructing `MergeBaseDb`")]
+    #[instrument]
     pub fn new(conn: &'conn rusqlite::Connection) -> anyhow::Result<Self> {
         init_tables(&conn).context("Initializing tables")?;
         Ok(MergeBaseDb { conn })
@@ -62,7 +68,7 @@ impl<'conn> MergeBaseDb<'conn> {
     ///
     /// Returns: The merge-base OID for these two commits. Returns `None` if no
     /// merge-base could be found.
-    #[context("Querying for merge-base of OIDs {:?} and {:?}", lhs_oid, rhs_oid)]
+    #[instrument]
     pub fn get_merge_base_oid(
         &self,
         repo: &Repo,

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -252,7 +252,7 @@ $",
         )
         .expect("Failed to compile DifferentialRevisionProvider regex");
     }
-    let captures = RE.captures(&message)?;
+    let captures = RE.captures(message)?;
     let diff_number = &captures["diff"];
     Some(diff_number.to_owned())
 }

--- a/src/core/rewrite/evolve.rs
+++ b/src/core/rewrite/evolve.rs
@@ -117,9 +117,11 @@ pub fn find_abandoned_children(
 #[cfg(test)]
 mod tests {
     use crate::core::eventlog::EventLogDb;
+    use crate::core::formatting::Glyphs;
     use crate::core::graph::{make_graph, BranchOids, HeadOid, MainBranchOid};
     use crate::core::mergebase::MergeBaseDb;
     use crate::testing::{make_git, Git, GitRunOptions};
+    use crate::tui::Output;
 
     use super::*;
 
@@ -127,6 +129,7 @@ mod tests {
         git: &Git,
         oid: NonZeroOid,
     ) -> eyre::Result<Option<MaybeZeroOid>> {
+        let output = Output::new_suppress_for_test(Glyphs::detect());
         let repo = git.get_repo()?;
         let conn = repo.get_db_conn()?;
         let merge_base_db = MergeBaseDb::new(&conn)?;
@@ -137,6 +140,7 @@ mod tests {
         let main_branch_oid = repo.get_main_branch_oid()?;
         let branch_oid_to_names = repo.get_branch_oid_to_names()?;
         let graph = make_graph(
+            &output,
             &repo,
             &merge_base_db,
             &event_replayer,

--- a/src/core/rewrite/evolve.rs
+++ b/src/core/rewrite/evolve.rs
@@ -126,7 +126,7 @@ mod tests {
     fn find_rewrite_target_helper(
         git: &Git,
         oid: NonZeroOid,
-    ) -> anyhow::Result<Option<MaybeZeroOid>> {
+    ) -> eyre::Result<Option<MaybeZeroOid>> {
         let repo = git.get_repo()?;
         let conn = repo.get_db_conn()?;
         let merge_base_db = MergeBaseDb::new(&conn)?;
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_rewrite_target() -> anyhow::Result<()> {
+    fn test_find_rewrite_target() -> eyre::Result<()> {
         let git = make_git()?;
 
         git.init_repo()?;

--- a/src/core/rewrite/execute.rs
+++ b/src/core/rewrite/execute.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use anyhow::Context;
 use os_str_bytes::OsStrBytes;
+use tracing::warn;
 
 use crate::core::eventlog::EventTransactionId;
 use crate::core::formatting::{printable_styled_string, Glyphs};
@@ -76,7 +77,7 @@ pub fn move_branches<'a>(
                             }
                         }
                         Ok(None) => {
-                            log::warn!("Reference not found, not deleting: {:?}", name)
+                            warn!(?name, "Reference not found, not deleting")
                         }
                         Err(err) => {
                             branch_move_err = Some(err);
@@ -125,6 +126,7 @@ mod in_memory {
     use anyhow::Context;
     use fn_error_context::context;
     use indicatif::{ProgressBar, ProgressStyle};
+    use tracing::warn;
 
     use crate::commands::gc::mark_commit_reachable;
     use crate::core::formatting::{printable_styled_string, Glyphs};
@@ -412,9 +414,9 @@ mod in_memory {
                         let new_head_oid = match skipped_head_new_oid {
                             Some(new_head_oid) => new_head_oid,
                             None => {
-                                log::warn!(
-                                    "`HEAD` OID {:?} was rewritten to 0, but no skipped `HEAD` OID was set",
-                                    head_oid
+                                warn!(
+                                    ?head_oid,
+                                    "`HEAD` OID was rewritten to 0, but no skipped `HEAD` OID was set",
                                 );
                                 head_oid
                             }

--- a/src/core/rewrite/execute.rs
+++ b/src/core/rewrite/execute.rs
@@ -33,7 +33,7 @@ pub fn move_branches<'a>(
     let mut branch_moves: Vec<(NonZeroOid, MaybeZeroOid, &OsStr)> = Vec::new();
     let mut branch_move_err: Option<eyre::Error> = None;
     'outer: for (old_oid, names) in branch_oid_to_names.iter() {
-        let new_oid = match rewritten_oids_map.get(&old_oid) {
+        let new_oid = match rewritten_oids_map.get(old_oid) {
             Some(new_oid) => new_oid,
             None => continue,
         };
@@ -257,7 +257,7 @@ mod in_memory {
                     let progress_template = format!("{} {{spinner}} {{wide_msg}}", commit_num);
                     let progress = ProgressBar::new_spinner();
                     progress.set_style(
-                        ProgressStyle::default_spinner().template(&progress_template.trim()),
+                        ProgressStyle::default_spinner().template(progress_template.trim()),
                     );
                     progress.set_message("Starting");
                     progress.enable_steady_tick(100);
@@ -370,7 +370,7 @@ mod in_memory {
                     let commit_num = format!("[{}/{}]", i, num_picks);
                     let progress_template = format!("{} {{spinner}} {{wide_msg}}", commit_num);
                     progress.set_style(
-                        ProgressStyle::default_spinner().template(&progress_template.trim()),
+                        ProgressStyle::default_spinner().template(progress_template.trim()),
                     );
                     let commit = match repo.find_commit(*commit_oid)? {
                         Some(commit) => commit,
@@ -775,7 +775,7 @@ pub fn execute_rebase_plan(
     if !force_on_disk {
         use in_memory::*;
         writeln!(output, "Attempting rebase in-memory...")?;
-        match rebase_in_memory(output, &repo, &rebase_plan, &options)? {
+        match rebase_in_memory(output, repo, rebase_plan, options)? {
             RebaseInMemoryResult::Succeeded {
                 rewritten_oids,
                 new_head_oid,
@@ -786,7 +786,7 @@ pub fn execute_rebase_plan(
                     repo,
                     &rewritten_oids,
                     new_head_oid,
-                    &options,
+                    options,
                 )?;
                 writeln!(output, "In-memory rebase succeeded.")?;
                 return Ok(0);
@@ -822,7 +822,7 @@ pub fn execute_rebase_plan(
 
     if !force_in_memory {
         use on_disk::*;
-        match rebase_on_disk(output, git_run_info, repo, &rebase_plan, &options)? {
+        match rebase_on_disk(output, git_run_info, repo, rebase_plan, options)? {
             Ok(exit_code) => return Ok(exit_code),
             Err(Error::ChangedFilesInRepository) => {
                 write!(

--- a/src/core/rewrite/execute.rs
+++ b/src/core/rewrite/execute.rs
@@ -124,9 +124,8 @@ mod in_memory {
     use std::ffi::OsString;
 
     use anyhow::Context;
-    use fn_error_context::context;
     use indicatif::{ProgressBar, ProgressStyle};
-    use tracing::warn;
+    use tracing::{instrument, warn};
 
     use crate::commands::gc::mark_commit_reachable;
     use crate::core::formatting::{printable_styled_string, Glyphs};
@@ -155,7 +154,7 @@ mod in_memory {
         },
     }
 
-    #[context("Rebasing in memory")]
+    #[instrument]
     pub fn rebase_in_memory(
         glyphs: &Glyphs,
         repo: &Repo,
@@ -269,7 +268,7 @@ mod in_memory {
                     progress
                         .set_message(format!("Applying patch for commit: {}", commit_description));
                     let mut rebased_index =
-                        repo.cherrypick_commit(&commit_to_apply, &current_commit, 0, None)?;
+                        repo.cherrypick_commit(&commit_to_apply, &current_commit, 0)?;
 
                     progress.set_message(format!(
                         "Checking for merge conflicts: {}",
@@ -540,8 +539,8 @@ mod in_memory {
 
 mod on_disk {
     use anyhow::Context;
-    use fn_error_context::context;
     use indicatif::ProgressBar;
+    use tracing::instrument;
 
     use crate::core::rewrite::plan::RebasePlan;
     use crate::git::{GitRunInfo, MaybeZeroOid, Repo};
@@ -558,7 +557,7 @@ mod on_disk {
     ///
     /// Note that this calls `git rebase`, which may fail (e.g. if there are
     /// merge conflicts). The exit code is then propagated to the caller.
-    #[context("Rebasing on disk")]
+    #[instrument]
     pub fn rebase_on_disk(
         git_run_info: &GitRunInfo,
         repo: &Repo,

--- a/src/core/rewrite/hooks.rs
+++ b/src/core/rewrite/hooks.rs
@@ -89,7 +89,7 @@ pub fn hook_post_rewrite(
         .exists()
     {
         move_branches(git_run_info, &repo, event_tx_id, &rewritten_oids)?;
-        check_out_new_head(output, &git_run_info, &repo, event_tx_id, &rewritten_oids)?;
+        check_out_new_head(output, git_run_info, &repo, event_tx_id, &rewritten_oids)?;
     }
 
     let should_check_abandoned_commits = get_restack_warn_abandoned(&repo)?;
@@ -134,7 +134,7 @@ fn check_out_new_head(
                     }
                     Some(MaybeZeroOid::Zero) => {
                         // The commit was skipped. Get the new location for `HEAD`.
-                        get_updated_head_oid(&repo)?.map(|oid| oid.to_string().into())
+                        get_updated_head_oid(repo)?.map(|oid| oid.to_string().into())
                     }
                     None => {
                         // This OID was not rewritten, so check it out again.
@@ -152,7 +152,7 @@ fn check_out_new_head(
                             // The branch was deleted because it pointed to
                             // a skipped commit. Get the new location for
                             // `HEAD`.
-                            get_updated_head_oid(&repo)?.map(|oid| oid.to_string().into())
+                            get_updated_head_oid(repo)?.map(|oid| oid.to_string().into())
                         }
                     }
                 }
@@ -194,8 +194,8 @@ fn warn_abandoned(
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
         output,
-        &repo,
-        &merge_base_db,
+        repo,
+        merge_base_db,
         &event_replayer,
         event_cursor,
         &HeadOid(head_oid),

--- a/src/core/rewrite/hooks.rs
+++ b/src/core/rewrite/hooks.rs
@@ -96,6 +96,7 @@ pub fn hook_post_rewrite(
     if should_check_abandoned_commits && !is_spurious_event {
         let merge_base_db = MergeBaseDb::new(&conn)?;
         warn_abandoned(
+            output,
             &repo,
             &merge_base_db,
             &event_log_db,
@@ -177,6 +178,7 @@ fn check_out_new_head(
 
 #[instrument(skip(old_commit_oids))]
 fn warn_abandoned(
+    output: &mut Output,
     repo: &Repo,
     merge_base_db: &MergeBaseDb,
     event_log_db: &EventLogDb,
@@ -191,6 +193,7 @@ fn warn_abandoned(
     let main_branch_oid = repo.get_main_branch_oid()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
     let graph = make_graph(
+        output,
         &repo,
         &merge_base_db,
         &event_replayer,

--- a/src/core/rewrite/plan.rs
+++ b/src/core/rewrite/plan.rs
@@ -120,7 +120,7 @@ impl BuildRebasePlanError {
         out: &mut impl Write,
         glyphs: &Glyphs,
         repo: &Repo,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         match self {
             BuildRebasePlanError::ConstraintCycle { cycle_oids } => {
                 writeln!(
@@ -198,7 +198,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         current_oid: NonZeroOid,
         upstream_patch_ids: &HashSet<PatchId>,
         mut acc: Vec<RebaseCommand>,
-    ) -> anyhow::Result<Vec<RebaseCommand>> {
+    ) -> eyre::Result<Vec<RebaseCommand>> {
         let acc = {
             let current_patch_id = match self.repo.find_commit(current_oid)? {
                 None => {
@@ -275,7 +275,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         &mut self,
         source_oid: NonZeroOid,
         dest_oid: NonZeroOid,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         self.constraints
             .entry(dest_oid)
             .or_default()
@@ -288,7 +288,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         &self,
         acc: &mut Vec<Constraint>,
         current_oid: NonZeroOid,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         // FIXME: O(n^2) algorithm.
         for (child_oid, node) in self.graph {
             if node.commit.get_parent_oids().contains(&current_oid) {
@@ -412,7 +412,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
     /// of a referred-to commit. This adds enough information to the constraint
     /// graph that it now represents the actual end-state commit graph that we
     /// want to create, not just a list of constraints.
-    fn add_descendant_constraints(&mut self) -> anyhow::Result<()> {
+    fn add_descendant_constraints(&mut self) -> eyre::Result<()> {
         let all_descendants_of_constrained_nodes = {
             let mut acc = Vec::new();
             for parent_oid in self.constraints.values().flatten().cloned() {
@@ -499,7 +499,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
     pub fn build(
         mut self,
         options: &BuildRebasePlanOptions,
-    ) -> anyhow::Result<Result<Option<RebasePlan>, BuildRebasePlanError>> {
+    ) -> eyre::Result<Result<Option<RebasePlan>, BuildRebasePlanError>> {
         if options.dump_rebase_constraints {
             println!(
                 "Rebase constraints before adding descendants: {:#?}",
@@ -550,7 +550,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         &self,
         current_oid: NonZeroOid,
         dest_oid: NonZeroOid,
-    ) -> anyhow::Result<HashSet<PatchId>> {
+    ) -> eyre::Result<HashSet<PatchId>> {
         let merge_base_oid =
             self.merge_base_db
                 .get_merge_base_oid(self.repo, dest_oid, current_oid)?;

--- a/src/core/rewrite/plan.rs
+++ b/src/core/rewrite/plan.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 
 use fn_error_context::context;
 use itertools::Itertools;
+use tracing::warn;
 
 use crate::core::formatting::{printable_styled_string, Glyphs};
 use crate::core::graph::{find_path_to_merge_base, CommitGraph, MainBranchOid};
@@ -200,7 +201,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         let acc = {
             let current_patch_id = match self.repo.find_commit(current_oid)? {
                 None => {
-                    log::warn!("Could not find commit: {:?}", current_oid);
+                    warn!(?current_oid, "Could not find commit");
                     None
                 }
                 Some(commit) => self.repo.get_patch_id(&commit)?,

--- a/src/core/rewrite/plan.rs
+++ b/src/core/rewrite/plan.rs
@@ -115,12 +115,7 @@ pub enum BuildRebasePlanError {
 
 impl BuildRebasePlanError {
     /// Write the error message to `out`.
-    pub fn describe(
-        &self,
-        out: &mut impl Write,
-        glyphs: &Glyphs,
-        repo: &Repo,
-    ) -> eyre::Result<()> {
+    pub fn describe(&self, out: &mut impl Write, glyphs: &Glyphs, repo: &Repo) -> eyre::Result<()> {
         match self {
             BuildRebasePlanError::ConstraintCycle { cycle_oids } => {
                 writeln!(
@@ -290,7 +285,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
         current_oid: NonZeroOid,
     ) -> eyre::Result<()> {
         // FIXME: O(n^2) algorithm.
-        for (child_oid, node) in self.graph {
+        for (child_oid, node) in self.graph.iter() {
             if node.commit.get_parent_oids().contains(&current_oid) {
                 acc.push(Constraint {
                     parent_oid: current_oid,

--- a/src/core/tui.rs
+++ b/src/core/tui.rs
@@ -32,12 +32,7 @@ pub(crate) fn with_siv<T, F: FnOnce(CursiveRunner<CursiveRunnable>) -> anyhow::R
             (PaletteColor::Primary, Color::TerminalDefault),
         ]);
     });
-    let old_max_level = log::max_level();
-    log::set_max_level(log::LevelFilter::Off);
-    let result = f(siv.into_runner());
-    log::set_max_level(old_max_level);
-    let result = result?;
-    Ok(result)
+    f(siv.into_runner())
 }
 
 /// Type-safe "singleton" view: a kind of view which is addressed by name, for

--- a/src/core/tui.rs
+++ b/src/core/tui.rs
@@ -3,9 +3,9 @@ use cursive::theme::{Color, PaletteColor};
 use cursive::{Cursive, CursiveRunnable, CursiveRunner};
 
 /// Create an instance of a `CursiveRunner`, and clean it up afterward.
-pub(crate) fn with_siv<T, F: FnOnce(CursiveRunner<CursiveRunnable>) -> anyhow::Result<T>>(
+pub(crate) fn with_siv<T, F: FnOnce(CursiveRunner<CursiveRunnable>) -> eyre::Result<T>>(
     f: F,
-) -> anyhow::Result<T> {
+) -> eyre::Result<T> {
     // I tried these back-ends:
     //
     // * `ncurses`/`pancurses`: Doesn't render ANSI escape codes. (NB: the fact

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -150,7 +150,7 @@ impl Config {
 
     /// Get a config key of one of various possible types.
     pub fn get<V: GetConfigValue<V>, S: AsRef<str>>(&self, key: S) -> eyre::Result<Option<V>> {
-        V::get_from_config(&self, key)
+        V::get_from_config(self, key)
     }
 
     /// Same as `get`, but uses a default value if the config key doesn't exist.

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::path::PathBuf;
 
-use anyhow::Context;
+use eyre::Context;
 use tracing::instrument;
 
 use super::repo::wrap_git_error;
@@ -71,16 +71,16 @@ impl Display for ConfigValue {
 /// Trait used to make `Config::get` able to return multiple types.
 pub trait GetConfigValue<V> {
     /// Get the given type of value from the config object.
-    fn get_from_config(config: &Config, key: impl AsRef<str>) -> anyhow::Result<Option<V>>;
+    fn get_from_config(config: &Config, key: impl AsRef<str>) -> eyre::Result<Option<V>>;
 }
 
 impl GetConfigValue<String> for String {
-    fn get_from_config(config: &Config, key: impl AsRef<str>) -> anyhow::Result<Option<String>> {
+    fn get_from_config(config: &Config, key: impl AsRef<str>) -> eyre::Result<Option<String>> {
         let value = match config.inner.get_string(key.as_ref()) {
             Ok(value) => Some(value),
             Err(err) if err.code() == git2::ErrorCode::NotFound => None,
             Err(err) => {
-                return Err(wrap_git_error(err)).with_context(|| {
+                return Err(wrap_git_error(err)).wrap_err_with(|| {
                     format!("Looking up string value for config key: {:?}", key.as_ref())
                 });
             }
@@ -90,12 +90,12 @@ impl GetConfigValue<String> for String {
 }
 
 impl GetConfigValue<bool> for bool {
-    fn get_from_config(config: &Config, key: impl AsRef<str>) -> anyhow::Result<Option<bool>> {
+    fn get_from_config(config: &Config, key: impl AsRef<str>) -> eyre::Result<Option<bool>> {
         let value = match config.inner.get_bool(key.as_ref()) {
             Ok(value) => Some(value),
             Err(err) if err.code() == git2::ErrorCode::NotFound => None,
             Err(err) => {
-                return Err(wrap_git_error(err)).with_context(|| {
+                return Err(wrap_git_error(err)).wrap_err_with(|| {
                     format!("Looking up bool value for config key: {:?}", key.as_ref())
                 })
             }
@@ -105,12 +105,12 @@ impl GetConfigValue<bool> for bool {
 }
 
 impl GetConfigValue<PathBuf> for PathBuf {
-    fn get_from_config(config: &Config, key: impl AsRef<str>) -> anyhow::Result<Option<PathBuf>> {
+    fn get_from_config(config: &Config, key: impl AsRef<str>) -> eyre::Result<Option<PathBuf>> {
         let value = match config.inner.get_path(key.as_ref()) {
             Ok(value) => Some(value),
             Err(err) if err.code() == git2::ErrorCode::NotFound => None,
             Err(err) => {
-                return Err(wrap_git_error(err)).with_context(|| {
+                return Err(wrap_git_error(err)).wrap_err_with(|| {
                     format!("Looking up path value for config key: {:?}", key.as_ref())
                 })
             }
@@ -125,7 +125,7 @@ impl Config {
         &mut self,
         key: S,
         value: ConfigValue,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         match &value.inner {
             ConfigValueInner::String(value) => self
                 .inner
@@ -143,13 +143,13 @@ impl Config {
         &mut self,
         key: S,
         value: impl Into<ConfigValue>,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         let value = value.into();
         self.set_internal(key, value)
     }
 
     /// Get a config key of one of various possible types.
-    pub fn get<V: GetConfigValue<V>, S: AsRef<str>>(&self, key: S) -> anyhow::Result<Option<V>> {
+    pub fn get<V: GetConfigValue<V>, S: AsRef<str>>(&self, key: S) -> eyre::Result<Option<V>> {
         V::get_from_config(&self, key)
     }
 
@@ -158,7 +158,7 @@ impl Config {
         &self,
         key: S,
         default: V,
-    ) -> anyhow::Result<V> {
+    ) -> eyre::Result<V> {
         let result = self.get(key)?;
         Ok(result.unwrap_or(default))
     }
@@ -168,7 +168,7 @@ impl Config {
         &self,
         key: S,
         default: F,
-    ) -> anyhow::Result<V> {
+    ) -> eyre::Result<V> {
         let result = self.get(key)?;
         match result {
             Some(result) => Ok(result),
@@ -178,11 +178,11 @@ impl Config {
 
     /// Remove the given key from the configuration.
     #[instrument(fields(key = key.as_ref()))]
-    pub fn remove(&mut self, key: impl AsRef<str>) -> anyhow::Result<()> {
+    pub fn remove(&mut self, key: impl AsRef<str>) -> eyre::Result<()> {
         self.inner
             .remove(key.as_ref())
             .map_err(wrap_git_error)
-            .with_context(|| format!("Removing config key: {:?}", key.as_ref()))?;
+            .wrap_err_with(|| format!("Removing config key: {:?}", key.as_ref()))?;
         Ok(())
     }
 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -30,7 +30,7 @@ use crate::core::config::get_main_branch_name;
 use crate::core::metadata::{render_commit_metadata, CommitMessageProvider, CommitOidProvider};
 use crate::git::config::Config;
 use crate::git::oid::{make_non_zero_oid, MaybeZeroOid, NonZeroOid};
-use crate::tui::Output;
+use crate::tui::{OperationType, Output};
 
 use super::GitRunInfo;
 
@@ -427,27 +427,36 @@ Either create it, or update the main branch setting by running:
     }
 
     /// Get the patch ID for this commit.
-    pub fn get_patch_id(&self, commit: &Commit) -> eyre::Result<Option<PatchId>> {
+    pub fn get_patch_id(&self, output: &Output, commit: &Commit) -> eyre::Result<Option<PatchId>> {
         match commit.get_only_parent() {
             None => Ok(None),
             Some(only_parent) => {
                 let parent_tree = only_parent.get_tree()?;
                 let current_tree = commit.get_tree()?;
-                let diff = self
-                    .inner
-                    .diff_tree_to_tree(Some(&parent_tree.inner), Some(&current_tree.inner), None)
-                    .wrap_err_with(|| {
+                let diff = {
+                    let _progress = output.start_operation(OperationType::CalculateDiff);
+                    self.inner
+                        .diff_tree_to_tree(
+                            Some(&parent_tree.inner),
+                            Some(&current_tree.inner),
+                            None,
+                        )
+                        .wrap_err_with(|| {
+                            format!(
+                                "Calculating diff between: {:?} and {:?}",
+                                commit, only_parent
+                            )
+                        })?
+                };
+                let patch_id = {
+                    let _progress = output.start_operation(OperationType::CalculatePatchId);
+                    diff.patchid(None).wrap_err_with(|| {
                         format!(
-                            "Calculating diff between: {:?} and {:?}",
+                            "Computing patch ID between: {:?} and {:?}",
                             commit, only_parent
                         )
-                    })?;
-                let patch_id = diff.patchid(None).wrap_err_with(|| {
-                    format!(
-                        "Computing patch ID between: {:?} and {:?}",
-                        commit, only_parent
-                    )
-                })?;
+                    })?
+                };
                 Ok(Some(PatchId { patch_id }))
             }
         }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -24,6 +24,7 @@ use cursive::theme::BaseColor;
 use cursive::utils::markup::StyledString;
 use fn_error_context::context;
 use os_str_bytes::{OsStrBytes, OsStringBytes};
+use tracing::warn;
 
 use crate::core::config::get_main_branch_name;
 use crate::core::metadata::{render_commit_metadata, CommitMessageProvider, CommitOidProvider};
@@ -218,7 +219,7 @@ impl Repo {
                 .set_head_detached(oid.inner)
                 .map_err(wrap_git_error),
             None => {
-                log::warn!("Attempted to detach `HEAD` while `HEAD` is unborn");
+                warn!("Attempted to detach `HEAD` while `HEAD` is unborn");
                 Ok(())
             }
         }
@@ -295,9 +296,9 @@ Either create it, or update the main branch setting by running:
             let reference = branch.into_reference();
             let reference_name = match reference.name() {
                 None => {
-                    log::warn!(
-                        "Could not decode branch name, skipping: {:?}",
-                        reference.name_bytes()
+                    warn!(
+                        reference_name = ?reference.name_bytes(),
+                        "Could not decode branch name, skipping"
                     );
                     continue;
                 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -30,6 +30,7 @@ use crate::core::config::get_main_branch_name;
 use crate::core::metadata::{render_commit_metadata, CommitMessageProvider, CommitOidProvider};
 use crate::git::config::Config;
 use crate::git::oid::{make_non_zero_oid, MaybeZeroOid, NonZeroOid};
+use crate::tui::Output;
 
 use super::GitRunInfo;
 
@@ -483,8 +484,13 @@ Either create it, or update the main branch setting by running:
     /// Check if the repository has staged or unstaged changes. Untracked files
     /// are not included. This operation may take a while.
     #[instrument]
-    pub fn has_changed_files(&self, git_run_info: &GitRunInfo) -> eyre::Result<bool> {
+    pub fn has_changed_files(
+        &self,
+        output: &mut Output,
+        git_run_info: &GitRunInfo,
+    ) -> eyre::Result<bool> {
         let exit_code = git_run_info.run(
+            output,
             // This is not a mutating operation, so we don't need a transaction ID.
             None,
             &["diff", "--quiet"],

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -74,7 +74,7 @@ impl HeadInfo {
             .as_ref()
             .map(|name| match name.strip_prefix("refs/heads/") {
                 Some(branch_name) => branch_name,
-                None => &name,
+                None => name,
             })
     }
 }

--- a/src/git/run.rs
+++ b/src/git/run.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi::{OsStr, OsString};
-use std::io::{stderr, stdout, Write};
+use std::fmt::Write;
+use std::io::{stderr, stdout, Write as WriteIo};
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
 
@@ -12,6 +13,7 @@ use tracing::instrument;
 use crate::core::config::get_core_hooks_path;
 use crate::core::eventlog::{EventTransactionId, BRANCHLESS_TRANSACTION_ID_ENV_VAR};
 use crate::git::repo::Repo;
+use crate::tui::Output;
 use crate::util::get_sh;
 
 /// Path to the `git` executable on disk to be executed.
@@ -51,6 +53,7 @@ impl GitRunInfo {
     #[must_use = "The return code for `run_git` must be checked"]
     pub fn run<S: AsRef<OsStr> + std::fmt::Debug>(
         &self,
+        output: &mut Output,
         event_tx_id: Option<EventTransactionId>,
         args: &[S],
     ) -> eyre::Result<isize> {
@@ -59,14 +62,15 @@ impl GitRunInfo {
             working_directory,
             env,
         } = self;
-        println!(
+        writeln!(
+            output,
             "branchless: {} {}",
             path_to_git.to_string_lossy(),
             args.iter()
                 .map(|arg| arg.as_ref().to_string_lossy().to_string())
                 .collect::<Vec<_>>()
                 .join(" ")
-        );
+        )?;
         stdout().flush()?;
         stderr().flush()?;
 

--- a/src/git/run.rs
+++ b/src/git/run.rs
@@ -15,7 +15,7 @@ use crate::git::repo::Repo;
 use crate::util::get_sh;
 
 /// Path to the `git` executable on disk to be executed.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GitRunInfo {
     /// The path to the Git executable on disk.
     pub path_to_git: PathBuf,
@@ -25,6 +25,16 @@ pub struct GitRunInfo {
 
     /// The environment variables that should be passed to the Git process.
     pub env: HashMap<OsString, OsString>,
+}
+
+impl std::fmt::Debug for GitRunInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "<GitRunInfo path_to_git={:?} working_directory={:?} env=not shown>",
+            self.path_to_git, self.working_directory
+        )
+    }
 }
 
 impl GitRunInfo {

--- a/src/git/run.rs
+++ b/src/git/run.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
 
 use anyhow::Context;
-use fn_error_context::context;
 use os_str_bytes::OsStrBytes;
+use tracing::instrument;
 
 use crate::core::config::get_core_hooks_path;
 use crate::core::eventlog::{EventTransactionId, BRANCHLESS_TRANSACTION_ID_ENV_VAR};
@@ -37,7 +37,7 @@ impl GitRunInfo {
     /// executable itself.
     ///
     /// Returns the exit code of Git (non-zero signifies error).
-    #[context("Running Git ({:?}) with args: {:?}", &self, args)]
+    #[instrument]
     #[must_use = "The return code for `run_git` must be checked"]
     pub fn run<S: AsRef<OsStr> + std::fmt::Debug>(
         &self,
@@ -144,13 +144,13 @@ impl GitRunInfo {
     /// Run a provided Git hook if it exists for the repository.
     ///
     /// See the man page for `githooks(5)` for more detail on Git hooks.
-    #[context("Running Git hook: {}", hook_name)]
-    pub fn run_hook(
+    #[instrument]
+    pub fn run_hook<S: AsRef<str> + std::fmt::Debug>(
         &self,
         repo: &Repo,
         hook_name: &str,
         event_tx_id: EventTransactionId,
-        args: &[impl AsRef<str>],
+        args: &[S],
         stdin: Option<OsString>,
     ) -> anyhow::Result<()> {
         let hook_dir = get_core_hooks_path(repo)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,4 +43,5 @@ pub mod commands;
 pub mod core;
 pub mod git;
 pub mod testing;
+pub mod tui;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,10 +342,12 @@ fn install_tracing() {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
-    let fmt_layer = fmt::layer().with_target(false);
     let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("info"))
+        .or_else(|_| EnvFilter::try_new("warn"))
         .unwrap();
+    let fmt_layer = fmt::layer()
+        .with_span_events(fmt::format::FmtSpan::CLOSE)
+        .with_target(false);
 
     tracing_subscriber::registry()
         .with(filter_layer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,7 @@ enum Opts {
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
+    install_tracing();
 
     let opts = Opts::from_args();
     let path_to_git = std::env::var_os("PATH_TO_GIT").unwrap_or_else(|| OsString::from("git"));
@@ -332,4 +333,23 @@ fn main() -> eyre::Result<()> {
 
     let exit_code: i32 = exit_code.try_into()?;
     std::process::exit(exit_code)
+}
+
+fn install_tracing() {
+    // From https://github.com/yaahc/color-eyre/blob/07b9f0351544e2b07fcd173dc1fc602a7fc8bb6b/examples/usage.rs
+    // Licensed under MIT.
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let fmt_layer = fmt::layer().with_target(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(ErrorLayer::default())
+        .init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,8 @@ use std::convert::TryInto;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use anyhow::Context;
 use branchless::commands::wrap;
 use branchless::git::{GitRunInfo, NonZeroOid};
-use simple_logger::SimpleLogger;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -184,10 +182,8 @@ enum Opts {
     HookReferenceTransaction { transaction_state: String },
 }
 
-fn main() -> anyhow::Result<()> {
-    SimpleLogger::new()
-        .init()
-        .with_context(|| "Initializing logging")?;
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
 
     let opts = Opts::from_args();
     let path_to_git = std::env::var_os("PATH_TO_GIT").unwrap_or_else(|| OsString::from("git"));
@@ -233,7 +229,7 @@ fn main() -> anyhow::Result<()> {
                 (false, false) => None,
                 (true, false) => Some(branchless::commands::navigation::Towards::Oldest),
                 (false, true) => Some(branchless::commands::navigation::Towards::Newest),
-                (true, true) => anyhow::bail!("Both --oldest and --newest were set"),
+                (true, true) => eyre::bail!("Both --oldest and --newest were set"),
             };
             branchless::commands::navigation::next(&git_run_info, num_commits, towards)?
         }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -199,7 +199,7 @@ impl Git {
             ("GIT_AUTHOR_DATE", &date),
             ("GIT_COMMITTER_DATE", &date),
             ("GIT_EDITOR", &git_editor),
-            ("PATH_TO_GIT", &self.path_to_git.as_os_str()),
+            ("PATH_TO_GIT", self.path_to_git.as_os_str()),
             ("PATH", &new_path),
         ];
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,4 +5,4 @@ mod output;
 
 pub use self::cursive::testing;
 pub use self::cursive::{with_siv, SingletonView};
-pub use output::Output;
+pub use output::{OperationType, Output};

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,8 @@
 //! Utilities to control output and render to the terminal.
 
 mod cursive;
+mod output;
 
 pub use self::cursive::testing;
 pub use self::cursive::{with_siv, SingletonView};
+pub use output::Output;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,6 @@
+//! Utilities to control output and render to the terminal.
+
+mod cursive;
+
+pub use self::cursive::testing;
+pub use self::cursive::{with_siv, SingletonView};

--- a/src/tui/cursive.rs
+++ b/src/tui/cursive.rs
@@ -3,7 +3,7 @@ use cursive::theme::{Color, PaletteColor};
 use cursive::{Cursive, CursiveRunnable, CursiveRunner};
 
 /// Create an instance of a `CursiveRunner`, and clean it up afterward.
-pub(crate) fn with_siv<T, F: FnOnce(CursiveRunner<CursiveRunnable>) -> eyre::Result<T>>(
+pub fn with_siv<T, F: FnOnce(CursiveRunner<CursiveRunnable>) -> eyre::Result<T>>(
     f: F,
 ) -> eyre::Result<T> {
     // I tried these back-ends:
@@ -43,14 +43,13 @@ pub trait SingletonView<V> {
     fn find(siv: &mut Cursive) -> cursive::views::ViewRef<V>;
 }
 
-/// Create a set of views with unique names. See also `new_view!` and
-/// `find_view!`.
+/// Create a set of views with unique names.
 ///
 /// ```
 /// # use cursive::Cursive;
 /// # use cursive::views::{EditView, TextView};
 /// # use branchless::declare_views;
-/// # use branchless::core::tui::SingletonView;
+/// # use branchless::tui::SingletonView;
 /// # fn main() {
 /// declare_views! {
 ///     SomeDisplayView => TextView,
@@ -69,7 +68,7 @@ macro_rules! declare_views {
                 view: cursive::views::NamedView<$v>,
             }
 
-            impl $crate::core::tui::SingletonView<$v> for $k {
+            impl $crate::tui::SingletonView<$v> for $k {
                 fn find(siv: &mut Cursive) -> cursive::views::ViewRef<$v> {
                     siv.find_name::<$v>(stringify!($k)).unwrap()
                 }

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -18,6 +18,7 @@ use crate::core::formatting::Glyphs;
 pub enum OperationType {
     BuildRebasePlan,
     CheckForCycles,
+    DetectDuplicateCommits,
     FindPathToMergeBase,
     GetMergeBase,
     GetUpstreamPatchIds,
@@ -30,9 +31,10 @@ impl ToString for OperationType {
         let s = match self {
             OperationType::BuildRebasePlan => "Building rebase plan",
             OperationType::CheckForCycles => "Checking for cycles",
+            OperationType::DetectDuplicateCommits => "Checking for duplicate commits",
             OperationType::FindPathToMergeBase => "Finding path to merge-base",
             OperationType::GetMergeBase => "Calculating merge-bases",
-            OperationType::GetUpstreamPatchIds => "Checking for duplicate commits",
+            OperationType::GetUpstreamPatchIds => "Computing patch IDs",
             OperationType::MakeGraph => "Examining local history",
             OperationType::WalkCommits => "Walking commits",
         };

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -1,0 +1,66 @@
+use std::cell::RefCell;
+use std::fmt::Write;
+use std::io::{stdout, Write as WriteIo};
+use std::rc::Rc;
+
+use crate::core::formatting::Glyphs;
+
+enum OutputDest {
+    Stdout,
+    Buffer(Rc<RefCell<Vec<u8>>>),
+}
+
+/// Wrapper around output. Also manages progress indicators.
+pub struct Output {
+    glyphs: Rc<Glyphs>,
+    dest: OutputDest,
+}
+
+impl std::fmt::Debug for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "<Output fancy={}>",
+            self.glyphs.should_write_ansi_escape_codes
+        )
+    }
+}
+
+impl Output {
+    /// Constructor. Writes to stdout.
+    pub fn new(glyphs: Glyphs) -> Self {
+        Output {
+            glyphs: Rc::new(glyphs),
+            dest: OutputDest::Stdout,
+        }
+    }
+
+    /// Constructor. Writes to the provided buffer. Panics on write if the
+    /// buffer is not mutably-borrowable at runtime.
+    pub fn new_from_buffer(glyphs: Glyphs, buffer: &Rc<RefCell<Vec<u8>>>) -> Self {
+        Output {
+            glyphs: Rc::new(glyphs),
+            dest: OutputDest::Buffer(Rc::clone(buffer)),
+        }
+    }
+
+    /// Get the set of glyphs associated with the output.
+    pub fn get_glyphs(&self) -> Rc<Glyphs> {
+        Rc::clone(&self.glyphs)
+    }
+}
+
+impl Write for Output {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        match &self.dest {
+            OutputDest::Stdout => {
+                print!("{}", s);
+                stdout().flush().unwrap();
+            }
+            OutputDest::Buffer(buffer) => {
+                write!(buffer.borrow_mut(), "{}", s).unwrap();
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -1,13 +1,101 @@
+use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fmt::Write;
 use std::io::{stderr, stdout, Write as WriteIo};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use lazy_static::lazy_static;
+use tracing::warn;
 
 use crate::core::formatting::Glyphs;
+
+#[allow(missing_docs)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OperationType {
+    BuildRebasePlan,
+    CheckForCycles,
+    FindPathToMergeBase,
+    GetMergeBase,
+    GetUpstreamPatchIds,
+    MakeGraph,
+    WalkCommits,
+}
+
+impl ToString for OperationType {
+    fn to_string(&self) -> String {
+        let s = match self {
+            OperationType::BuildRebasePlan => "Building rebase plan",
+            OperationType::CheckForCycles => "Checking for cycles",
+            OperationType::FindPathToMergeBase => "Finding path to merge-base",
+            OperationType::GetMergeBase => "Calculating merge-bases",
+            OperationType::GetUpstreamPatchIds => "Checking for duplicate commits",
+            OperationType::MakeGraph => "Examining local history",
+            OperationType::WalkCommits => "Walking commits",
+        };
+        s.to_string()
+    }
+}
 
 #[derive(Clone)]
 enum OutputDest {
     Stdout,
+    SuppressForTest,
     BufferForTest(Arc<Mutex<Vec<u8>>>),
+}
+
+struct OperationState {
+    operation_type: OperationType,
+    progress_bar: ProgressBar,
+    progress: Option<(usize, usize)>,
+    start_time: Option<Instant>,
+    elapsed_duration: Duration,
+}
+
+impl OperationState {
+    pub fn set_progress(&mut self, current: usize, total: usize) {
+        self.progress = Some((current, total));
+        self.progress_bar.set_position(current.try_into().unwrap());
+        self.progress_bar.set_length(total.try_into().unwrap());
+    }
+
+    pub fn tick(&self) {
+        lazy_static! {
+            static ref CHECKMARK: String = console::style("✓").green().to_string();
+            static ref IN_PROGRESS_SPINNER_STYLE: ProgressStyle =
+                ProgressStyle::default_spinner().template("{prefix}{spinner} {msg}");
+            static ref IN_PROGRESS_BAR_STYLE: ProgressStyle =
+                ProgressStyle::default_bar().template("{prefix}{spinner} {msg} {bar} {pos}/{len}");
+            static ref FINISHED_PROGRESS_STYLE: ProgressStyle = IN_PROGRESS_SPINNER_STYLE
+                .clone()
+                // Requires at least two tick values, so just pass the same one twice.
+                .tick_strings(&[&CHECKMARK, &CHECKMARK]);
+        }
+
+        let elapsed_duration = match self.start_time {
+            None => self.elapsed_duration,
+            Some(start_time) => {
+                let additional_duration = Instant::now().saturating_duration_since(start_time);
+                self.elapsed_duration + additional_duration
+            }
+        };
+
+        self.progress_bar.set_message(format!(
+            "{} ({:.1}s)",
+            self.operation_type.to_string(),
+            elapsed_duration.as_secs_f64(),
+        ));
+        self.progress_bar
+            .set_style(match (self.start_time, self.progress) {
+                (None, _) => FINISHED_PROGRESS_STYLE.clone(),
+                (Some(_), None) => IN_PROGRESS_SPINNER_STYLE.clone(),
+                (Some(_), Some(_)) => IN_PROGRESS_BAR_STYLE.clone(),
+            });
+        self.progress_bar.tick();
+    }
 }
 
 /// Wrapper around output. Also manages progress indicators.
@@ -15,6 +103,9 @@ enum OutputDest {
 pub struct Output {
     glyphs: Arc<Glyphs>,
     dest: OutputDest,
+    multi_progress: Arc<MultiProgress>,
+    nesting_level: Arc<AtomicUsize>,
+    operation_states: Arc<RwLock<HashMap<OperationType, OperationState>>>,
 }
 
 impl std::fmt::Debug for Output {
@@ -27,12 +118,51 @@ impl std::fmt::Debug for Output {
     }
 }
 
+fn spawn_progress_updater_thread(
+    operation_states: &Arc<RwLock<HashMap<OperationType, OperationState>>>,
+) {
+    let operation_states = Arc::downgrade(operation_states);
+    thread::spawn(move || {
+        loop {
+            // Drop the `Arc` after this block, before the sleep, to make sure
+            // that progress bars aren't kept alive longer than they should be.
+            match operation_states.upgrade() {
+                None => return,
+                Some(operation_states) => {
+                    let operation_states = operation_states.read().unwrap();
+                    for operation_state in operation_states.values() {
+                        operation_state.tick();
+                    }
+                }
+            }
+
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+}
+
 impl Output {
     /// Constructor. Writes to stdout.
     pub fn new(glyphs: Glyphs) -> Self {
+        let operation_states = Default::default();
+        spawn_progress_updater_thread(&operation_states);
         Output {
             glyphs: Arc::new(glyphs),
             dest: OutputDest::Stdout,
+            multi_progress: Default::default(),
+            nesting_level: Default::default(),
+            operation_states,
+        }
+    }
+
+    /// Constructor. Suppresses all output.
+    pub fn new_suppress_for_test(glyphs: Glyphs) -> Self {
+        Output {
+            glyphs: Arc::new(glyphs),
+            dest: OutputDest::SuppressForTest,
+            multi_progress: Default::default(),
+            nesting_level: Default::default(),
+            operation_states: Default::default(),
         }
     }
 
@@ -41,6 +171,101 @@ impl Output {
         Output {
             glyphs: Arc::new(glyphs),
             dest: OutputDest::BufferForTest(Arc::clone(buffer)),
+            multi_progress: Default::default(),
+            nesting_level: Default::default(),
+            operation_states: Default::default(),
+        }
+    }
+
+    /// Start reporting progress for the specified operation type.
+    ///
+    /// A progress spinner is shown until the returned `ProgressHandle` is
+    /// dropped, at which point the spinner transitions to a "complete" message.
+    ///
+    /// Progress spinners are nested hierarchically. If this function is called
+    /// while another `ProgressHandle` is still alive, then the returned
+    /// `ProgressHandle` will be a child of the first handle.
+    ///
+    /// None of the progress indicators are cleared from the screen until *all*
+    /// of the operations have completed. Furthermore, their internal timer is
+    /// not reset while they are still on the screen.
+    ///
+    /// If you finish and then start the same operation type again while it is
+    /// still displayed, then it will transition back into the "progress" state,
+    /// and its displayed duration will start increasing from its previous
+    /// value, rather than from zero. The practical implication is that you can
+    /// see the aggregate time it took to carry out sibling operations, i.e. the
+    /// same operation called multiple times in a loop.
+    pub fn start_operation(&self, operation_type: OperationType) -> ProgressHandle {
+        let now = Instant::now();
+        let mut operation_states = self.operation_states.write().unwrap();
+        let nesting_level = self.nesting_level.fetch_add(1, Ordering::SeqCst);
+
+        let mut operation_state = operation_states.entry(operation_type).or_insert_with(|| {
+            let progress_bar = self.multi_progress.add(ProgressBar::new_spinner());
+            progress_bar.set_prefix("  ".repeat(nesting_level));
+            let operation_state = OperationState {
+                operation_type,
+                progress_bar,
+                start_time: Some(now),
+                progress: Default::default(),
+                elapsed_duration: Default::default(),
+            };
+            operation_state.tick();
+            operation_state
+        });
+        let new_start_time = match operation_state.start_time {
+            Some(start_time) => start_time,
+            None => now,
+        };
+        operation_state.start_time = Some(new_start_time);
+
+        ProgressHandle {
+            output: self,
+            operation_type,
+        }
+    }
+
+    fn on_notify_progress(&self, operation_type: OperationType, current: usize, total: usize) {
+        let mut operation_states = self.operation_states.write().unwrap();
+        let operation_state = match operation_states.get_mut(&operation_type) {
+            Some(operation_state) => operation_state,
+            None => return,
+        };
+
+        operation_state.set_progress(current, total);
+        operation_state.tick();
+    }
+
+    fn on_drop_progress_handle(&self, operation_type: OperationType) {
+        let now = Instant::now();
+        let mut operation_states = self.operation_states.write().unwrap();
+        self.nesting_level.fetch_sub(1, Ordering::SeqCst);
+
+        let operation_state = match operation_states.get_mut(&operation_type) {
+            Some(operation_state) => operation_state,
+            None => {
+                warn!("Progress operation not started");
+                return;
+            }
+        };
+        let start_time = match operation_state.start_time.take() {
+            Some(start_time) => start_time,
+            None => {
+                warn!("Progress operation ended without matching start call");
+                return;
+            }
+        };
+        let duration = now.saturating_duration_since(start_time);
+        operation_state.elapsed_duration += duration;
+
+        // Reset all elapsed times only if the root-level operation completed.
+        if operation_states
+            .values()
+            .all(|operation_state| operation_state.start_time.is_none())
+        {
+            self.multi_progress.clear().unwrap();
+            operation_states.clear();
         }
     }
 
@@ -63,6 +288,11 @@ impl Write for Output {
                 print!("{}", s);
                 stdout().flush().unwrap();
             }
+
+            OutputDest::SuppressForTest => {
+                // Do nothing.
+            }
+
             OutputDest::BufferForTest(buffer) => {
                 let mut buffer = buffer.lock().unwrap();
                 write!(buffer, "{}", s).unwrap();
@@ -83,10 +313,34 @@ impl Write for ErrorOutput {
                 eprint!("{}", s);
                 stderr().flush().unwrap();
             }
+
+            OutputDest::SuppressForTest => {
+                // Do nothing.
+            }
+
             OutputDest::BufferForTest(_) => {
                 // Drop the error output, as the buffer only represents `stdout`.
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ProgressHandle<'output> {
+    output: &'output Output,
+    operation_type: OperationType,
+}
+
+impl Drop for ProgressHandle<'_> {
+    fn drop(&mut self) {
+        self.output.on_drop_progress_handle(self.operation_type)
+    }
+}
+
+impl ProgressHandle<'_> {
+    pub fn notify_progress(&self, current: usize, total: usize) {
+        self.output
+            .on_notify_progress(self.operation_type, current, total);
     }
 }

--- a/tests/command/test_hide.rs
+++ b/tests/command/test_hide.rs
@@ -1,7 +1,7 @@
 use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
-fn test_hide_commit() -> anyhow::Result<()> {
+fn test_hide_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -43,7 +43,7 @@ fn test_hide_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hide_bad_commit() -> anyhow::Result<()> {
+fn test_hide_bad_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -63,7 +63,7 @@ fn test_hide_bad_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hide_already_hidden_commit() -> anyhow::Result<()> {
+fn test_hide_already_hidden_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -84,7 +84,7 @@ fn test_hide_already_hidden_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hide_current_commit() -> anyhow::Result<()> {
+fn test_hide_current_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -105,7 +105,7 @@ fn test_hide_current_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hidden_commit_with_head_as_child() -> anyhow::Result<()> {
+fn test_hidden_commit_with_head_as_child() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -133,7 +133,7 @@ fn test_hidden_commit_with_head_as_child() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hide_master_commit_with_hidden_children() -> anyhow::Result<()> {
+fn test_hide_master_commit_with_hidden_children() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -158,7 +158,7 @@ fn test_hide_master_commit_with_hidden_children() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_branches_always_visible() -> anyhow::Result<()> {
+fn test_branches_always_visible() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -191,7 +191,7 @@ fn test_branches_always_visible() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_unhide() -> anyhow::Result<()> {
+fn test_unhide() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -242,7 +242,7 @@ fn test_unhide() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_hide_recursive() -> anyhow::Result<()> {
+fn test_hide_recursive() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -1,11 +1,11 @@
 use crate::util::trim_lines;
 
-use anyhow::Context;
 use branchless::git::GitVersion;
 use branchless::testing::{make_git, GitInitOptions, GitRunOptions};
+use eyre::Context;
 
 #[test]
-fn test_hook_installed() -> anyhow::Result<()> {
+fn test_hook_installed() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -16,7 +16,7 @@ fn test_hook_installed() -> anyhow::Result<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         let metadata = std::fs::metadata(&hook_path)
-            .with_context(|| format!("Reading hook permissions for {:?}", &hook_path))?;
+            .wrap_err_with(|| format!("Reading hook permissions for {:?}", &hook_path))?;
         let mode = metadata.permissions().mode();
         assert!(mode & 0o111 == 0o111);
     }
@@ -25,7 +25,7 @@ fn test_hook_installed() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_alias_installed() -> anyhow::Result<()> {
+fn test_alias_installed() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -48,7 +48,7 @@ fn test_alias_installed() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_old_git_version_warning() -> anyhow::Result<()> {
+fn test_old_git_version_warning() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -96,7 +96,7 @@ fn test_old_git_version_warning() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_init_basic() -> anyhow::Result<()> {
+fn test_init_basic() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -138,7 +138,7 @@ fn test_init_basic() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_init_prompt_for_main_branch() -> anyhow::Result<()> {
+fn test_init_prompt_for_main_branch() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -197,7 +197,7 @@ fn test_init_prompt_for_main_branch() -> anyhow::Result<()> {
 
 #[cfg(unix)]
 #[test]
-fn test_main_branch_not_found_error_message() -> anyhow::Result<()> {
+fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -214,6 +214,12 @@ fn test_main_branch_not_found_error_message() -> anyhow::Result<()> {
         )?;
         insta::assert_snapshot!(trim_lines(stderr), @r###"
         Error:
+           0: [91mCould not find repository main branch[0m
+
+        Location:
+           [35msrc/git/repo.rs[0m:[35m263[0m
+
+        [96mSuggestion[0m:
         The main branch "master" could not be found in your repository
         at path: "<repo-path>/.git/".
         These branches exist: []
@@ -221,6 +227,10 @@ fn test_main_branch_not_found_error_message() -> anyhow::Result<()> {
 
             git config branchless.core.mainBranch <branch>
 
+
+        Backtrace omitted.
+        Run with RUST_BACKTRACE=1 environment variable to display it.
+        Run with RUST_BACKTRACE=full to include source snippets.
         "###);
         insta::assert_snapshot!(stdout, @"");
     }
@@ -229,7 +239,7 @@ fn test_main_branch_not_found_error_message() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_init_uninstall() -> anyhow::Result<()> {
+fn test_init_uninstall() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -219,11 +219,6 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
         Location:
            [35msrc/git/repo.rs[0m:[35m263[0m
 
-          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-           0: [91mbranchless::commands::smartlog[0m[91m::[0m[91msmartlog[0m
-              at [35msrc/commands/smartlog.rs[0m:[35m266[0m
-
         [96mSuggestion[0m:
         The main branch "master" could not be found in your repository
         at path: "<repo-path>/.git/".

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -217,7 +217,7 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
            0: [91mCould not find repository main branch[0m
 
         Location:
-           [35msrc/git/repo.rs[0m:[35m263[0m
+           [35msrc/git/repo.rs[0m:[35m264[0m
 
         [96mSuggestion[0m:
         The main branch "master" could not be found in your repository

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -219,6 +219,11 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
         Location:
            [35msrc/git/repo.rs[0m:[35m263[0m
 
+          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+           0: [91mbranchless::commands::smartlog[0m[91m::[0m[91msmartlog[0m
+              at [35msrc/commands/smartlog.rs[0m:[35m266[0m
+
         [96mSuggestion[0m:
         The main branch "master" could not be found in your repository
         at path: "<repo-path>/.git/".

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -1,7 +1,7 @@
 use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
-fn test_move_stick_on_disk() -> anyhow::Result<()> {
+fn test_move_stick_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -39,7 +39,7 @@ fn test_move_stick_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_stick_in_memory() -> anyhow::Result<()> {
+fn test_move_stick_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -124,7 +124,7 @@ fn test_move_stick_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_tree_on_disk() -> anyhow::Result<()> {
+fn test_move_tree_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -166,7 +166,7 @@ fn test_move_tree_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_tree_in_memory() -> anyhow::Result<()> {
+fn test_move_tree_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -208,7 +208,7 @@ fn test_move_tree_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_with_source_not_in_smartlog_on_disk() -> anyhow::Result<()> {
+fn test_move_with_source_not_in_smartlog_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -243,7 +243,7 @@ fn test_move_with_source_not_in_smartlog_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
+fn test_move_with_source_not_in_smartlog_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -326,7 +326,7 @@ fn test_move_with_source_not_in_smartlog_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_merge_conflict() -> anyhow::Result<()> {
+fn test_move_merge_conflict() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -411,7 +411,7 @@ fn test_move_merge_conflict() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_base() -> anyhow::Result<()> {
+fn test_move_base() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -492,7 +492,7 @@ fn test_move_base() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_base_shared() -> anyhow::Result<()> {
+fn test_move_base_shared() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -546,7 +546,7 @@ fn test_move_base_shared() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_checkout_new_head() -> anyhow::Result<()> {
+fn test_move_checkout_new_head() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -606,7 +606,7 @@ fn test_move_checkout_new_head() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_branch() -> anyhow::Result<()> {
+fn test_move_branch() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -678,7 +678,7 @@ fn test_move_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_base_onto_head() -> anyhow::Result<()> {
+fn test_move_base_onto_head() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -726,7 +726,7 @@ fn test_move_base_onto_head() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_force_in_memory() -> anyhow::Result<()> {
+fn test_move_force_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -760,7 +760,7 @@ fn test_move_force_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_rebase_in_memory_updates_committer_timestamp() -> anyhow::Result<()> {
+fn test_rebase_in_memory_updates_committer_timestamp() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -800,7 +800,7 @@ fn test_rebase_in_memory_updates_committer_timestamp() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_in_memory_gc() -> anyhow::Result<()> {
+fn test_move_in_memory_gc() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -896,7 +896,7 @@ fn test_move_in_memory_gc() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_main_branch_commits() -> anyhow::Result<()> {
+fn test_move_main_branch_commits() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -983,7 +983,7 @@ fn test_move_main_branch_commits() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_branches_after_move_on_disk() -> anyhow::Result<()> {
+fn test_move_branches_after_move_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1078,7 +1078,7 @@ fn test_move_branches_after_move_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_no_reapply_upstream_commits_in_memory() -> anyhow::Result<()> {
+fn test_move_no_reapply_upstream_commits_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1129,7 +1129,7 @@ fn test_move_no_reapply_upstream_commits_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_no_reapply_squashed_commits_in_memory() -> anyhow::Result<()> {
+fn test_move_no_reapply_squashed_commits_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1196,7 +1196,7 @@ fn test_move_no_reapply_squashed_commits_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_no_reapply_upstream_commits_on_disk() -> anyhow::Result<()> {
+fn test_move_no_reapply_upstream_commits_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1253,7 +1253,7 @@ fn test_move_no_reapply_upstream_commits_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_no_reapply_squashed_commits_on_disk() -> anyhow::Result<()> {
+fn test_move_no_reapply_squashed_commits_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1331,7 +1331,7 @@ fn test_move_no_reapply_squashed_commits_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_delete_checked_out_branch_in_memory() -> anyhow::Result<()> {
+fn test_move_delete_checked_out_branch_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1403,7 +1403,7 @@ fn test_move_delete_checked_out_branch_in_memory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_delete_checked_out_branch_on_disk() -> anyhow::Result<()> {
+fn test_move_delete_checked_out_branch_on_disk() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -1483,7 +1483,7 @@ fn test_move_delete_checked_out_branch_on_disk() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_on_disk_with_unstaged_changes() -> anyhow::Result<()> {
+fn test_move_on_disk_with_unstaged_changes() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -784,16 +784,6 @@ fn test_rebase_in_memory_updates_committer_timestamp() -> eyre::Result<()> {
         .get_committer()
         .get_time();
 
-    println!(
-        "original_committer_timestamp: {:?} {:?}",
-        original_committer_timestamp.seconds(),
-        original_committer_timestamp.offset_minutes()
-    );
-    println!(
-        "updated_committer_timestamp: {:?} {:?}",
-        updated_committer_timestamp.seconds(),
-        updated_committer_timestamp.offset_minutes()
-    );
     assert!(original_committer_timestamp < updated_committer_timestamp);
 
     Ok(())

--- a/tests/command/test_navigation.rs
+++ b/tests/command/test_navigation.rs
@@ -1,7 +1,7 @@
 use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
-fn test_prev() -> anyhow::Result<()> {
+fn test_prev() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -35,7 +35,7 @@ fn test_prev() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_prev_multiple() -> anyhow::Result<()> {
+fn test_prev_multiple() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -56,7 +56,7 @@ fn test_prev_multiple() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_next_multiple() -> anyhow::Result<()> {
+fn test_next_multiple() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -81,7 +81,7 @@ fn test_next_multiple() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_next_ambiguous() -> anyhow::Result<()> {
+fn test_next_ambiguous() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -145,7 +145,7 @@ fn test_next_ambiguous() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_next_on_master() -> anyhow::Result<()> {
+fn test_next_on_master() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -170,7 +170,7 @@ fn test_next_on_master() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_next_on_master2() -> anyhow::Result<()> {
+fn test_next_on_master2() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -11,7 +11,7 @@ fn remove_rebase_lines(output: String) -> String {
 }
 
 #[test]
-fn test_restack_amended_commit() -> anyhow::Result<()> {
+fn test_restack_amended_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_committer_date_is_author_date()? {
@@ -67,7 +67,7 @@ fn test_restack_amended_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_restack_consecutive_rewrites() -> anyhow::Result<()> {
+fn test_restack_consecutive_rewrites() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_committer_date_is_author_date()? {
@@ -110,7 +110,7 @@ fn test_restack_consecutive_rewrites() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_move_abandoned_branch() -> anyhow::Result<()> {
+fn test_move_abandoned_branch() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -138,7 +138,7 @@ fn test_move_abandoned_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_amended_initial_commit() -> anyhow::Result<()> {
+fn test_amended_initial_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_committer_date_is_author_date()? {
@@ -183,7 +183,7 @@ fn test_amended_initial_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_restack_amended_master() -> anyhow::Result<()> {
+fn test_restack_amended_master() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_committer_date_is_author_date()? {
@@ -220,7 +220,7 @@ fn test_restack_amended_master() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_restack_aborts_during_rebase_conflict() -> anyhow::Result<()> {
+fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -244,7 +244,7 @@ fn test_restack_aborts_during_rebase_conflict() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_restack_multiple_amended() -> anyhow::Result<()> {
+fn test_restack_multiple_amended() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -285,7 +285,7 @@ fn test_restack_multiple_amended() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_restack_single_of_many_commits() -> anyhow::Result<()> {
+fn test_restack_single_of_many_commits() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {

--- a/tests/command/test_smartlog.rs
+++ b/tests/command/test_smartlog.rs
@@ -2,7 +2,7 @@ use branchless::git::GitRunInfo;
 use branchless::testing::{get_path_to_git, make_git, Git, GitInitOptions, GitRunOptions};
 
 #[test]
-fn test_init_smartlog() -> anyhow::Result<()> {
+fn test_init_smartlog() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -17,7 +17,7 @@ fn test_init_smartlog() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_show_reachable_commit() -> anyhow::Result<()> {
+fn test_show_reachable_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -37,7 +37,7 @@ fn test_show_reachable_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_tree() -> anyhow::Result<()> {
+fn test_tree() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -62,7 +62,7 @@ fn test_tree() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_rebase() -> anyhow::Result<()> {
+fn test_rebase() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -88,7 +88,7 @@ fn test_rebase() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_sequential_master_commits() -> anyhow::Result<()> {
+fn test_sequential_master_commits() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -108,7 +108,7 @@ fn test_sequential_master_commits() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_merge_commit() -> anyhow::Result<()> {
+fn test_merge_commit() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -147,7 +147,7 @@ fn test_merge_commit() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_rebase_conflict() -> anyhow::Result<()> {
+fn test_rebase_conflict() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -182,7 +182,7 @@ fn test_rebase_conflict() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_non_adjacent_commits() -> anyhow::Result<()> {
+fn test_non_adjacent_commits() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -211,7 +211,7 @@ fn test_non_adjacent_commits() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_non_adjacent_commits2() -> anyhow::Result<()> {
+fn test_non_adjacent_commits2() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -243,7 +243,7 @@ fn test_non_adjacent_commits2() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_non_adjacent_commits3() -> anyhow::Result<()> {
+fn test_non_adjacent_commits3() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -278,7 +278,7 @@ fn test_non_adjacent_commits3() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_custom_main_branch() -> anyhow::Result<()> {
+fn test_custom_main_branch() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -302,7 +302,7 @@ fn test_custom_main_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_main_remote_branch() -> anyhow::Result<()> {
+fn test_main_remote_branch() -> eyre::Result<()> {
     let path_to_git = get_path_to_git()?;
     let temp_dir = tempfile::tempdir()?;
     let git_run_info = GitRunInfo {
@@ -364,7 +364,7 @@ fn test_main_remote_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_show_rewritten_commit_hash() -> anyhow::Result<()> {
+fn test_show_rewritten_commit_hash() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/command/test_undo.rs
+++ b/tests/command/test_undo.rs
@@ -7,11 +7,9 @@ use branchless::commands::undo::testing::{select_past_event, undo_events};
 use branchless::core::eventlog::{EventCursor, EventLogDb, EventReplayer};
 use branchless::core::formatting::Glyphs;
 use branchless::core::mergebase::MergeBaseDb;
-use branchless::core::tui::testing::{
-    screen_to_string, CursiveTestingBackend, CursiveTestingEvent,
-};
 use branchless::git::{GitRunInfo, Repo};
 use branchless::testing::{make_git, Git};
+use branchless::tui::testing::{screen_to_string, CursiveTestingBackend, CursiveTestingEvent};
 
 use cursive::event::Key;
 use cursive::CursiveRunnable;

--- a/tests/command/test_undo.rs
+++ b/tests/command/test_undo.rs
@@ -23,6 +23,7 @@ fn run_select_past_event(
     events: Vec<CursiveTestingEvent>,
 ) -> eyre::Result<Option<EventCursor>> {
     let glyphs = Glyphs::text();
+    let output = Output::new_suppress_for_test(glyphs);
     let conn = repo.get_db_conn()?;
     let merge_base_db = MergeBaseDb::new(&conn)?;
     let event_log_db: EventLogDb = EventLogDb::new(&conn)?;
@@ -32,7 +33,7 @@ fn run_select_past_event(
     });
     select_past_event(
         siv.into_runner(),
-        &glyphs,
+        &output,
         repo,
         &merge_base_db,
         &mut event_replayer,

--- a/tests/command/test_undo.rs
+++ b/tests/command/test_undo.rs
@@ -20,7 +20,7 @@ use os_str_bytes::OsStrBytes;
 fn run_select_past_event(
     repo: &Repo,
     events: Vec<CursiveTestingEvent>,
-) -> anyhow::Result<Option<EventCursor>> {
+) -> eyre::Result<Option<EventCursor>> {
     let glyphs = Glyphs::text();
     let conn = repo.get_db_conn()?;
     let merge_base_db = MergeBaseDb::new(&conn)?;
@@ -38,7 +38,7 @@ fn run_select_past_event(
     )
 }
 
-fn run_undo_events(git: &Git, event_cursor: EventCursor) -> anyhow::Result<String> {
+fn run_undo_events(git: &Git, event_cursor: EventCursor) -> eyre::Result<String> {
     let glyphs = Glyphs::text();
     let repo = git.get_repo()?;
     let conn = repo.get_db_conn()?;
@@ -86,7 +86,7 @@ fn run_undo_events(git: &Git, event_cursor: EventCursor) -> anyhow::Result<Strin
 }
 
 #[test]
-fn test_undo_help() -> anyhow::Result<()> {
+fn test_undo_help() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -122,7 +122,7 @@ fn test_undo_help() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_undo_navigate() -> anyhow::Result<()> {
+fn test_undo_navigate() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -174,7 +174,7 @@ fn test_undo_navigate() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_go_to_event() -> anyhow::Result<()> {
+fn test_go_to_event() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -219,7 +219,7 @@ fn test_go_to_event() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_undo_hide() -> anyhow::Result<()> {
+fn test_undo_hide() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -289,7 +289,7 @@ fn test_undo_hide() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_undo_move_refs() -> anyhow::Result<()> {
+fn test_undo_move_refs() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -344,7 +344,7 @@ fn test_undo_move_refs() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_historical_smartlog_visibility() -> anyhow::Result<()> {
+fn test_historical_smartlog_visibility() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -395,7 +395,7 @@ fn test_historical_smartlog_visibility() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_undo_doesnt_make_working_dir_dirty() -> anyhow::Result<()> {
+fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {

--- a/tests/command/test_wrap.rs
+++ b/tests/command/test_wrap.rs
@@ -3,7 +3,7 @@ use branchless::core::eventlog::{Event, EventLogDb, EventReplayer};
 use branchless::testing::{make_git, GitRunOptions};
 
 #[test]
-fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
+fn test_wrap_rebase_in_transaction() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {
@@ -154,7 +154,7 @@ fn test_wrap_rebase_in_transaction() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_wrap_explicit_git_executable() -> anyhow::Result<()> {
+fn test_wrap_explicit_git_executable() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
@@ -177,7 +177,7 @@ fn test_wrap_explicit_git_executable() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_wrap_without_repo() -> anyhow::Result<()> {
+fn test_wrap_without_repo() -> eyre::Result<()> {
     let git = make_git()?;
 
     let (stdout, stderr) = git.run_with_options(
@@ -195,7 +195,7 @@ fn test_wrap_without_repo() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_wrap_exit_code() -> anyhow::Result<()> {
+fn test_wrap_exit_code() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.run_with_options(

--- a/tests/core/test_eventlog.rs
+++ b/tests/core/test_eventlog.rs
@@ -3,7 +3,7 @@ use branchless::core::eventlog::{Event, EventLogDb, EventReplayer};
 use branchless::testing::make_git;
 
 #[test]
-fn test_git_v2_31_events() -> anyhow::Result<()> {
+fn test_git_v2_31_events() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_reference_transactions()? {

--- a/tests/core/test_gc.rs
+++ b/tests/core/test_gc.rs
@@ -1,7 +1,7 @@
 use branchless::testing::make_git;
 
 #[test]
-fn test_gc() -> anyhow::Result<()> {
+fn test_gc() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;

--- a/tests/test_branchless.rs
+++ b/tests/test_branchless.rs
@@ -1,7 +1,7 @@
 use branchless::testing::make_git;
 
 #[test]
-fn test_commands() -> anyhow::Result<()> {
+fn test_commands() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;


### PR DESCRIPTION
- cleanup(build): remove unused dependencies
- refactor: switch from `log` to `tracing`
- refactor: replace `fn_error_context::context` with `tracing::instrument`
- refactor: use `eyre` instead of `anyhow`
- refactor: use `color-eyre` to print out backtraces with parameter values
- refactor(tracing): make usable to see where the program is spending time
- refactor(tui): create submodules for `tui`
- refactor(graph): wrap `CommitGraph` type
- refactor(tui): create `output` module
- testing(init): remove code location from snapshot
- tui: write subprocess output to `Output`
- tui: create nested progress meter system
