### PR TITLE
feat(tui): add flag to allow overriding glyphs detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `git branchless init` takes a `--main-branch` option to specify the name of the main branch without interactive prompting.
+- The `--color=[auto,always,never]` flag can be used to override the automatically detected value for terminal colors.
+- The `CLICOLOR` and `NOCOLOR` environment variables are now respected.
 
 ### Changed
 
@@ -34,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Output of subcommands is no longer overwritten by progress updates.
-- Improved performance up to 100x for commit deduplication during  `git move` when rebasing past certain large commits.
+- Improved performance up to 100x for commit deduplication during `git move` when rebasing past certain large commits.
 - Improved performance up to 10x for smartlog rendering.
 
 ## [0.3.5] - 2021-09-11
@@ -101,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The version number in `git-branchless --help` was fixed at `0.2.0`. It now reflects the version of the package.
--  `git branchless wrap` no longer fails to run if there is no Git repository in the current directory.
+- `git branchless wrap` no longer fails to run if there is no Git repository in the current directory.
 - User hooks which are invoked by `git-branchless` are now invoked in the correct working directory.
 
 ## [0.3.2] - 2021-06-23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "concolor-control"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7104119c2f80d887239879d0c50e033cd40eac9a3f3561e0684ba7d5d654f4da"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad159cc964ac8f9d407cbc0aa44b02436c054b541f2b4b5f06972e1efdc54bc7"
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +800,7 @@ dependencies = [
  "clap 3.0.0-beta.5",
  "clippy",
  "color-eyre",
+ "concolor-control",
  "console",
  "criterion",
  "cursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ assert_cmd = "2.0.0"
 chashmap = "2.2.2"
 clap = "=3.0.0-beta.5"
 color-eyre = "0.5.11"
+concolor-control = { version = "0.0.7", features = ["auto"] }
 console = "0.14.1"
 cursive = { version = "0.17.0-alpha.0", default-features = false, features = [
   "crossterm-backend",

--- a/src/core/formatting.rs
+++ b/src/core/formatting.rs
@@ -107,7 +107,8 @@ pub struct Glyphs {
 impl Glyphs {
     /// Make the `Glyphs` object appropriate for `stdout`.
     pub fn detect() -> Self {
-        if console::user_attended() {
+        let color_support = concolor_control::get(concolor_control::Stream::Stdout);
+        if color_support.color() {
             Glyphs::pretty()
         } else {
             Glyphs::text()
@@ -336,7 +337,7 @@ fn render_style_as_ansi(content: &str, style: Style) -> eyre::Result<String> {
     Ok(output.to_string())
 }
 
-/// Write the provided string to `out`, using ANSI escape codfes as necessary to
+/// Write the provided string to `out`, using ANSI escape codes as necessary to
 /// style it.
 ///
 /// TODO: return something that implements `Display` instead of a `String`.

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,6 @@
 //! The command-line options for `git-branchless`.
 
-use clap::{App, IntoApp, Parser};
+use clap::{App, ArgEnum, IntoApp, Parser};
 use man::Arg;
 use std::path::{Path, PathBuf};
 
@@ -227,6 +227,18 @@ pub enum Command {
     },
 }
 
+/// Whether to display terminal colors.
+#[derive(ArgEnum, Clone)]
+pub enum ColorSetting {
+    /// Automatically determine whether to display colors from the terminal and environment variables.
+    /// This is the default behavior.
+    Auto,
+    /// Always display terminal colors.
+    Always,
+    /// Never display terminal colors.
+    Never,
+}
+
 /// Branchless workflow for Git.
 ///
 /// See the documentation at https://github.com/arxanas/git-branchless/wiki.
@@ -237,6 +249,10 @@ pub struct Opts {
     /// (The option is called `-C` for symmetry with Git.)
     #[clap(short = 'C')]
     pub working_directory: Option<PathBuf>,
+
+    /// Flag to force enable or disable terminal colors.
+    #[clap(long = "color", arg_enum)]
+    pub color: Option<ColorSetting>,
 
     /// The `git-branchless` subcommand to run.
     #[clap(subcommand)]


### PR DESCRIPTION
Adds a --glyphs flag to override the default detected glyphs setting.

This is useful when a user wants to force "pretty" glyphs to be printed, even if the terminal doesn't present itself as a TTY interface. (For example, when running with 'watch').

This fixes #130.

Example: `git-branchless --glyphs=pretty smartlog`