### PR TITLE
feat(amend): Initial amend command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - References created for garbage collection purposes are no longer generated unless you've run `git branchless init` in the repository.
 - `git next` and `git prev` accept `-a`/`--all` to take you all the way to a head or root commit for your commit stack, respectively.
 - `git next` and `git prev` accept `-b`/`--branch` to take you to the next or previous branch for your commit stack, respectively.
+- New `git branchless amend` command (aliased to `git amend`) that amends the current HEAD commit, and automatically performs a restack.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,11 @@ name = "git-branchless-checkout"
 path = "bin/entry_points/git-branchless-checkout.rs"
 required-features = ["man-pages"]
 
+[[bin]]
+name = "git-branchless-amend"
+path = "bin/entry_points/git-branchless-amend.rs"
+required-features = ["man-pages"]
+
 ## Testing binaries ##
 [[bin]]
 name = "git-branchless-regression-test-cherry-pick"

--- a/bin/entry_points/git-branchless-amend.rs
+++ b/bin/entry_points/git-branchless-amend.rs
@@ -1,0 +1,3 @@
+fn main() {
+    branchless::commands::main();
+}

--- a/src/commands/amend.rs
+++ b/src/commands/amend.rs
@@ -1,0 +1,165 @@
+//! Amend the current commit.
+//!
+//! This command amends the HEAD commit with changes to files
+//! that are already tracked in the repo. Following the amend,
+//! the command performs a restack.
+
+use std::convert::TryInto;
+use std::fmt::Write;
+use std::time::SystemTime;
+
+use eyre::Context;
+use itertools::Itertools;
+
+use crate::commands::gc::mark_commit_reachable;
+use crate::commands::restack;
+use crate::core::config::get_restack_preserve_timestamps;
+use crate::core::effects::Effects;
+use crate::core::eventlog::{Event, EventLogDb};
+use crate::core::formatting::Pluralize;
+use crate::git::{AmendFastOptions, FileStatus, GitRunInfo, Repo};
+use crate::opts::MoveOptions;
+
+/// Amends the existing HEAD commit.
+pub fn amend(
+    effects: &Effects,
+    git_run_info: &GitRunInfo,
+    move_options: &MoveOptions,
+) -> eyre::Result<isize> {
+    let now = SystemTime::now();
+    let repo = Repo::from_current_dir()?;
+    let conn = repo.get_db_conn()?;
+    let mut event_log_db = EventLogDb::new(&conn)?;
+
+    let head_oid = match repo.get_head_info()?.oid {
+        Some(oid) => oid,
+        None => {
+            writeln!(
+                effects.get_output_stream(),
+                "No commit is currently checked out. Check out a commit to amend and then try again.",
+            )?;
+            return Ok(1);
+        }
+    };
+    let head_commit = repo.find_commit_or_fail(head_oid)?;
+
+    let index = repo.get_index()?;
+    if index.has_conflicts() {
+        writeln!(
+            effects.get_output_stream(),
+            "Cannot amend, because there are unresolved merge conflicts. Resolve the merge conflicts and try again."
+        )?;
+        return Ok(1);
+    }
+
+    let event_tx_id = event_log_db.make_transaction_id(now, "amend")?;
+    let staged_index_paths = repo.get_staged_paths()?;
+    let (opts, dirty_working_tree) = if !staged_index_paths.is_empty() {
+        let dirty_working_tree = repo.has_changed_files(effects, git_run_info)?;
+        let opts = AmendFastOptions::FromIndex {
+            paths: staged_index_paths.into_iter().collect_vec(),
+        };
+        (opts, dirty_working_tree)
+    } else {
+        let status = repo.get_status(git_run_info, Some(event_tx_id))?;
+        let entries_to_amend = status
+            .into_iter()
+            .filter(|entry| match entry.working_copy_status {
+                FileStatus::Added
+                | FileStatus::Copied
+                | FileStatus::Deleted
+                | FileStatus::Modified
+                | FileStatus::Renamed => true,
+                FileStatus::Ignored
+                | FileStatus::Unmerged
+                | FileStatus::Unmodified
+                | FileStatus::Untracked => false,
+            })
+            .collect_vec();
+        let opts = AmendFastOptions::FromWorkingCopy {
+            status_entries: entries_to_amend,
+        };
+        (opts, true)
+    };
+    if opts.is_empty() {
+        writeln!(
+            effects.get_output_stream(),
+            "There are no uncommitted or staged changes. Nothing to amend."
+        )?;
+        return Ok(0);
+    }
+
+    let amended_tree = repo.amend_fast(&head_commit, &opts)?;
+    let timestamp = now.duration_since(SystemTime::UNIX_EPOCH)?.as_secs_f64();
+
+    let (author, committer) = (head_commit.get_author(), head_commit.get_committer());
+    let (author, committer) = if get_restack_preserve_timestamps(&repo)? {
+        (author, committer)
+    } else {
+        (
+            author.update_timestamp(now)?,
+            committer.update_timestamp(now)?,
+        )
+    };
+
+    let amended_commit_oid = head_commit.amend_commit(
+        Some("HEAD"),
+        Some(&author),
+        Some(&committer),
+        None,
+        Some(&amended_tree),
+    )?;
+    mark_commit_reachable(&repo, amended_commit_oid)
+        .wrap_err("Marking commit as reachable for GC purposes.")?;
+
+    event_log_db.add_events(vec![Event::RewriteEvent {
+        timestamp,
+        event_tx_id,
+        old_commit_oid: head_oid.into(),
+        new_commit_oid: amended_commit_oid.into(),
+    }])?;
+
+    if let AmendFastOptions::FromWorkingCopy { .. } = opts {
+        // TODO(#201): Figure out a way to perform "fast amend" on the working copy without needing a reset.
+        git_run_info.run(effects, Some(event_tx_id), &["reset"])?;
+    }
+
+    let restack_exit_code = restack::restack(
+        effects,
+        git_run_info,
+        vec![head_oid.to_string()],
+        move_options,
+    )?;
+    if restack_exit_code != 0 {
+        return Ok(restack_exit_code);
+    }
+
+    match opts {
+        AmendFastOptions::FromIndex { paths } => {
+            let staged_changes = Pluralize {
+                amount: paths.len().try_into()?,
+                plural: "staged changes",
+                singular: "staged change",
+            };
+            let mut message = format!("Amended with {}.", staged_changes.to_string());
+            // TODO: Include the number of uncommitted changes.
+            if dirty_working_tree {
+                message += " (Some uncommitted changes were not amended.)";
+            }
+            writeln!(effects.get_output_stream(), "{}", message)?;
+        }
+        AmendFastOptions::FromWorkingCopy { status_entries } => {
+            let uncommitted_changes = Pluralize {
+                amount: status_entries.len().try_into()?,
+                plural: "uncommitted changes",
+                singular: "uncommitted change",
+            };
+            writeln!(
+                effects.get_output_stream(),
+                "Amended with {}.",
+                uncommitted_changes.to_string(),
+            )?;
+        }
+    }
+    Ok(0)
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -70,6 +70,7 @@ const ALL_ALIASES: &[(&str, &str)] = &[
     ("undo", "undo"),
     ("move", "move"),
     ("co", "checkout"),
+    ("amend", "amend"),
 ];
 
 #[derive(Debug)]
@@ -297,6 +298,8 @@ fn install_aliases(
     let version_str = git_run_info
         .run_silent(repo, None, &["version"])
         .wrap_err("Determining Git version")?;
+    let version_str =
+        String::from_utf8(version_str).wrap_err("Decoding stdout from Git subprocess")?;
     let version_str = version_str.trim();
     let version: GitVersion = version_str
         .parse()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! Sub-commands of `git-branchless`.
 
+pub mod amend;
 pub mod gc;
 pub mod hide;
 pub mod hooks;
@@ -164,6 +165,8 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             base,
             move_options,
         } => r#move::r#move(&effects, &git_run_info, source, dest, base, &move_options)?,
+
+        Command::Amend { move_options } => amend::amend(&effects, &git_run_info, &move_options)?,
 
         Command::Restack {
             commits,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -14,9 +14,9 @@ pub use dag::{
 };
 pub use oid::{MaybeZeroOid, NonZeroOid};
 pub use repo::{
-    Branch, CategorizedReferenceName, CherryPickFastError, CherryPickFastOptions, Commit, Diff,
-    GitVersion, PatchId, Reference, ReferenceTarget, Repo, RepoReferencesSnapshot,
-    ResolvedReferenceInfo,
+    AmendFastOptions, Branch, CategorizedReferenceName, CherryPickFastError, CherryPickFastOptions,
+    Commit, Diff, FileStatus, GitVersion, PatchId, Reference, ReferenceTarget, Repo,
+    RepoReferencesSnapshot, ResolvedReferenceInfo, StatusEntry,
 };
 pub use run::{check_out_commit, GitRunInfo};
 pub use tree::Tree;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -185,6 +185,13 @@ pub enum Command {
         move_options: MoveOptions,
     },
 
+    /// Amend the current HEAD commit.
+    Amend {
+        /// Options for moving commits.
+        #[clap(flatten)]
+        move_options: MoveOptions,
+    },
+
     /// Browse or return to a previous state of the repository.
     Undo,
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsString;
+use std::fs;
 use std::io::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -361,6 +362,24 @@ impl Git {
         Ok(())
     }
 
+    /// Delete the provided file in the repository root.
+    pub fn delete_file(&self, name: &str) -> eyre::Result<()> {
+        let file_path = self.repo_path.join(format!("{}.txt", name));
+        fs::remove_file(file_path)?;
+        Ok(())
+    }
+
+    /// Delete the provided file in the repository root.
+    pub fn set_file_permissions(
+        &self,
+        name: &str,
+        permissions: fs::Permissions,
+    ) -> eyre::Result<()> {
+        let file_path = self.repo_path.join(format!("{}.txt", name));
+        fs::set_permissions(file_path, permissions)?;
+        Ok(())
+    }
+
     /// Commit a file with default contents. The `time` argument is used to set
     /// the commit timestamp, which is factored into the commit hash.
     #[instrument]
@@ -501,7 +520,6 @@ impl Deref for GitWrapper {
 /// From https://stackoverflow.com/a/65192210
 /// License: CC-BY-SA 4.0
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    use std::fs;
     fs::create_dir_all(&dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;

--- a/tests/command/test_amend.rs
+++ b/tests/command/test_amend.rs
@@ -1,0 +1,321 @@
+use branchless::testing::{make_git, GitRunOptions};
+
+#[test]
+fn test_amend_with_children() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^"])?;
+
+    git.write_file("test2", "updated contents")?;
+
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> reset
+        Attempting rebase in-memory...
+        [1/1] Committed as: b51f01b6 create test3.txt
+        branchless: processing 1 rewritten commit
+        In-memory rebase succeeded.
+        Finished restacking commits.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout 7ac317b9d1dd1bbdf46e8ee692b9b9e280f28a50
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ 7ac317b9 create test2.txt
+        |
+        o b51f01b6 create test3.txt
+        Amended with 1 uncommitted change.
+        "###);
+    }
+
+    git.write_file("test3", "create merge conflict")?;
+    git.run(&["add", "."])?;
+    {
+        let (stdout, _stderr) = git.run_with_options(
+            &["branchless", "amend"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> diff --quiet
+        Attempting rebase in-memory...
+        This operation would cause a merge conflict:
+        - (1 conflicting file) b51f01b6 create test3.txt
+        To resolve merge conflicts, retry this operation with the --merge option.
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_rename() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    git.run(&["mv", "test1.txt", "moved.txt"])?;
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> diff --quiet
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout f6b255388219264f4bcd258a3020d262c2d7b03e
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ f6b25538 create test2.txt
+        Amended with 2 staged changes.
+        "###);
+    }
+    {
+        let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        f6b2553 create test2.txt
+        :100644 100644 7432a8f 7432a8f R100	test1.txt	moved.txt
+        :000000 100644 0000000 4e512d2 A	test2.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_delete() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    git.delete_file("test1")?;
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> reset
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout f0f07277a6448cac370e6023ab379ec0c601ccfe
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ f0f07277 create test2.txt
+        Amended with 1 uncommitted change.
+        "###);
+    }
+    {
+        let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        f0f0727 create test2.txt
+        :100644 000000 7432a8f 0000000 D	test1.txt
+        :000000 100644 0000000 4e512d2 A	test2.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_with_working_copy() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    git.write_file("test1", "updated contents")?;
+    git.write_file("test2", "updated contents")?;
+    git.run(&["add", "test1.txt"])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> diff --quiet
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout f8e4ba1be5cefcf22e831f51b1525b0be8215a31
+        M	test2.txt
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ f8e4ba1b create test2.txt
+        Amended with 1 staged change. (Some uncommitted changes were not amended.)
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> reset
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout 2e69581cb466962fa85e5918f29af6d2925fdd6f
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ 2e69581c create test2.txt
+        Amended with 1 uncommitted change.
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_head() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.write_file("test1", "updated contents")?;
+
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> reset
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout 3b98a960e6ebde39a933c25413b43bce8c0fd128
+        O f777ecc9 (master) create initial.txt
+        |
+        @ 3b98a960 create test1.txt
+        Amended with 1 uncommitted change.
+        "###);
+    }
+
+    // Amend should only update tracked files.
+    git.write_file("newfile", "some new file")?;
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @"There are no uncommitted or staged changes. Nothing to amend.
+");
+    }
+
+    git.run(&["add", "."])?;
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> diff --quiet
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout 685ef311b070a460b7c86a9aed068be563978021
+        O f777ecc9 (master) create initial.txt
+        |
+        @ 685ef311 create test1.txt
+        Amended with 1 staged change.
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn test_amend_executable() -> eyre::Result<()> {
+    use std::{fs, os::unix::prelude::PermissionsExt};
+
+    let git = make_git()?;
+
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    let executable = fs::Permissions::from_mode(0o777);
+    git.write_file("executable_file", "contents")?;
+    git.set_file_permissions("executable_file", executable)?;
+    git.run(&["add", "."])?;
+
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "amend"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> diff --quiet
+        No abandoned commits to restack.
+        No abandoned branches to restack.
+        branchless: running command: <git-executable> checkout f00ec4b5a81438f4e792ca5576a290b16fed8fdb
+        O f777ecc9 (master) create initial.txt
+        |
+        o 62fc20d2 create test1.txt
+        |
+        @ f00ec4b5 create test2.txt
+        Amended with 1 staged change.
+        "###);
+    }
+    {
+        let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        f00ec4b create test2.txt
+        :000000 100755 0000000 0839b2e A	executable_file.txt
+        :000000 100644 0000000 4e512d2 A	test2.txt
+        "###);
+    }
+
+    Ok(())
+}
+#[test]
+#[cfg(unix)]
+fn test_amend_unresolved_merge_conflict() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    git.init_repo()?;
+    git.commit_file("file1", 1)?;
+    git.run(&["checkout", "-b", "branch1"])?;
+    git.write_file("file1", "branch1 contents")?;
+    git.run(&["commit", "-a", "-m", "updated"])?;
+    git.run(&["checkout", "master"])?;
+    git.write_file("file1", "master contents")?;
+    git.run(&["commit", "-a", "-m", "updated"])?;
+    git.run_with_options(
+        &["merge", "branch1"],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    )?;
+
+    {
+        let (stdout, _stderr) = git.run_with_options(
+            &["branchless", "amend"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @"Cannot amend, because there are unresolved merge conflicts. Resolve the merge conflicts and try again.
+");
+    }
+
+    Ok(())
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -7,6 +7,7 @@ mod core {
 }
 
 mod command {
+    mod test_amend;
     mod test_hide;
     mod test_init;
     mod test_move;


### PR DESCRIPTION
Create a new amend command that automatically amends changes to tracked files onto the HEAD commit, and can optionally perform an immediate restack.

(See e.g. #48)