### PR TITLE
ci: add Nix build on Linux and macOS

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -1,0 +1,22 @@
+name: Nix on Linux
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    name: nix-build
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v14.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix build --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -1,0 +1,29 @@
+name: Nix on macOS
+
+on:
+  schedule:
+    # Run once every day at 6:40AM UTC.
+    - cron: "40 6 * * *"
+
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - "ci-*"
+
+jobs:
+  nix:
+    runs-on: macos-latest
+    name: nix-build
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v14.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix build --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "git-branchless";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      lib = nixpkgs.lib;
+      systems = [
+        "aarch64-linux"
+        "aarch64-darwin"
+        "i686-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      foreachSystem = f: lib.foldl' (attrs: system: lib.recursiveUpdate attrs (f system)) { } systems;
+    in
+    foreachSystem (system: {
+      packages.${system}.git-branchless = with nixpkgs.legacyPackages.${system};
+        rustPlatform.buildRustPackage {
+          name = "git-branchless";
+
+          src = self;
+
+          cargoLock = {
+            lockFile = "${self}/Cargo.lock";
+          };
+
+          nativeBuildInputs = [ pkg-config ];
+
+          buildInputs = [
+            ncurses
+            openssl
+            sqlite
+          ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+            Security
+            SystemConfiguration
+            libiconv
+          ]);
+
+          buildType = "debug";
+          preCheck = ''
+            export RUST_BACKTRACE=1
+            export PATH_TO_GIT=${git}/bin/git
+            export GIT_EXEC_PATH=$(${git}/bin/git --exec-path)
+          '';
+          # FIXME: these tests deadlock when run in the Nix sandbox
+          checkFlags = [
+            "--skip=test_checkout_pty"
+            "--skip=test_next_ambiguous_interactive"
+          ];
+        };
+      defaultPackage.${system} = self.packages.${system}.git-branchless;
+    });
+}


### PR DESCRIPTION
As promised in #120.

This introduces a new file `default.nix` at the top-level of the repository. If it is in the way, I can also hide it somewhere else and just move it to the top-level in the CI.

The Nix build is rather slow because it transitively fetches all of the dependencies and nothing is cached paired with general build slowness of Rust. It's possible to obtain some caching but it involves a third-party provider. GitHub itself does not offer a Nix binary cache (yet?).