### PR TITLE
fix(init): skip adding aliases to a repo when a user already has that alias defined

### DIFF
--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -204,6 +204,14 @@ impl Config {
         Ok(Config { inner })
     }
 
+    /// Open a configuration instance derived from the global, XDG and
+    /// system configuration files.
+    #[instrument]
+    pub fn open_default() -> eyre::Result<Self> {
+        let inner = git2::Config::open_default().map_err(wrap_git_error)?;
+        Ok(Config { inner })
+    }
+
     #[instrument]
     fn set_inner(&mut self, key: &str, value: ConfigValue) -> eyre::Result<()> {
         match &value.inner {


### PR DESCRIPTION
As per https://github.com/arxanas/git-branchless/issues/219.

This is a simple change to skip adding an alias if it's already defined in the user's default configs ("global, XDG and system configuration files" as per https://docs.rs/git2/latest/git2/struct.Config.html#method.open_default).