### PR TITLE
feat(next): Add interactive ambiguity resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `git branchless checkout` command, which enables you to interactively pick a commit to checkout from the commits tracked in the smartlog.
   - This command is aliased to `git co`.
+- `git next` accepts an `--interactive` flag which, if set, prompts which commit to advance to in ambiguous circumstances. This can be enabled by default with the `branchless.next.interactive` config setting.
 
 ## [0.3.7] - 2021-10-22
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -144,12 +144,16 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             num_commits,
             oldest,
             newest,
+            interactive,
         } => {
-            let towards = match (oldest, newest) {
-                (false, false) => None,
-                (true, false) => Some(navigation::Towards::Oldest),
-                (false, true) => Some(navigation::Towards::Newest),
-                (true, true) => eyre::bail!("Both --oldest and --newest were set"),
+            let towards = match (oldest, newest, interactive) {
+                (false, false, false) => None,
+                (true, false, false) => Some(navigation::Towards::Oldest),
+                (false, true, false) => Some(navigation::Towards::Newest),
+                (false, false, true) => Some(navigation::Towards::Interactive),
+                (_, _, _) => {
+                    eyre::bail!("Only one of --oldest, --newest, and --interactive can be set")
+                }
             };
             navigation::next(&effects, &git_run_info, num_commits, towards)?
         }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -40,6 +40,13 @@ pub fn get_restack_preserve_timestamps(repo: &Repo) -> eyre::Result<bool> {
         .get_or("branchless.restack.preserveTimestamps", false)
 }
 
+/// If `true`, when advancing to a "next" commit, prompt interactively to
+/// if there is ambiguity in which commit to advance to.
+pub fn get_next_interactive(repo: &Repo) -> eyre::Result<bool> {
+    repo.get_readonly_config()?
+        .get_or("branchless.next.interactive", false)
+}
+
 /// Config key for `get_restack_warn_abandoned`.
 pub const RESTACK_WARN_ABANDONED_CONFIG_KEY: &str = "branchless.restack.warnAbandoned";
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -111,6 +111,16 @@ pub enum Command {
         /// When encountering multiple next commits, choose the newest.
         #[clap(short = 'n', long = "newest", conflicts_with("oldest"))]
         newest: bool,
+
+        /// When encountering multiple next commits, interactively prompt which to
+        /// advance to.
+        #[clap(
+            short = 'i',
+            long = "interactive",
+            conflicts_with("newest"),
+            conflicts_with("oldest")
+        )]
+        interactive: bool,
     },
 
     /// Interactively pick a commit to checkout.

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -3,12 +3,18 @@ use crate::git::{Commit, NonZeroOid};
 /// Prompt the user to select a commit from the provided list
 /// of commits, and returns the OID of the selected commit.
 #[cfg(unix)]
-pub fn prompt_select_commit(commits: Vec<Commit>) -> eyre::Result<Option<NonZeroOid>> {
-    skim::prompt_skim(commits)
+pub fn prompt_select_commit(
+    commits: Vec<Commit>,
+    header: Option<&str>,
+) -> eyre::Result<Option<NonZeroOid>> {
+    skim::prompt_skim(commits, header)
 }
 
 #[cfg(not(unix))]
-pub fn prompt_select_commit(commits: Vec<Commit>) -> eyre::Result<Option<NonZeroOid>> {
+pub fn prompt_select_commit(
+    commits: Vec<Commit>,
+    header: Option<&str>,
+) -> eyre::Result<Option<NonZeroOid>> {
     unimplemented!("Non-unix targets are currently unsupported for prompting")
 }
 
@@ -97,13 +103,18 @@ mod skim {
         }
     }
 
-    pub fn prompt_skim(commits: Vec<Commit>) -> eyre::Result<Option<NonZeroOid>> {
+    #[cfg(unix)]
+    pub fn prompt_skim(
+        commits: Vec<Commit>,
+        header: Option<&str>,
+    ) -> eyre::Result<Option<NonZeroOid>> {
         let options = SkimOptionsBuilder::default()
             .height(Some("100%"))
             .preview(Some(""))
             .preview_window(Some("up:70%"))
             .sync(true) // Consume all items before displaying selector.
             .bind(vec!["Enter:accept"])
+            .header(header)
             .build()
             .map_err(|e| eyre!("building Skim options failed: {}", e))?;
 


### PR DESCRIPTION
Followup to #152, which finishes up #138.

This allows you to optionally use the interactive commit picker to resolve ambiguities encountered when running `git next`.