### PR TITLE
feat(checkout): Add checkout subcommand alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `git branchless checkout` command, which enables you to interactively pick a commit to checkout from the commits tracked in the smartlog.
+  - This command is aliased to `git co`.
 
 ## [0.3.7] - 2021-10-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ name = "git-branchless-move"
 path = "bin/entry_points/git-branchless-move.rs"
 required-features = ["man-pages"]
 
+[[bin]]
+name = "git-branchless-checkout"
+path = "bin/entry_points/git-branchless-checkout.rs"
+required-features = ["man-pages"]
+
 ## Testing binaries ##
 [[bin]]
 name = "git-branchless-regression-test-cherry-pick"

--- a/bin/entry_points/git-branchless-checkout.rs
+++ b/bin/entry_points/git-branchless-checkout.rs
@@ -1,0 +1,3 @@
+fn main() {
+    branchless::commands::main();
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -69,6 +69,7 @@ const ALL_ALIASES: &[(&str, &str)] = &[
     ("restack", "restack"),
     ("undo", "undo"),
     ("move", "move"),
+    ("co", "checkout"),
 ];
 
 #[derive(Debug)]


### PR DESCRIPTION
Followup to https://github.com/arxanas/git-branchless/pull/152#issuecomment-952126432

This aliases `git branchless checkout` to `git co`