### PR TITLE
fix(run): Default to treating git failures as errors

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -296,8 +296,9 @@ fn install_aliases(
     }
 
     let version_str = git_run_info
-        .run_silent(repo, None, &["version"])
-        .wrap_err("Determining Git version")?;
+        .run_silent(repo, None, &["version"], Default::default())
+        .wrap_err("Determining Git version")?
+        .stdout;
     let version_str =
         String::from_utf8(version_str).wrap_err("Decoding stdout from Git subprocess")?;
     let version_str = version_str.trim();

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -673,11 +673,14 @@ Either create it, or update the main branch setting by running:
         git_run_info: &GitRunInfo,
         event_tx_id: Option<EventTransactionId>,
     ) -> eyre::Result<Vec<StatusEntry>> {
-        let output = git_run_info.run_silent(
-            self,
-            event_tx_id,
-            &["status", "--porcelain=v2", "--untracked-files=no", "-z"],
-        )?;
+        let output = git_run_info
+            .run_silent(
+                self,
+                event_tx_id,
+                &["status", "--porcelain=v2", "--untracked-files=no", "-z"],
+                Default::default(),
+            )?
+            .stdout;
 
         let not_null_terminator = |c: &u8| *c != 0_u8;
         let mut statuses = Vec::new();


### PR DESCRIPTION
Fixes #200.

- `run_silent` now returns stderr, stdout, and exit_code
- `run_silent` now defaults to returning an error if git exits with a nonzero code (though, this behavior can be disabled with an option)