### PR TITLE
ci: provide Nix overlay

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -20,4 +20,4 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - run: nix build --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs
+      - run: nix flake check --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -27,4 +27,4 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - run: nix build --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs
+      - run: nix flake check --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638371214,
+        "narHash": "sha256-0kE6KhgH7n0vyuX4aUoGsGIQOqjIx2fJavpCWtn73rc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a640d8394f34714578f3e6335fc767d0755d78f9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Currently Nix is only used for CI. With this contribution using the development version of git-branchless will become very ergonomic for Nix users.

For example, Nix users with `experimental-features = nix-command flakes` enabled can now use
```
nix shell github:arxanas/git-branchless
```
to be dropped into a shell where the latest git-branchless is available.

Users who like to be on the bleeding edge can add git-branchless to their flake inputs and use the included overlay to add git-branchless to their profile.
```nix
{
  inputs.git-branchless.url = "github:arxanas/git-branchless";

  outputs = { self, nixpkgs, git-branchless, ... }:
    let
      system = "x86_64-linux";
      pkgs = import nixpkgs {
        inherit system;
        overlays = [ git-branchless.overlay ];
      };
    in {
      # flake outputs ...
      # pkgs.git-branchless refers to the GitHub version
    };
}
```