### PR TITLE
feat(smartlog): add `--only-branches` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - EXPERIMENTAL: created `git sync` command, which moves all commit stacks onto the main branch (if possible).
+- The `--only-branches` option can be passed to `git smartlog` to only show commits which are on branches.
 
 ### Changed
 

--- a/src/commands/bug_report.rs
+++ b/src/commands/bug_report.rs
@@ -104,7 +104,15 @@ fn describe_event_cursor(
 
     let glyphs = Glyphs::text();
     let effects = Effects::new(glyphs.clone());
-    let graph = make_smartlog_graph(&effects, repo, dag, event_replayer, event_cursor, true)?;
+    let graph = make_smartlog_graph(
+        &effects,
+        repo,
+        dag,
+        event_replayer,
+        event_cursor,
+        true,
+        false,
+    )?;
     let graph_lines = render_graph(
         &effects,
         repo,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -224,12 +224,14 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
 
         Command::Smartlog {
             show_hidden_commits,
+            only_show_branches,
         } => {
             smartlog::smartlog(
                 &effects,
                 &git_run_info,
                 &SmartlogOptions {
                     show_hidden_commits,
+                    only_show_branches,
                 },
             )?;
             0

--- a/src/commands/navigation.rs
+++ b/src/commands/navigation.rs
@@ -540,7 +540,15 @@ pub fn checkout(
         &references_snapshot,
     )?;
 
-    let graph = make_smartlog_graph(effects, &repo, &dag, &event_replayer, event_cursor, true)?;
+    let graph = make_smartlog_graph(
+        effects,
+        &repo,
+        &dag,
+        &event_replayer,
+        event_cursor,
+        true,
+        false,
+    )?;
 
     let initial_query = get_initial_query(checkout_options);
     let target = match initial_query {

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -53,7 +53,15 @@ fn render_cursor_smartlog(
         reference_name: None,
     };
 
-    let graph = make_smartlog_graph(effects, repo, &dag, event_replayer, event_cursor, true)?;
+    let graph = make_smartlog_graph(
+        effects,
+        repo,
+        &dag,
+        event_replayer,
+        event_cursor,
+        true,
+        false,
+    )?;
     let result = render_graph(
         effects,
         repo,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -282,6 +282,10 @@ pub enum Command {
         /// Also show commits which have been hidden.
         #[clap(long = "hidden")]
         show_hidden_commits: bool,
+
+        /// Only show commits that exist on a branch.
+        #[clap(long = "only-branches", conflicts_with = "show-hidden-commits")]
+        only_show_branches: bool,
     },
 
     /// Move any local commit stacks on top of the main branch.

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -327,7 +327,7 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::git::repo::get_main_branch_oid with self=<Git repository at: "<repo-path>/.git/">
           at some/file/path.rs:123
-       1: branchless::commands::smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { show_hidden_commits: false }
+       1: branchless::commands::smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { show_hidden_commits: false, only_show_branches: false }
           at some/file/path.rs:123
 
     Suggestion:


### PR DESCRIPTION
I believe that this implements an `--only-branches` flag for `smartlog`. This is my first time using Rust (hence the "I believe" part), so any comments or suggestions to make this more idiomatic for rust or the project are warmly welcomed. Also, I was 100% like `\o/` "it compiles!" :smile:

This includes a test, and I've wired up all of the connections that I was able to discern by looking at examples from other commands, etc. Please let me know if I missed something, or should remove any of it.

The logic change was actually pretty easy: instead of `observed_commits.difference(obsolete_commits)`, I only needed to do `observed_commits.intersection(branch_commits)`, so no changes were needed for `query_active_heads` as discussed in #283. *That said*, though this is passing the tests and the handful of examples I have thrown at it, it's entirely possible that I've missed something and this implementation is too naive.

You'll see that I also configured `smartlog` to not allow `--hidden` and `--only-branches` to be used together. This was actually the trickiest part for me to think through, but I ended up realizing hidden branches are shown by default anyway, so `hidden` is just adding hidden *non-branch* commits to the smartlog, which is at odds w/ the goal of `only-branches`. Happy to reconsider this if I've missed something.



