### PR TITLE
Bug report template with hint to find rust version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Steps to reproduce
+<!-- A clear and concise description of what the bug is. -->
+
+```sh
+# Your reproduction script goes here
+```
+
+### Expected behavior
+<!-- Tell us what should happen -->
+
+### Actual behavior
+<!-- Tell us what happens instead -->
+
+### System configuration
+**Rust version**:
+<!-- paste result of the following command -->
+<!-- rustc --version -->
+
+**git-branchless version**:
+<!-- paste result of the following command -->
+<!-- git-branchless --version -->


### PR DESCRIPTION
Here is my contribution.
When I reported my first issue on git-branchless, I couldn't provide rust version, because I had no idea it was using rust nor I didn't know the command to get rust version.
I order to help users filling bug reports I think a template with commands to get rust and git-branchless versions could be nice. 