### PR TITLE
fix(undo): report unsupported use-case for empty events

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,9 @@ jobs:
         id: cache-git-build
         with:
           key: ${{ runner.os }}-git-${{ matrix.git-version }}
-          path: git
+          path: |
+            git
+            git-*
       - name: Build Git ${{ matrix.git-version }}
         if: steps.cache-git-build.outputs.cache-hit != 'true'
         run: |
@@ -31,7 +33,7 @@ jobs:
           sudo apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev
           make
       - name: Package Git
-        run: tar -czf git.tar.gz git
+        run: tar -czf git.tar.gz git git-*
       - name: "Upload artifact: git"
         uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed: `git restack` warns if a sub-command fails (e.g. if `git rebase` fails with merge conflicts that need to be resolved).
+- Fixed (#57): `git undo` shows an informative link when dealing with empty events, rather than warning about a bug.
 
 ## [0.3.4] - 2021-08-12
 

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -70,6 +70,10 @@ fn render_cursor_smartlog(
 }
 
 fn describe_event(repo: &Repo, event: &Event) -> eyre::Result<Vec<StyledString>> {
+    // Links to https://github.com/arxanas/git-branchless/issues/57
+    const EMPTY_EVENT_MESSAGE: &str =
+        "This may be an unsupported use-case; see https://git.io/J0b7z";
+
     let result = match event {
         Event::CommitEvent {
             timestamp: _,
@@ -177,9 +181,7 @@ fn describe_event(repo: &Repo, event: &Event) -> eyre::Result<Vec<StyledString>>
                     .append_plain(CategorizedReferenceName::new(ref_name).render_full())
                     .build(),
                 StyledStringBuilder::new()
-                    .append_plain("This event should not appear. ")
-                    .append_plain("This is a (benign) bug -- ")
-                    .append_plain("please report it.")
+                    .append_plain(EMPTY_EVENT_MESSAGE)
                     .build(),
             ]
         }
@@ -276,9 +278,7 @@ fn describe_event(repo: &Repo, event: &Event) -> eyre::Result<Vec<StyledString>>
                     .append_plain("Empty rewrite event.")
                     .build(),
                 StyledStringBuilder::new()
-                    .append_plain("This event should not appear. ")
-                    .append_plain("This is a (benign) bug -- ")
-                    .append_plain("please report it.")
+                    .append_plain(EMPTY_EVENT_MESSAGE)
                     .build(),
             ]
         }


### PR DESCRIPTION
Closes #57. Some operations, such as bisecting and stashing, use references in an unconventional way. These are reported as if there is no change to the content of the reference, which might happen e.g. if instead the reflog for that reference was changed, or if it was touched but left unchanged.

These uses for references don't really affect the commit graph. Ideally, we would handle them entirely differently. They should have an entirely separate history, and it should be possible to rewind them separately from the commit graph's history. For example, you should be able to unmark a certain commit during a bisect operation without affecting any commits you may have made since starting the bisect.

The UI for this would need to be considered thoughtfully. Since this isn't too common of a use-case for now, I'm updating this message to just warn that it may be an unsupported use-case, and deferring it the alternative UI for later.
