### PR TITLE
macos fix build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - "*macos*"
 
 jobs:
   run-tests:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,4 +22,5 @@ jobs:
         run: |
           export RUST_BACKTRACE=1
           export PATH_TO_GIT=$(which git)
+          export GIT_EXEC_PATH=$(git --exec-path)
           cargo test

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -136,11 +136,16 @@ impl Git {
     }
 
     fn get_git_exec_path(&self) -> PathBuf {
-        let git_path = self
-            .path_to_git
-            .parent()
-            .expect("Unable to find git path parent");
-        git_path.to_path_buf()
+        match std::env::var_os("GIT_EXEC_PATH") {
+            Some(git_exec_path) => git_exec_path.into(),
+            None => {
+                let git_path = self
+                    .path_to_git
+                    .parent()
+                    .expect("Unable to find git path parent");
+                git_path.to_path_buf()
+            }
+        }
     }
 
     /// Get the `PATH` environment variable to use for testing.


### PR DESCRIPTION
- tests: inherit GIT_EXEC_PATH in testing if set
- ci: run macOS build on branches with `macos` in name
