### PR TITLE
tests: ignore system config in tests

### DIFF
--- a/src/testing.rs
+++ b/src/testing.rs
@@ -173,6 +173,7 @@ impl Git {
 
         let new_path = self.get_path_for_env();
         let envs = vec![
+            ("GIT_CONFIG_NOSYSTEM", OsString::from("1")),
             ("GIT_AUTHOR_DATE", date.clone()),
             ("GIT_COMMITTER_DATE", date),
             ("GIT_EDITOR", git_editor),


### PR DESCRIPTION
My system has a hook installed (for checking for accidentally
committed secrets), which interfered with tests. Let' set
`GIT_CONFIG_NOSYSTEM` to fix that.