### PR TITLE
ci: Add timeout to test run steps

### DIFF
--- a/.github/workflows/linux-git-devel.yml
+++ b/.github/workflows/linux-git-devel.yml
@@ -62,11 +62,13 @@ jobs:
           path: git-branchless
 
       - name: Run Rust tests on Git `master`
+        timeout-minutes: 10
         run: |
           export PATH_TO_GIT="$PWD"/git-master/git
           (cd git-branchless && cargo test --all-features)
 
       - name: Run Rust tests on Git `next`
+        timeout-minutes: 10
         run: |
           export PATH_TO_GIT="$PWD"/git-next/git
           (cd git-branchless && cargo test --all-features)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,13 +82,13 @@ jobs:
         run: cargo build --benches --tests
 
       - name: Run Rust tests (all features)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           export PATH_TO_GIT="$PWD"/git
           cargo test --all-features
 
       - name: Run Rust tests (no default features)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           export PATH_TO_GIT="$PWD"/git
           cargo test --no-default-features

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,6 +37,7 @@ jobs:
         run: cargo build --benches --tests
 
       - name: Run tests
+        timeout-minutes: 10
         run: |
           export RUST_BACKTRACE=1
           export PATH_TO_GIT=$(which git)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,6 +29,7 @@ jobs:
         run: cargo build --benches --tests
 
       - name: Run tests
+        timeout-minutes: 10
         run: |
           $env:PATH_TO_GIT='C:\Program Files\Git\cmd\git.exe'
           cargo test


### PR DESCRIPTION
Followup to #152.

I noticed that the tests have the default timeout set, which means that the tests will continue to run for ~6 hours ([ref](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)) before timing out.

The test suite currently runs in ~2 minutes, so anything more than ~10 minutes is more likely to be a bug (like we encountered in #152) than the tests legitimately taking a long time to run.