### PR TITLE
feat(init): hide GC-related references from `git log` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `git branchless checkout` command, which enables you to interactively pick a commit to checkout from the commits tracked in the smartlog.
   - This command is aliased to `git co`.
 - `git next` accepts an `--interactive` flag which, if set, prompts which commit to advance to in ambiguous circumstances. This can be enabled by default with the `branchless.next.interactive` config setting.
+- References created for garbage collection purposes no longer appear in `git log` by default.
 
 ### Fixed
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -424,6 +424,7 @@ fn set_configs(
 
     config.set("branchless.core.mainBranch", main_branch_name)?;
     config.set("advice.detachedHead", false)?;
+    config.set("log.excludeDecoration", "refs/branchless/*")?;
 
     Ok(())
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -446,6 +446,13 @@ impl Git {
         Ok(version >= GitVersion(2, 29, 0))
     }
 
+    /// The `log.excludeDecoration` configuration option was introduced in Git
+    /// v2.27.
+    pub fn supports_log_exclude_decoration(&self) -> eyre::Result<bool> {
+        let version = self.get_version()?;
+        Ok(version >= GitVersion(2, 27, 0))
+    }
+
     /// Resolve a file during a merge or rebase conflict with the provided
     /// contents.
     #[instrument]


### PR DESCRIPTION
Closes #171.