### PR TITLE
feat(init): use git's init.defaultBranch in main branch detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: If your local main branch has an upstream branch, then that upstream branch will be treated as the repository's main branch, and your local main will be treated as a branch like any other. This should make workflows which commit to the main branch more ergonomic.
 - BREAKING: `git move` and `git restack` will no longer perform merge conflict resolution unless the `--merge` option was passed.
+- `git branchless init` will use `init.defaultBranch` when detecting the name of the main branch, if one is not provided by `--main-branch`.
 
 ### Fixed
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,7 +9,7 @@ use eyre::Context;
 use path_slash::PathExt;
 use tracing::{instrument, warn};
 
-use crate::core::config::get_core_hooks_path;
+use crate::core::config::{get_core_hooks_path, get_default_branch_name};
 use crate::git::{Config, ConfigRead, ConfigWrite, GitRunInfo, GitVersion, Repo};
 use crate::opts::write_man_pages;
 use crate::tui::Effects;
@@ -246,6 +246,15 @@ fn install_alias(repo: &Repo, config: &mut Config, from: &str, to: &str) -> eyre
 
 #[instrument]
 fn detect_main_branch_name(repo: &Repo) -> eyre::Result<Option<String>> {
+    if let Some(default_branch_name) = get_default_branch_name(repo)? {
+        if repo
+            .find_branch(&default_branch_name, git2::BranchType::Local)?
+            .is_some()
+        {
+            return Ok(Some(default_branch_name));
+        }
+    }
+
     for branch_name in [
         "master",
         "main",

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -26,6 +26,13 @@ pub fn get_main_branch_name(repo: &Repo) -> eyre::Result<String> {
     Ok(main_branch_name)
 }
 
+/// Get the default init branch name.
+pub fn get_default_branch_name(repo: &Repo) -> eyre::Result<Option<String>> {
+    let config = repo.get_readonly_config()?;
+    let default_branch_name: Option<String> = config.get("init.defaultBranch")?;
+    Ok(default_branch_name)
+}
+
 /// If `true`, when restacking a commit, do not update its timestamp to the
 /// current time.
 pub fn get_restack_preserve_timestamps(repo: &Repo) -> eyre::Result<bool> {


### PR DESCRIPTION
If there is an `init.defaultBranch` name set, and that branch exists in the repo, prefer using that for the main branch before checking the list of hardcoded main branch names.

Fixes #135