### PR TITLE
feat(amend, checkout): re-enable `git amend`/`git checkout` aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- (#267) Aliases like `git amend` are now installed only if the user does not already have aliases with the same name. Thanks to @rslabbert for implementing this.
+
 ## [0.3.9] - 2022-02-08
 
 ### Fixed

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -60,9 +60,8 @@ echo 'branchless: This is a bug. Please report it.'
 ];
 
 const ALL_ALIASES: &[(&str, &str)] = &[
-    // Re-enable these aliases when they no longer clobber user aliases:
-    // ("amend", "amend"),
-    // ("co", "checkout"),
+    ("amend", "amend"),
+    ("co", "checkout"),
     ("hide", "hide"),
     ("move", "move"),
     ("next", "next"),


### PR DESCRIPTION
Now doable thanks to https://github.com/arxanas/git-branchless/pull/267.
