### PR TITLE
feat: implement `git reword` command (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - EXPERIMENTAL: created `git sync` command, which moves all commit stacks onto the main branch (if possible).
+- EXPERIMENTAL: created `git reword` command, which can rewrite commit messages anywhere in the commit tree.
 - The `--only-branches` option can be passed to `git smartlog` to only show commits which are on branches.
 - The `git move` command, and other commands which can move commits, now accepts the option `--no-deduplicate-commits` to skip commit deduplication.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
+dependencies = [
+ "console",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +968,7 @@ dependencies = [
  "criterion",
  "cursive",
  "cursive_buffered_backend",
+ "dialoguer",
  "esl01-dag",
  "eyre",
  "git2",
@@ -2968,3 +2980,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ cursive = { version = "0.17.0", default-features = false, features = [
   "crossterm-backend",
 ] }
 cursive_buffered_backend = "0.6.0"
+dialoguer = "0.10.0"
 eden_dag = { package = "esl01-dag", version = "0.2.1" }
 eyre = "0.6.7"
 git2 = { version = "0.14.2", default-features = false }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -67,6 +67,7 @@ const ALL_ALIASES: &[(&str, &str)] = &[
     ("next", "next"),
     ("prev", "prev"),
     ("restack", "restack"),
+    ("reword", "reword"),
     ("sl", "smartlog"),
     ("smartlog", "smartlog"),
     ("sync", "sync"),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -223,19 +223,9 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             move_options,
         } => restack::restack(&effects, &git_run_info, commits, &move_options)?,
 
-        Command::Reword {
-            commits,
-            force,
-            messages,
-            rebase_options,
-        } => reword::reword(
-            &effects,
-            force,
-            commits,
-            messages,
-            &git_run_info,
-            &rebase_options,
-        )?,
+        Command::Reword { commits, messages } => {
+            reword::reword(&effects, commits, messages, &git_run_info)?
+        }
 
         Command::Smartlog {
             show_hidden_commits,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod r#move;
 pub mod navigation;
 pub mod restack;
+pub mod reword;
 pub mod smartlog;
 pub mod sync;
 pub mod undo;
@@ -221,6 +222,20 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             commits,
             move_options,
         } => restack::restack(&effects, &git_run_info, commits, &move_options)?,
+
+        Command::Reword {
+            commits,
+            force,
+            messages,
+            rebase_options,
+        } => reword::reword(
+            &effects,
+            force,
+            commits,
+            messages,
+            &git_run_info,
+            &rebase_options,
+        )?,
 
         Command::Smartlog {
             show_hidden_commits,

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -176,7 +176,7 @@ pub fn r#move(
     };
 
     match result {
-        ExecuteRebasePlanResult::Succeeded => Ok(0),
+        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => Ok(0),
 
         ExecuteRebasePlanResult::DeclinedToMerge { merge_conflict } => {
             merge_conflict.describe(effects, &repo)?;

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -147,7 +147,7 @@ fn restack_commits(
     let execute_rebase_plan_result =
         execute_rebase_plan(effects, git_run_info, &repo, &rebase_plan, execute_options)?;
     match execute_rebase_plan_result {
-        ExecuteRebasePlanResult::Succeeded => {
+        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => {
             writeln!(effects.get_output_stream(), "Finished restacking commits.")?;
             Ok(0)
         }

--- a/src/commands/reword.rs
+++ b/src/commands/reword.rs
@@ -252,17 +252,21 @@ fn build_messages(
             .require_save(false)
             .edit(message.as_str())?
             .unwrap();
+
         if edited_message == message {
             return Ok(BuildRewordMessageResult::IdenticalMessage);
         }
-        edited_message
+
+        // clean up the commit message: remove comment lines, finish w/ a newline, etc
+        // TODO move this to git module
+        git2::message_prettify(edited_message, comment_char)?
     } else {
+        // ensure that CLI messages also end w/ a newline
+        if !message.ends_with('\n') {
+            message.push('\n');
+        }
         message
     };
-
-    // clean up the commit message: remove comment lines, finish w/ a newline, etc
-    // TODO ask if this should be here or if it should be moved to the git module per project wiki
-    let message = git2::message_prettify(message, comment_char)?;
 
     if message.trim().is_empty() {
         return Ok(BuildRewordMessageResult::EmptyMessage);

--- a/src/commands/reword.rs
+++ b/src/commands/reword.rs
@@ -1,35 +1,35 @@
 //! Update commit messages
 
 use rayon::ThreadPoolBuilder;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Write;
 use std::time::SystemTime;
 
-use dialoguer::{Confirm, Editor};
+use dialoguer::Editor;
 use eden_dag::DagAlgorithm;
-use tracing::instrument;
+use eyre::Context;
+use tracing::{instrument, warn};
 
-use crate::core::config::get_restack_preserve_timestamps;
+use crate::core::config::{get_comment_char, get_restack_preserve_timestamps};
 use crate::core::dag::{resolve_commits, CommitSet, Dag, ResolveCommitsResult};
-use crate::core::effects::{Effects, OperationType};
+use crate::core::effects::Effects;
 use crate::core::eventlog::{EventLogDb, EventReplayer};
+use crate::core::formatting::{printable_styled_string, Glyphs};
+use crate::core::node_descriptors::{render_node_descriptors, CommitOidDescriptor, NodeObject};
 use crate::core::rewrite::{
-    execute_rebase_plan, BuildRebasePlanError, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
-    ExecuteRebasePlanResult, RebasePlan, RebasePlanBuilder, RepoResource,
+    execute_rebase_plan, BuildRebasePlanOptions, ExecuteRebasePlanOptions, ExecuteRebasePlanResult,
+    RebasePlanBuilder, RepoResource,
 };
-use crate::git::{Commit, GitRunInfo, NonZeroOid, Repo};
-use crate::opts::RebaseOptions;
+use crate::git::{CheckOutCommitOptions, Commit, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo};
 
 /// Reword a commit and restack it's descendants.
 #[instrument]
 pub fn reword(
     effects: &Effects,
-    force: bool,
     hashes: Vec<String>,
     messages: Vec<String>,
     git_run_info: &GitRunInfo,
-    rebase_options: &RebaseOptions,
 ) -> eyre::Result<isize> {
     let repo = Repo::from_current_dir()?;
     let references_snapshot = repo.get_references_snapshot()?;
@@ -50,99 +50,76 @@ pub fn reword(
         None => return Ok(1),
     };
 
-    let messages = match build_messages(&messages, &commits)? {
+    let messages = match build_messages(&messages, &commits, get_comment_char(&repo)?)? {
         BuildRewordMessageResult::Succeeded { messages } => messages,
         BuildRewordMessageResult::IdenticalMessage => {
-            println!("The message wasn't edited; nothing to do. Stopping.");
+            writeln!(
+                effects.get_output_stream(),
+                "The message wasn't edited; nothing to do. Stopping."
+            )?;
             return Ok(1);
         }
         BuildRewordMessageResult::EmptyMessage => {
-            eprintln!("Error: the reworded message was empty. Stopping.");
-            return Ok(1);
-        }
-        BuildRewordMessageResult::Failed { message } => {
-            if message != None {
-                eprintln!("{}", message.unwrap());
-            }
-            eprintln!("Error: problem processing commit message. Nothing reworded.");
+            writeln!(
+                effects.get_error_stream(),
+                "Error: the reworded message was empty. Stopping."
+            )?;
             return Ok(1);
         }
     };
 
-    if commits.len() != 1
-        && !force
-        && !Confirm::new()
-            .with_prompt(format!(
-                "Warning: attempting to apply the same message to {} commits. Continue?",
-                commits.len()
-            ))
-            .default(false)
-            .interact()?
-    {
-        println!("Ok. Nothing reworded.");
-        return Ok(1);
-    }
-
     let subtree_roots = find_subtree_roots(&repo, &dag, &commits)?;
 
-    // TODO instead of calling into `r#move` shoud we just be building the rebase plan ourselves?
-    // TODO look at `sync` to see how it handles return values for multiple subtree moves
-    // TODO what if there is no parent?
-    // TODO what if there are multiple parents?
-    let RebaseOptions {
-        force_in_memory,
-        force_on_disk,
-        detect_duplicate_commits_via_patch_id,
-        resolve_merge_conflicts,
-        dump_rebase_constraints,
-        dump_rebase_plan,
-    } = *rebase_options;
-
-    let subtree_roots_and_plans: Vec<(Commit, Option<RebasePlan>)> = {
+    let rebase_plan = {
         let pool = ThreadPoolBuilder::new().build()?;
         let repo_pool = RepoResource::new_pool(&repo)?;
-        let builder = RebasePlanBuilder::new(&dag);
+        let mut builder = RebasePlanBuilder::new(&dag);
 
-        let subtree_roots_and_plans =
-            subtree_roots
-                .into_iter()
-                .map(
-                    |root_commit| -> eyre::Result<
-                        Result<(Commit, Option<RebasePlan>), BuildRebasePlanError>,
-                    > {
-                        // Keep access to the same underlying caches by cloning the same instance of the
-                        // builder.
-                        let mut builder = builder.clone();
+        for root_commit in subtree_roots {
+            let only_parent_id = root_commit.get_only_parent().map(|parent| parent.get_oid());
+            if only_parent_id == None {
+                eyre::bail!(
+                    "###
+                    Refusing to reword commit {}, which has {} parents.
+                    Rewording only supported for commits with 1 parent.
+                    Stopping; nothing reworded.
+                    ###",
+                    root_commit.get_oid(),
+                    root_commit.get_parents().len(),
+                );
+            }
+            builder.move_subtree(root_commit.get_oid(), only_parent_id.unwrap())?;
+        }
 
-                        let rebase_plan = {
-                            let only_parent_id =
-                                root_commit.get_only_parent().map(|parent| parent.get_oid());
-                            if only_parent_id == None {
-                                // TODO multiple parents!
-                            }
-                            builder.move_subtree(root_commit.get_oid(), only_parent_id.unwrap())?;
-                            builder.reword_commits(&messages)?;
-                            builder.build(
-                                effects,
-                                &pool,
-                                &repo_pool,
-                                &BuildRebasePlanOptions {
-                                    dump_rebase_constraints,
-                                    dump_rebase_plan,
-                                    detect_duplicate_commits_via_patch_id,
-                                },
-                            )?
-                        };
+        for commit in commits.iter() {
+            let message = messages.get(&commit.get_oid()).unwrap();
+            // This looks funny, but just means "leave everything but the message as is"
+            let replacement_oid =
+                commit.amend_commit(None, None, None, Some(message.as_str()), None)?;
+            builder.replace_commit(commit.get_oid(), replacement_oid)?;
+        }
 
-                        Ok(rebase_plan.map(|rebase_plan| (root_commit, rebase_plan)))
-                    },
-                )
-                .collect::<eyre::Result<Vec<_>>>()?
-                .into_iter()
-                .collect::<Result<Vec<_>, BuildRebasePlanError>>();
-
-        match subtree_roots_and_plans {
-            Ok(subtree_roots_and_plans) => subtree_roots_and_plans,
+        match builder.build(
+            effects,
+            &pool,
+            &repo_pool,
+            &BuildRebasePlanOptions {
+                dump_rebase_constraints: false,
+                dump_rebase_plan: false,
+                detect_duplicate_commits_via_patch_id: false,
+            },
+        )? {
+            Ok(Some(rebase_plan)) => rebase_plan,
+            Ok(None) => {
+                writeln!(
+                    effects.get_output_stream(),
+                    "###
+                    BUG: rebase plan indicates nothing to do, but rewording should always do something.
+                    Stopping; nothing reworded.
+                    ###"
+                )?;
+                return Ok(1);
+            }
             Err(err) => {
                 err.describe(effects, &repo)?;
                 return Ok(1);
@@ -156,97 +133,34 @@ pub fn reword(
         now,
         event_tx_id,
         preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
-        force_in_memory,
-        force_on_disk,
-        resolve_merge_conflicts,
-        check_out_commit_options: Default::default(),
+        force_in_memory: true,
+        force_on_disk: false,
+        resolve_merge_conflicts: false,
+        check_out_commit_options: CheckOutCommitOptions {
+            additional_args: Default::default(),
+            render_smartlog: false,
+        },
     };
+    let result = execute_rebase_plan(effects, git_run_info, &repo, &rebase_plan, &execute_options)?;
 
-    let (_success_commits, _merge_conflict_commits, _skipped_commits) = {
-        let mut success_commits: Vec<Commit> = Vec::new();
-        let mut merge_conflict_commits: Vec<Commit> = Vec::new();
-        let mut skipped_commits: Vec<Commit> = Vec::new();
+    let exit_code = match result {
+        ExecuteRebasePlanResult::Succeeded { rewritten_oids } => {
+            render_status_report(&repo, effects, &commits, &rewritten_oids)?;
 
-        let (effects, progress) = effects.start_operation(OperationType::RebaseCommits);
-        progress.notify_progress(0, subtree_roots_and_plans.len());
-
-        for (root_commit, rebase_plan) in subtree_roots_and_plans {
-            let rebase_plan = match rebase_plan {
-                Some(rebase_plan) => rebase_plan,
-                None => {
-                    // Nothing to do ... but why? Bug?
-                    skipped_commits.push(root_commit);
-                    continue;
-                }
-            };
-
-            let result = execute_rebase_plan(
-                &effects,
-                git_run_info,
-                &repo,
-                &rebase_plan,
-                &execute_options,
-            )?;
-            progress.notify_progress_inc(1);
-
-            match result {
-                ExecuteRebasePlanResult::Succeeded => {
-                    success_commits.push(root_commit);
-                }
-                ExecuteRebasePlanResult::DeclinedToMerge { merge_conflict: _ } => {
-                    // FIXME not sure this is even possible here...
-                    merge_conflict_commits.push(root_commit);
-                }
-                ExecuteRebasePlanResult::Failed { exit_code } => {
-                    return Ok(exit_code);
-                }
-            }
+            0
         }
+        ExecuteRebasePlanResult::DeclinedToMerge { merge_conflict: _ } => {
+            writeln!(
+                effects.get_error_stream(),
+                "BUG: Merge conflict detected, but rewording shouldn't cause any conflicts."
+            )?;
 
-        (success_commits, merge_conflict_commits, skipped_commits)
+            1
+        }
+        ExecuteRebasePlanResult::Failed { exit_code } => exit_code,
     };
 
-    // FIXME how much of this is relevant? User asked to reword commits, but we've rebased subtrees
-    // If we really want to show a relevant message perhaps it should be something like
-    // "executed X rebases to reword Y commits"?
-    //
-    // for success_commit in success_commits {
-    //     writeln!(
-    //         effects.get_output_stream(),
-    //         "{}",
-    //         printable_styled_string(
-    //             &glyphs,
-    //             StyledStringBuilder::new()
-    //                 .append_plain("Synced ")
-    //                 .append(success_commit.friendly_describe(&glyphs)?)
-    //                 .build()
-    //         )?
-    //     )?;
-    // }
-    //
-    // for merge_conflict_commit in merge_conflict_commits {
-    //     writeln!(
-    //         effects.get_output_stream(),
-    //         "{}",
-    //         printable_styled_string(
-    //             &glyphs,
-    //             StyledStringBuilder::new()
-    //                 .append_plain("Merge conflict for ")
-    //                 .append(merge_conflict_commit.friendly_describe(&glyphs)?)
-    //                 .build()
-    //         )?
-    //     )?;
-    // }
-    //
-    // for skipped_commit in skipped_commits {
-    //     writeln!(
-    //         effects.get_output_stream(),
-    //         "Not moving up-to-date stack at {}",
-    //         printable_styled_string(&glyphs, skipped_commit.friendly_describe(&glyphs)?)?
-    //     )?;
-    // }
-
-    Ok(0)
+    Ok(exit_code)
 }
 
 /// Turn a list of ref-ish strings into a list of Commits.
@@ -287,45 +201,37 @@ pub enum BuildRewordMessageResult {
 
     /// The reworded message was empty.
     EmptyMessage,
-
-    /// Misc failure.
-    Failed {
-        /// The failue message, if any.
-        message: Option<String>,
-    },
 }
 
 /// Builds the message(s) that will be used for rewording. These are mapped from each commit's
 /// NonZeroOid to the relevant message.
+#[instrument]
 fn build_messages(
     messages: &[String],
     commits: &[Commit],
+    comment_char: Option<u8>,
 ) -> eyre::Result<BuildRewordMessageResult> {
     let message = messages.join("\n\n").trim().to_string();
 
-    // TODO(maybe?) stdin?
-
     let (message, load_editor) = if message.is_empty() {
-        let message_for_editor = match commits.len() {
-            1 => {
-                // FIXME lots of error checking to do
-                let commit = commits.first().unwrap();
-                let msg = commit.get_message_raw()?;
-                let msg = msg.into_string();
-                match msg {
-                    Ok(msg) => msg,
-                    _ => {
-                        return Ok(BuildRewordMessageResult::Failed {
-                            message: Some(String::from(
-                                "Reword: Error decoding original commit message!",
-                            )),
-                        })
-                    }
-                }
-            }
-            len => {
-                // TODO build a bulk edit message for multiple commits
-                format!("Enter a commit message to apply to {} commits", len)
+        let message_for_editor = match commits.to_vec().as_slice() {
+            [commit] => match commit.get_message_raw()?.into_string() {
+                Ok(msg) => msg,
+                _ => eyre::bail!(
+                    "###
+                    Error decoding original message for commit: {:?}.
+                    Stopping; nothing reworded.
+                    ###",
+                    commit.get_oid()
+                ),
+            },
+            _ => {
+                // TODO(bulk edit) build a bulk edit message for multiple commits
+                format!(
+                    "{} Enter a commit message to apply to {} commits",
+                    comment_char.unwrap(),
+                    commits.len()
+                )
             }
         };
         (message_for_editor, true)
@@ -334,8 +240,10 @@ fn build_messages(
     };
 
     let message = if load_editor {
-        // Editor::edit will only return None if saving is required; b/c we've disabled the save
-        // requirement, we don't need to worry about it.
+        // Editor::edit() normally requires that the file being editted is saved before the editor
+        // is closed. If it's not, it will return None; and in all other cases, it will return
+        // Some(message). We don't care if the file has been saved, only if it hasn't changed, so
+        // here we call `require_save(false)` and just ignore the None case.
         let edited_message = Editor::new()
             .require_save(false)
             .edit(message.as_str())?
@@ -348,100 +256,103 @@ fn build_messages(
         message
     };
 
-    // TODO process the message: remove comment lines, trim, etc
+    // clean up the commit message: remove comment lines, finish w/ a newline, etc
+    // TODO ask if this should be here or if it should be moved to the git module per project wiki
+    let message = git2::message_prettify(message, comment_char)?;
 
-    if message.is_empty() {
+    if message.trim().is_empty() {
         return Ok(BuildRewordMessageResult::EmptyMessage);
     }
 
-    // TODO if the message appears to be a "bulk edit" message, break it apart
-    // TODO FIXME what if the bulk edit message doesn't include messages for != `commits.len`
-    // TODO FIXME what if the bulk edit message includes messages for commits not in `commits`
+    // TODO(bulk edit) process message if it looks like a bulk edit message
+    // - break it apart in separate messages
+    // - parse the marker lines into hashes
+    // - map hashes into NonZeroOid
+    // - create a map with OIDs as keys and relevant messages as values
+    // - confirm that we have edits for the right set of commits
+    //     - just those spec'd on the CLI, no more no less
+    //     - no duplicates
 
-    let messages: HashMap<NonZeroOid, String> = {
-        let mut m = HashMap::new();
-        for commit in commits.iter() {
-            m.insert(commit.get_oid(), message.clone());
-        }
-        m
-    };
+    let messages: HashMap<NonZeroOid, String> = commits
+        .iter()
+        .map(|commit| (commit.get_oid(), message.clone()))
+        .collect();
 
     Ok(BuildRewordMessageResult::Succeeded { messages })
 }
 
-/// Given a set of commits, remove all commits that have ancestors also in the set. In other words,
-/// leave behind only the commits that have *no* ancestors in the set. The idea is to find the
-/// minimum number of subtrees that much be rebased to include all of our rewording. This is
-/// similar to "greatest common ancestor" except that this is more like "greatest common ancestors
-/// for each subtree included in this set".
-///
-/// Example commit graph:
-/// a - b - c - d
-///  \   \- e - f
-///   \---- g - h
-///
-/// For example, given the above graph, the subtree roots should be this:
-/// - *query*      => *result*
-/// - `c, d`       => `c`
-/// - `d, f`       => `d, f`
-/// - `b, d, e`    => `b`
-/// - `b, c, e, g` => `b, g`
+/// Return the root commits for given a list of commits. This is the list of commits that have *no*
+/// ancestors also in the list. The idea is to find the minimum number of subtrees that much be
+/// rebased to include all of our rewording.
 fn find_subtree_roots<'repo>(
     repo: &'repo Repo,
     dag: &Dag,
     commits: &[Commit],
 ) -> eyre::Result<Vec<Commit<'repo>>> {
-    let mut subtree_roots: HashSet<NonZeroOid> = HashSet::new();
-    let commits: CommitSet = commits
-        .iter()
-        .map(|commit| commit.get_oid())
-        .rev()
+    let commits: CommitSet = commits.iter().map(|commit| commit.get_oid()).collect();
+
+    // Find the vertices representing the roots of this set of commits
+    let subtree_roots = dag
+        .query()
+        .roots(commits)
+        .wrap_err("Computing subtree roots")?;
+
+    // convert the vertices back into actual Commits
+    let root_commits = subtree_roots
+        .iter()?
+        .filter_map(|vertex| NonZeroOid::try_from(vertex.ok()?).ok())
+        .filter_map(|oid| repo.find_commit(oid).ok()?)
         .collect();
 
-    // create a working collection from our base collection of commits
-    let mut working_set = commits.clone();
+    Ok(root_commits)
+}
 
-    // iterate over each commit in working collection
-    let mut i = 0;
-    while !working_set.is_empty()? {
-        // get the first (aka "HEAD-iest") commit left in the set
-        let current_commit = CommitSet::from_static_names(working_set.first()?);
-
-        // get *all* ancestors of this commit
-        let all_ancestors = dag.query().ancestors(current_commit)?;
-
-        // which of these ancestors are relevant (ie are included in our base set of commits)
-        let relevant_ancestors = commits.intersection(&all_ancestors);
-        let relevant_ancestors = dag.query().sort(&relevant_ancestors)?;
-
-        // get the last commit from these relevant ancestors; it is the root of the subtree that
-        // contains current_commit (and convert it from a VertexName into a NonZeroOid)
-        let last_ancestor = NonZeroOid::try_from(relevant_ancestors.last()?.unwrap());
-        // TODO error check on the result of try_from
-        subtree_roots.insert(last_ancestor?);
-
-        // finally, remove these ancestors from our working set; we've already found their common
-        // root
-        working_set = working_set - relevant_ancestors;
-
-        // now finally finally, just cover our behind in case I really screwed something up!
-        i += 1;
-        if i == 100 {
-            println!("Bailing out after 100 loop iterations: this is either a REALLY big query or a bug.");
-            break;
-        }
+/// Print a basic status report of what commits were reworded.
+fn render_status_report(
+    repo: &Repo,
+    effects: &Effects,
+    commits: &[Commit],
+    rewritten_oids: &HashMap<NonZeroOid, MaybeZeroOid>,
+) -> eyre::Result<()> {
+    let glyphs = Glyphs::detect();
+    let num_commits = commits.len();
+    for original_commit in commits {
+        let replacement_oid = match rewritten_oids.get(&original_commit.get_oid()).unwrap() {
+            MaybeZeroOid::NonZero(new_oid) => new_oid,
+            MaybeZeroOid::Zero => {
+                warn!(
+                    "Encountered ZeroOid after success rewriting commit {}",
+                    original_commit.get_oid()
+                );
+                continue;
+            }
+        };
+        let replacement_commit = repo.find_commit(*replacement_oid)?.unwrap();
+        writeln!(
+            effects.get_output_stream(),
+            "Reworded commit {} as {}",
+            printable_styled_string(
+                &glyphs,
+                // Commit doesn't offer `friendly_describe_oid`, so we'll do it ourselves
+                render_node_descriptors(
+                    &glyphs,
+                    &NodeObject::Commit {
+                        commit: original_commit.clone(),
+                    },
+                    &mut [&mut CommitOidDescriptor::new(true)?],
+                )?
+            )?,
+            printable_styled_string(&glyphs, replacement_commit.friendly_describe(&glyphs)?)?
+        )?;
     }
 
-    // convert all of the NonZeroOid into actual Commits
-    let root_commits: Vec<Commit> = {
-        let mut commits = Vec::new();
-        for commit_oid in subtree_roots.into_iter() {
-            if let Some(commit) = repo.find_commit(commit_oid)? {
-                commits.push(commit)
-            }
-        }
-        commits
-    };
+    if num_commits != 1 {
+        writeln!(
+            effects.get_output_stream(),
+            "Reworded {} commits with same message. If this was unintentional, run: git undo",
+            num_commits,
+        )?;
+    }
 
-    Ok(root_commits)
+    Ok(())
 }

--- a/src/commands/reword.rs
+++ b/src/commands/reword.rs
@@ -1,0 +1,447 @@
+//! Update commit messages
+
+use rayon::ThreadPoolBuilder;
+use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
+use std::fmt::Write;
+use std::time::SystemTime;
+
+use dialoguer::{Confirm, Editor};
+use eden_dag::DagAlgorithm;
+use tracing::instrument;
+
+use crate::core::config::get_restack_preserve_timestamps;
+use crate::core::dag::{resolve_commits, CommitSet, Dag, ResolveCommitsResult};
+use crate::core::effects::{Effects, OperationType};
+use crate::core::eventlog::{EventLogDb, EventReplayer};
+use crate::core::rewrite::{
+    execute_rebase_plan, BuildRebasePlanError, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
+    ExecuteRebasePlanResult, RebasePlan, RebasePlanBuilder, RepoResource,
+};
+use crate::git::{Commit, GitRunInfo, NonZeroOid, Repo};
+use crate::opts::RebaseOptions;
+
+/// Reword a commit and restack it's descendants.
+#[instrument]
+pub fn reword(
+    effects: &Effects,
+    force: bool,
+    hashes: Vec<String>,
+    messages: Vec<String>,
+    git_run_info: &GitRunInfo,
+    rebase_options: &RebaseOptions,
+) -> eyre::Result<isize> {
+    let repo = Repo::from_current_dir()?;
+    let references_snapshot = repo.get_references_snapshot()?;
+    let conn = repo.get_db_conn()?;
+    let event_log_db = EventLogDb::new(&conn)?;
+    let event_replayer = EventReplayer::from_event_log_db(effects, &repo, &event_log_db)?;
+    let event_cursor = event_replayer.make_default_cursor();
+    let mut dag = Dag::open_and_sync(
+        effects,
+        &repo,
+        &event_replayer,
+        event_cursor,
+        &references_snapshot,
+    )?;
+
+    let commits = match resolve_commits_from_hashes(&repo, &mut dag, effects, hashes)? {
+        Some(commits) => commits,
+        None => return Ok(1),
+    };
+
+    let messages = match build_messages(&messages, &commits)? {
+        BuildRewordMessageResult::Succeeded { messages } => messages,
+        BuildRewordMessageResult::IdenticalMessage => {
+            println!("The message wasn't edited; nothing to do. Stopping.");
+            return Ok(1);
+        }
+        BuildRewordMessageResult::EmptyMessage => {
+            eprintln!("Error: the reworded message was empty. Stopping.");
+            return Ok(1);
+        }
+        BuildRewordMessageResult::Failed { message } => {
+            if message != None {
+                eprintln!("{}", message.unwrap());
+            }
+            eprintln!("Error: problem processing commit message. Nothing reworded.");
+            return Ok(1);
+        }
+    };
+
+    if commits.len() != 1
+        && !force
+        && !Confirm::new()
+            .with_prompt(format!(
+                "Warning: attempting to apply the same message to {} commits. Continue?",
+                commits.len()
+            ))
+            .default(false)
+            .interact()?
+    {
+        println!("Ok. Nothing reworded.");
+        return Ok(1);
+    }
+
+    let subtree_roots = find_subtree_roots(&repo, &dag, &commits)?;
+
+    // TODO instead of calling into `r#move` shoud we just be building the rebase plan ourselves?
+    // TODO look at `sync` to see how it handles return values for multiple subtree moves
+    // TODO what if there is no parent?
+    // TODO what if there are multiple parents?
+    let RebaseOptions {
+        force_in_memory,
+        force_on_disk,
+        detect_duplicate_commits_via_patch_id,
+        resolve_merge_conflicts,
+        dump_rebase_constraints,
+        dump_rebase_plan,
+    } = *rebase_options;
+
+    let subtree_roots_and_plans: Vec<(Commit, Option<RebasePlan>)> = {
+        let pool = ThreadPoolBuilder::new().build()?;
+        let repo_pool = RepoResource::new_pool(&repo)?;
+        let builder = RebasePlanBuilder::new(&dag);
+
+        let subtree_roots_and_plans =
+            subtree_roots
+                .into_iter()
+                .map(
+                    |root_commit| -> eyre::Result<
+                        Result<(Commit, Option<RebasePlan>), BuildRebasePlanError>,
+                    > {
+                        // Keep access to the same underlying caches by cloning the same instance of the
+                        // builder.
+                        let mut builder = builder.clone();
+
+                        let rebase_plan = {
+                            let only_parent_id =
+                                root_commit.get_only_parent().map(|parent| parent.get_oid());
+                            if only_parent_id == None {
+                                // TODO multiple parents!
+                            }
+                            builder.move_subtree(root_commit.get_oid(), only_parent_id.unwrap())?;
+                            builder.reword_commits(&messages)?;
+                            builder.build(
+                                effects,
+                                &pool,
+                                &repo_pool,
+                                &BuildRebasePlanOptions {
+                                    dump_rebase_constraints,
+                                    dump_rebase_plan,
+                                    detect_duplicate_commits_via_patch_id,
+                                },
+                            )?
+                        };
+
+                        Ok(rebase_plan.map(|rebase_plan| (root_commit, rebase_plan)))
+                    },
+                )
+                .collect::<eyre::Result<Vec<_>>>()?
+                .into_iter()
+                .collect::<Result<Vec<_>, BuildRebasePlanError>>();
+
+        match subtree_roots_and_plans {
+            Ok(subtree_roots_and_plans) => subtree_roots_and_plans,
+            Err(err) => {
+                err.describe(effects, &repo)?;
+                return Ok(1);
+            }
+        }
+    };
+
+    let now = SystemTime::now();
+    let event_tx_id = event_log_db.make_transaction_id(now, "reword")?;
+    let execute_options = ExecuteRebasePlanOptions {
+        now,
+        event_tx_id,
+        preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
+        force_in_memory,
+        force_on_disk,
+        resolve_merge_conflicts,
+        check_out_commit_options: Default::default(),
+    };
+
+    let (_success_commits, _merge_conflict_commits, _skipped_commits) = {
+        let mut success_commits: Vec<Commit> = Vec::new();
+        let mut merge_conflict_commits: Vec<Commit> = Vec::new();
+        let mut skipped_commits: Vec<Commit> = Vec::new();
+
+        let (effects, progress) = effects.start_operation(OperationType::RebaseCommits);
+        progress.notify_progress(0, subtree_roots_and_plans.len());
+
+        for (root_commit, rebase_plan) in subtree_roots_and_plans {
+            let rebase_plan = match rebase_plan {
+                Some(rebase_plan) => rebase_plan,
+                None => {
+                    // Nothing to do ... but why? Bug?
+                    skipped_commits.push(root_commit);
+                    continue;
+                }
+            };
+
+            let result = execute_rebase_plan(
+                &effects,
+                git_run_info,
+                &repo,
+                &rebase_plan,
+                &execute_options,
+            )?;
+            progress.notify_progress_inc(1);
+
+            match result {
+                ExecuteRebasePlanResult::Succeeded => {
+                    success_commits.push(root_commit);
+                }
+                ExecuteRebasePlanResult::DeclinedToMerge { merge_conflict: _ } => {
+                    // FIXME not sure this is even possible here...
+                    merge_conflict_commits.push(root_commit);
+                }
+                ExecuteRebasePlanResult::Failed { exit_code } => {
+                    return Ok(exit_code);
+                }
+            }
+        }
+
+        (success_commits, merge_conflict_commits, skipped_commits)
+    };
+
+    // FIXME how much of this is relevant? User asked to reword commits, but we've rebased subtrees
+    // If we really want to show a relevant message perhaps it should be something like
+    // "executed X rebases to reword Y commits"?
+    //
+    // for success_commit in success_commits {
+    //     writeln!(
+    //         effects.get_output_stream(),
+    //         "{}",
+    //         printable_styled_string(
+    //             &glyphs,
+    //             StyledStringBuilder::new()
+    //                 .append_plain("Synced ")
+    //                 .append(success_commit.friendly_describe(&glyphs)?)
+    //                 .build()
+    //         )?
+    //     )?;
+    // }
+    //
+    // for merge_conflict_commit in merge_conflict_commits {
+    //     writeln!(
+    //         effects.get_output_stream(),
+    //         "{}",
+    //         printable_styled_string(
+    //             &glyphs,
+    //             StyledStringBuilder::new()
+    //                 .append_plain("Merge conflict for ")
+    //                 .append(merge_conflict_commit.friendly_describe(&glyphs)?)
+    //                 .build()
+    //         )?
+    //     )?;
+    // }
+    //
+    // for skipped_commit in skipped_commits {
+    //     writeln!(
+    //         effects.get_output_stream(),
+    //         "Not moving up-to-date stack at {}",
+    //         printable_styled_string(&glyphs, skipped_commit.friendly_describe(&glyphs)?)?
+    //     )?;
+    // }
+
+    Ok(0)
+}
+
+/// Turn a list of ref-ish strings into a list of Commits.
+fn resolve_commits_from_hashes<'repo>(
+    repo: &'repo Repo,
+    dag: &mut Dag,
+    effects: &Effects,
+    hashes: Vec<String>,
+) -> eyre::Result<Option<Vec<Commit<'repo>>>> {
+    let hashes = if hashes.is_empty() {
+        vec!["HEAD".to_string()]
+    } else {
+        hashes
+    };
+
+    let commits = resolve_commits(effects, repo, dag, hashes)?;
+    let commits = match commits {
+        ResolveCommitsResult::Ok { commits } => commits,
+        ResolveCommitsResult::CommitNotFound { commit: hash } => {
+            writeln!(effects.get_output_stream(), "Commit not found: {}", hash)?;
+            return Ok(None);
+        }
+    };
+    Ok(Some(commits))
+}
+
+/// The result of building the reword message.
+#[must_use]
+pub enum BuildRewordMessageResult {
+    /// The reworded message was built successfully.
+    Succeeded {
+        /// The reworded messages for each commit.
+        messages: HashMap<NonZeroOid, String>,
+    },
+
+    /// The reworded message matches the original message.
+    IdenticalMessage,
+
+    /// The reworded message was empty.
+    EmptyMessage,
+
+    /// Misc failure.
+    Failed {
+        /// The failue message, if any.
+        message: Option<String>,
+    },
+}
+
+/// Builds the message(s) that will be used for rewording. These are mapped from each commit's
+/// NonZeroOid to the relevant message.
+fn build_messages(
+    messages: &[String],
+    commits: &[Commit],
+) -> eyre::Result<BuildRewordMessageResult> {
+    let message = messages.join("\n\n").trim().to_string();
+
+    // TODO(maybe?) stdin?
+
+    let (message, load_editor) = if message.is_empty() {
+        let message_for_editor = match commits.len() {
+            1 => {
+                // FIXME lots of error checking to do
+                let commit = commits.first().unwrap();
+                let msg = commit.get_message_raw()?;
+                let msg = msg.into_string();
+                match msg {
+                    Ok(msg) => msg,
+                    _ => {
+                        return Ok(BuildRewordMessageResult::Failed {
+                            message: Some(String::from(
+                                "Reword: Error decoding original commit message!",
+                            )),
+                        })
+                    }
+                }
+            }
+            len => {
+                // TODO build a bulk edit message for multiple commits
+                format!("Enter a commit message to apply to {} commits", len)
+            }
+        };
+        (message_for_editor, true)
+    } else {
+        (message, false)
+    };
+
+    let message = if load_editor {
+        // Editor::edit will only return None if saving is required; b/c we've disabled the save
+        // requirement, we don't need to worry about it.
+        let edited_message = Editor::new()
+            .require_save(false)
+            .edit(message.as_str())?
+            .unwrap();
+        if edited_message == message {
+            return Ok(BuildRewordMessageResult::IdenticalMessage);
+        }
+        edited_message
+    } else {
+        message
+    };
+
+    // TODO process the message: remove comment lines, trim, etc
+
+    if message.is_empty() {
+        return Ok(BuildRewordMessageResult::EmptyMessage);
+    }
+
+    // TODO if the message appears to be a "bulk edit" message, break it apart
+    // TODO FIXME what if the bulk edit message doesn't include messages for != `commits.len`
+    // TODO FIXME what if the bulk edit message includes messages for commits not in `commits`
+
+    let messages: HashMap<NonZeroOid, String> = {
+        let mut m = HashMap::new();
+        for commit in commits.iter() {
+            m.insert(commit.get_oid(), message.clone());
+        }
+        m
+    };
+
+    Ok(BuildRewordMessageResult::Succeeded { messages })
+}
+
+/// Given a set of commits, remove all commits that have ancestors also in the set. In other words,
+/// leave behind only the commits that have *no* ancestors in the set. The idea is to find the
+/// minimum number of subtrees that much be rebased to include all of our rewording. This is
+/// similar to "greatest common ancestor" except that this is more like "greatest common ancestors
+/// for each subtree included in this set".
+///
+/// Example commit graph:
+/// a - b - c - d
+///  \   \- e - f
+///   \---- g - h
+///
+/// For example, given the above graph, the subtree roots should be this:
+/// - *query*      => *result*
+/// - `c, d`       => `c`
+/// - `d, f`       => `d, f`
+/// - `b, d, e`    => `b`
+/// - `b, c, e, g` => `b, g`
+fn find_subtree_roots<'repo>(
+    repo: &'repo Repo,
+    dag: &Dag,
+    commits: &[Commit],
+) -> eyre::Result<Vec<Commit<'repo>>> {
+    let mut subtree_roots: HashSet<NonZeroOid> = HashSet::new();
+    let commits: CommitSet = commits
+        .iter()
+        .map(|commit| commit.get_oid())
+        .rev()
+        .collect();
+
+    // create a working collection from our base collection of commits
+    let mut working_set = commits.clone();
+
+    // iterate over each commit in working collection
+    let mut i = 0;
+    while !working_set.is_empty()? {
+        // get the first (aka "HEAD-iest") commit left in the set
+        let current_commit = CommitSet::from_static_names(working_set.first()?);
+
+        // get *all* ancestors of this commit
+        let all_ancestors = dag.query().ancestors(current_commit)?;
+
+        // which of these ancestors are relevant (ie are included in our base set of commits)
+        let relevant_ancestors = commits.intersection(&all_ancestors);
+        let relevant_ancestors = dag.query().sort(&relevant_ancestors)?;
+
+        // get the last commit from these relevant ancestors; it is the root of the subtree that
+        // contains current_commit (and convert it from a VertexName into a NonZeroOid)
+        let last_ancestor = NonZeroOid::try_from(relevant_ancestors.last()?.unwrap());
+        // TODO error check on the result of try_from
+        subtree_roots.insert(last_ancestor?);
+
+        // finally, remove these ancestors from our working set; we've already found their common
+        // root
+        working_set = working_set - relevant_ancestors;
+
+        // now finally finally, just cover our behind in case I really screwed something up!
+        i += 1;
+        if i == 100 {
+            println!("Bailing out after 100 loop iterations: this is either a REALLY big query or a bug.");
+            break;
+        }
+    }
+
+    // convert all of the NonZeroOid into actual Commits
+    let root_commits: Vec<Commit> = {
+        let mut commits = Vec::new();
+        for commit_oid in subtree_roots.into_iter() {
+            if let Some(commit) = repo.find_commit(commit_oid)? {
+                commits.push(commit)
+            }
+        }
+        commits
+    };
+
+    Ok(root_commits)
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -196,7 +196,7 @@ pub fn sync(
             )?;
             progress.notify_progress_inc(1);
             match result {
-                ExecuteRebasePlanResult::Succeeded => {
+                ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => {
                     success_commits.push(root_commit);
                 }
                 ExecuteRebasePlanResult::DeclinedToMerge { merge_conflict: _ } => {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -41,12 +41,12 @@ pub fn get_main_branch_name(repo: &Repo) -> eyre::Result<String> {
 
 /// Get the default comment character.
 #[instrument]
-pub fn get_comment_char(repo: &Repo) -> eyre::Result<Option<u8>> {
-    let config = repo.get_readonly_config()?;
-    let comment_char: Option<String> = config.get("core.commentChar")?;
-    let comment_char = match comment_char {
-        Some(c) => Some(c.chars().next().unwrap() as u8),
-        None => git2::DEFAULT_COMMENT_CHAR,
+pub fn get_comment_char(repo: &Repo) -> eyre::Result<char> {
+    let from_config: Option<String> = repo.get_readonly_config()?.get("core.commentChar")?;
+    let comment_char = match from_config {
+        // Note that git also allows `core.commentChar="auto"`, which we do not currently support.
+        Some(comment_char) => comment_char.chars().next().unwrap(),
+        None => git2::DEFAULT_COMMENT_CHAR.unwrap() as char,
     };
     Ok(comment_char)
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -30,6 +30,18 @@ pub fn get_main_branch_name(repo: &Repo) -> eyre::Result<String> {
     Ok(main_branch_name)
 }
 
+/// Get the default comment character.
+#[instrument]
+pub fn get_comment_char(repo: &Repo) -> eyre::Result<Option<u8>> {
+    let config = repo.get_readonly_config()?;
+    let comment_char: Option<String> = config.get("core.commentChar")?;
+    let comment_char = match comment_char {
+        Some(c) => Some(c.chars().next().unwrap() as u8),
+        None => git2::DEFAULT_COMMENT_CHAR,
+    };
+    Ok(comment_char)
+}
+
 /// Get the default init branch name.
 #[instrument]
 pub fn get_default_branch_name(repo: &Repo) -> eyre::Result<Option<String>> {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -9,9 +9,9 @@ mod tree;
 pub use config::{Config, ConfigRead, ConfigValue, ConfigWrite};
 pub use oid::{MaybeZeroOid, NonZeroOid};
 pub use repo::{
-    AmendFastOptions, Branch, CategorizedReferenceName, CherryPickFastError, CherryPickFastOptions,
-    Commit, Diff, FileStatus, GitVersion, PatchId, Reference, ReferenceTarget, Repo,
-    RepoReferencesSnapshot, ResolvedReferenceInfo, StatusEntry,
+    message_prettify, AmendFastOptions, Branch, CategorizedReferenceName, CherryPickFastError,
+    CherryPickFastOptions, Commit, Diff, FileStatus, GitVersion, PatchId, Reference,
+    ReferenceTarget, Repo, RepoReferencesSnapshot, ResolvedReferenceInfo, StatusEntry,
 };
 pub use run::{check_out_commit, CheckOutCommitOptions, GitRunInfo};
 pub use tree::Tree;

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -44,6 +44,14 @@ use crate::git::tree::{dehydrate_tree, get_changed_paths_between_trees, hydrate_
 pub(super) fn wrap_git_error(error: git2::Error) -> eyre::Error {
     eyre::eyre!("Git error {:?}: {}", error.code(), error.message())
 }
+
+/// Clean up a message, removing extraneous whitespace plus comment lines starting with
+/// `comment_char`, and ensure that the message ends with a newline.
+pub fn message_prettify(message: &str, comment_char: char) -> eyre::Result<String> {
+    let message = git2::message_prettify(message, Some(comment_char as u8))?;
+    Ok(message)
+}
+
 /// A snapshot of information about a certain reference. Updates to the
 /// reference after this value is obtained are not reflected.
 ///

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -48,41 +48,6 @@ pub struct MoveOptions {
     pub dump_rebase_plan: bool,
 }
 
-/// Options for rebasing commits. These are the same as MoveOptions, but without the shorthand -m.
-#[derive(Args, Debug)]
-pub struct RebaseOptions {
-    /// Only attempt to perform an in-memory rebase. If it fails, do not
-    /// attempt an on-disk rebase.
-    #[clap(long = "in-memory", conflicts_with_all(&["force-on-disk", "merge"]))]
-    pub force_in_memory: bool,
-
-    /// Skip attempting to use an in-memory rebase, and try an
-    /// on-disk rebase directly.
-    #[clap(long = "on-disk")]
-    pub force_on_disk: bool,
-
-    /// Don't attempt to deduplicate commits. Normally, a commit with the same
-    /// contents as another commit which has already been applied to the target
-    /// branch is skipped. If set, this flag skips that check.
-    #[clap(long = "no-deduplicate-commits", parse(from_flag = std::ops::Not::not))]
-    pub detect_duplicate_commits_via_patch_id: bool,
-
-    /// Attempt to resolve merge conflicts, if any. If a merge conflict
-    /// occurs and this option is not set, the operation is aborted.
-    #[clap(name = "merge", long = "merge")]
-    pub resolve_merge_conflicts: bool,
-
-    /// Debugging option. Print the constraints used to create the rebase
-    /// plan before executing it.
-    #[clap(long = "debug-dump-rebase-constraints")]
-    pub dump_rebase_constraints: bool,
-
-    /// Debugging option. Print the rebase plan that will be executed before
-    /// executing it.
-    #[clap(long = "debug-dump-rebase-plan")]
-    pub dump_rebase_plan: bool,
-}
-
 /// Options for traversing commits.
 #[derive(Args, Debug)]
 pub struct TraverseCommitsOptions {
@@ -318,25 +283,17 @@ pub enum Command {
         move_options: MoveOptions,
     },
 
-    /// Reword the current HEAD commit.
+    /// Reword commits.
     Reword {
-        /// Zero or more commits to reword.
+        /// Zero or more commits to reword. If not provided, defaults to "HEAD".
         ///
         /// Can either be hashes, like `abc123`, or ref-specs, like `HEAD^`.
         commits: Vec<String>,
 
         /// Message to apply to commits. Multiple messages will be combined as separate paragraphs,
-        /// similar to `git commit`
+        /// similar to `git commit`.
         #[clap(short = 'm', long = "message")]
         messages: Vec<String>,
-
-        /// Don't prompt for confirmation when rewording multiple commits.
-        #[clap(short = 'f', long = "force")]
-        force: bool,
-
-        /// Options for moving commits.
-        #[clap(flatten)]
-        rebase_options: RebaseOptions,
     },
 
     /// Display a nice graph of the commits you've recently worked on.

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -48,6 +48,41 @@ pub struct MoveOptions {
     pub dump_rebase_plan: bool,
 }
 
+/// Options for rebasing commits. These are the same as MoveOptions, but without the shorthand -m.
+#[derive(Args, Debug)]
+pub struct RebaseOptions {
+    /// Only attempt to perform an in-memory rebase. If it fails, do not
+    /// attempt an on-disk rebase.
+    #[clap(long = "in-memory", conflicts_with_all(&["force-on-disk", "merge"]))]
+    pub force_in_memory: bool,
+
+    /// Skip attempting to use an in-memory rebase, and try an
+    /// on-disk rebase directly.
+    #[clap(long = "on-disk")]
+    pub force_on_disk: bool,
+
+    /// Don't attempt to deduplicate commits. Normally, a commit with the same
+    /// contents as another commit which has already been applied to the target
+    /// branch is skipped. If set, this flag skips that check.
+    #[clap(long = "no-deduplicate-commits", parse(from_flag = std::ops::Not::not))]
+    pub detect_duplicate_commits_via_patch_id: bool,
+
+    /// Attempt to resolve merge conflicts, if any. If a merge conflict
+    /// occurs and this option is not set, the operation is aborted.
+    #[clap(name = "merge", long = "merge")]
+    pub resolve_merge_conflicts: bool,
+
+    /// Debugging option. Print the constraints used to create the rebase
+    /// plan before executing it.
+    #[clap(long = "debug-dump-rebase-constraints")]
+    pub dump_rebase_constraints: bool,
+
+    /// Debugging option. Print the rebase plan that will be executed before
+    /// executing it.
+    #[clap(long = "debug-dump-rebase-plan")]
+    pub dump_rebase_plan: bool,
+}
+
 /// Options for traversing commits.
 #[derive(Args, Debug)]
 pub struct TraverseCommitsOptions {
@@ -281,6 +316,27 @@ pub enum Command {
         /// Options for moving commits.
         #[clap(flatten)]
         move_options: MoveOptions,
+    },
+
+    /// Reword the current HEAD commit.
+    Reword {
+        /// Zero or more commits to reword.
+        ///
+        /// Can either be hashes, like `abc123`, or ref-specs, like `HEAD^`.
+        commits: Vec<String>,
+
+        /// Message to apply to commits. Multiple messages will be combined as separate paragraphs,
+        /// similar to `git commit`
+        #[clap(short = 'm', long = "message")]
+        messages: Vec<String>,
+
+        /// Don't prompt for confirmation when rewording multiple commits.
+        #[clap(short = 'f', long = "force")]
+        force: bool,
+
+        /// Options for moving commits.
+        #[clap(flatten)]
+        rebase_options: RebaseOptions,
     },
 
     /// Display a nice graph of the commits you've recently worked on.

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -68,12 +68,14 @@ fn test_move_stick() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     Pick {
                         commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -254,12 +256,14 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
                         },
                         Pick {
                             commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                            message: None,
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                         },
                         Pick {
                             commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                            message: None,
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -359,6 +363,7 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
@@ -434,12 +439,14 @@ fn test_move_base() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
                     },
                     Pick {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
@@ -565,6 +572,7 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
@@ -635,6 +643,7 @@ fn test_move_branch() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
@@ -824,6 +833,7 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
                     },
                     Pick {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        message: None,
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
@@ -1623,6 +1633,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                         },
                         Pick {
                             commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                            message: None,
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -67,15 +67,15 @@ fn test_move_stick() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                        message: None,
+                        original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
-                        message: None,
+                        original_commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        commit_to_apply_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -255,15 +255,15 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
                             ),
                         },
                         Pick {
-                            commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                            message: None,
+                            original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                            commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                         },
                         Pick {
-                            commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
-                            message: None,
+                            original_commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                            commit_to_apply_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -362,8 +362,8 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
-                        message: None,
+                        original_commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
+                        commit_to_apply_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
@@ -438,15 +438,15 @@ fn test_move_base() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
-                        message: None,
+                        original_commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        commit_to_apply_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                        message: None,
+                        original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
@@ -571,8 +571,8 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
-                        message: None,
+                        original_commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                        commit_to_apply_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
@@ -642,8 +642,8 @@ fn test_move_branch() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
-                        message: None,
+                        original_commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
+                        commit_to_apply_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
@@ -832,8 +832,8 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
                         ),
                     },
                     Pick {
-                        commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
-                        message: None,
+                        original_commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        commit_to_apply_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
@@ -1632,8 +1632,8 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                             ),
                         },
                         Pick {
-                            commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
-                            message: None,
+                            original_commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                            commit_to_apply_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),

--- a/tests/command/test_reword.rs
+++ b/tests/command/test_reword.rs
@@ -15,9 +15,9 @@ fn test_reword_head() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (test1) create test1.txt
+    O 62fc20d (test1) create test1.txt
     |
-    @ 96d1c37a (> master) create test2.txt
+    @ 96d1c37 (> master) create test2.txt
     "###);
 
     git.run(&["reword", "--message", "foo"])?;
@@ -25,9 +25,9 @@ fn test_reword_head() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (test1) create test1.txt
+    O 62fc20d (test1) create test1.txt
     |
-    @ c1f5400a (> master) foo
+    @ c1f5400 (> master) foo
     "###);
 
     Ok(())
@@ -49,9 +49,9 @@ fn test_reword_current_commit_not_head() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d2 (test1) create test1.txt
+    @ 62fc20d (test1) create test1.txt
     |
-    O 96d1c37a (master) create test2.txt
+    O 96d1c37 (master) create test2.txt
     "###);
 
     git.run(&["reword", "--message", "foo"])?;
@@ -59,9 +59,9 @@ fn test_reword_current_commit_not_head() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ a6f88684 (test1) foo
+    @ a6f8868 (test1) foo
     |
-    O 5207ad50 (master) create test2.txt
+    O 5207ad5 (master) create test2.txt
     "###);
 
     Ok(())
@@ -147,9 +147,9 @@ fn test_reword_non_head_commit() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (test1) create test1.txt
+    O 62fc20d (test1) create test1.txt
     |
-    @ 96d1c37a (> master) create test2.txt
+    @ 96d1c37 (> master) create test2.txt
     "###);
 
     git.run(&["reword", "HEAD^", "--message", "bar"])?;
@@ -157,9 +157,9 @@ fn test_reword_non_head_commit() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 8d4a670d (test1) bar
+    O 8d4a670 (test1) bar
     |
-    @ 8f7f70ea (> master) create test2.txt
+    @ 8f7f70e (> master) create test2.txt
     "###);
 
     Ok(())
@@ -180,9 +180,9 @@ fn test_reword_multiple_commits_on_same_branch() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (test1) create test1.txt
+    O 62fc20d (test1) create test1.txt
     |
-    @ 96d1c37a (> master) create test2.txt
+    @ 96d1c37 (> master) create test2.txt
     "###);
 
     let (_stdout, _stderr) = git.run(&["reword", "HEAD", "HEAD^", "--message", "foo"])?;
@@ -190,9 +190,9 @@ fn test_reword_multiple_commits_on_same_branch() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O a6f88684 (test1) foo
+    O a6f8868 (test1) foo
     |
-    @ e2308b39 (> master) foo
+    @ e2308b3 (> master) foo
     "###);
 
     Ok(())
@@ -218,13 +218,13 @@ fn test_reword_tree() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 96d1c37a (master) create test2.txt
+    O 96d1c37 (master) create test2.txt
     |
-    o 70deb1e2 create test3.txt
+    o 70deb1e create test3.txt
     |\
-    | o 355e173b create test4.txt
+    | o 355e173 create test4.txt
     |
-    @ 9ea1b368 create test5.txt
+    @ 9ea1b36 create test5.txt
     "###);
 
     let (_stdout, _stderr) = git.run(&["reword", &test3_oid.to_string(), "--message", "foo"])?;
@@ -232,13 +232,13 @@ fn test_reword_tree() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 96d1c37a (master) create test2.txt
+    O 96d1c37 (master) create test2.txt
     |
-    o 929b68d8 foo
+    o 929b68d foo
     |\
-    | o a3679359 create test4.txt
+    | o a367935 create test4.txt
     |
-    @ 38f9ce96 create test5.txt
+    @ 38f9ce9 create test5.txt
     "###);
 
     Ok(())
@@ -264,15 +264,15 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (master) create test1.txt
+    O 62fc20d (master) create test1.txt
     |\
-    | o 96d1c37a create test2.txt
+    | o 96d1c37 create test2.txt
     | |
-    | o 70deb1e2 create test3.txt
+    | o 70deb1e create test3.txt
     |
-    o bf0d52a6 create test4.txt
+    o bf0d52a create test4.txt
     |
-    @ 848121cb create test5.txt
+    @ 848121c create test5.txt
     "###);
 
     let (_stdout, _stderr) = git.run(&[
@@ -286,15 +286,15 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     let (stdout, _stderr) = git.run(&["smartlog"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d2 (master) create test1.txt
+    O 62fc20d (master) create test1.txt
     |\
-    | o c1f5400a foo
+    | o c1f5400 foo
     | |
-    | o 1c9ad631 create test3.txt
+    | o 1c9ad63 create test3.txt
     |
-    o 3c442fc0 foo
+    o 3c442fc foo
     |
-    @ 8648fbd2 create test5.txt
+    @ 8648fbd create test5.txt
     "###);
 
     Ok(())

--- a/tests/command/test_reword.rs
+++ b/tests/command/test_reword.rs
@@ -1,0 +1,233 @@
+use branchless::testing::make_git;
+
+#[test]
+fn test_reword_head() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["branch", "test1"])?;
+    git.commit_file("test2", 2)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (test1) create test1.txt
+    |
+    @ 96d1c37a (> master) create test2.txt
+    "###);
+
+    git.run(&["reword", "--message", "foo"])?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (test1) create test1.txt
+    |
+    @ b38039bd (> master) foo
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_reword_with_multiple_messages() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    62fc20d
+    create test1.txt
+    "###);
+
+    git.run(&["reword", "-m", "foo", "-m", "bar"])?;
+
+    let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    961064b
+    foo
+
+    bar
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_reword_non_head_commit() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["branch", "test1"])?;
+    git.commit_file("test2", 2)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (test1) create test1.txt
+    |
+    @ 96d1c37a (> master) create test2.txt
+    "###);
+
+    git.run(&["reword", "HEAD^", "--message", "bar"])?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 09b42f44 (test1) bar
+    |
+    @ 8ab8b750 (> master) create test2.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_reword_multiple_commits_on_same_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.run(&["branch", "test1"])?;
+    git.commit_file("test2", 2)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (test1) create test1.txt
+    |
+    @ 96d1c37a (> master) create test2.txt
+    "###);
+
+    let (_stdout, _stderr) =
+        git.run(&["reword", "HEAD", "HEAD^", "--message", "foo", "--force"])?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 5b4452da (test1) foo
+    |
+    @ 12217a2f (> master) foo
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_reword_tree() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.detach_head()?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+    git.run(&["checkout", &test3_oid.to_string()])?;
+    git.commit_file("test5", 5)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 96d1c37a (master) create test2.txt
+    |
+    o 70deb1e2 create test3.txt
+    |\
+    | o 355e173b create test4.txt
+    |
+    @ 9ea1b368 create test5.txt
+    "###);
+
+    let (_stdout, _stderr) = git.run(&["reword", &test3_oid.to_string(), "--message", "foo"])?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 96d1c37a (master) create test2.txt
+    |
+    o 4de8ed1a foo
+    |\
+    | o 93c8ffd1 create test4.txt
+    |
+    @ 92c4833c create test5.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_reword_across_branches() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+    git.run(&["checkout", &test1_oid.to_string()])?;
+    let test4_oid = git.commit_file("test4", 4)?;
+    git.commit_file("test5", 5)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (master) create test1.txt
+    |\
+    | o 96d1c37a create test2.txt
+    | |
+    | o 70deb1e2 create test3.txt
+    |
+    o bf0d52a6 create test4.txt
+    |
+    @ 848121cb create test5.txt
+    "###);
+
+    let (_stdout, _stderr) = git.run(&[
+        "reword",
+        &test2_oid.to_string(),
+        &test4_oid.to_string(),
+        "--message",
+        "foo",
+        "--force",
+    ])?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d2 (master) create test1.txt
+    |\
+    | o b38039bd foo
+    | |
+    | o 0c46d151 create test3.txt
+    |
+    o b376ed9e foo
+    |
+    @ a9fc71df create test5.txt
+    "###);
+
+    Ok(())
+}

--- a/tests/command/test_reword.rs
+++ b/tests/command/test_reword.rs
@@ -98,7 +98,7 @@ fn test_reword_with_multiple_messages() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_reword_removes_comment_lines_from_messages() -> eyre::Result<()> {
+fn test_reword_preserves_comment_lines_for_messages_on_cli() -> eyre::Result<()> {
     let git = make_git()?;
 
     if !git.supports_committer_date_is_author_date()? {
@@ -119,8 +119,12 @@ fn test_reword_removes_comment_lines_from_messages() -> eyre::Result<()> {
     // confirm the '#' messages aren't present
     let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
     insta::assert_snapshot!(stdout, @r###"
-    2666020
+    11a0c54
     foo
+
+    # bar
+
+    #
 
     buz
     "###);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,6 +14,7 @@ mod command {
     mod test_move;
     mod test_navigation;
     mod test_restack;
+    mod test_reword;
     mod test_smartlog;
     mod test_sync;
     mod test_undo;


### PR DESCRIPTION
**Updated PR description:**

This supports all of the use-cases that [I mentioned on #179](https://github.com/arxanas/git-branchless/issues/179#issuecomment-1071087014), except for the fancy bulk editing case. That is to say:

 - Reword single or multiple commits within or across subtrees.
 - Currently, the same message is applied to all commits.
 - If multiple message flags are given on the CLI, they are combined into separate paragraphs.
 - If no message flags are passed on the CLI, `$EDITOR` is opened w/ either the message of the commit being reworded (if just rewording a single commit) or a stub message when rewording multiple commits.
 - Bails out if the edited message is identical to the input message, or if it's blank.

A few things to make special note of:

 -  I'm still *very much* learning my way through Rust, so please let me know where I can improve my usage of the language or be more in line w/ the community or project. 
 -  I think I've taken a pretty good stab at error handling, but please keep a special eye out for possible places that I missed something or was over eager w/ my usage of `?` or `.unwrap()`, etc

Finally, there a few things left to do:

 -  [x] I haven't done anything to look at @epage request that it [operate independent of `branchless init`](https://github.com/arxanas/git-branchless/issues/179#issuecomment-955109646). At this time, I don't even know where to start w/ that, so any pointers would be most welcome.
 -  [x] The bulk editing feature is not implemented; I am voting :hand: for us to review this as is and add that later, though I'm also fine to push on to work on bulk editing now if you'd prefer.
 -  [x] During my latest read through, I decided that we should probably a "footer" message to the `$EDITOR` akin to the default `commit` message from `git`. I'll work on this soon.
 -  [x] I'd like to take another look through my error handling and borrow/clone/dereferencing/option/basically/everything usage again.

I *think* that covers most of it, but I'm sure I'm missing something! :smile:


**Original PR description below:**

Still *very* draft, but it's working for all of the use-cases that [I mentioned on #179](https://github.com/arxanas/git-branchless/issues/179#issuecomment-1071087014), except for the fancy bulk editing case. That is to say:

 - Reword single or multiple commits within or across subtrees.
 - Currently, the same message is applied to all commits.
 - If multiple message flags are given on the CLI, they are combined into separate paragraphs.
 - If no message flags are passed on the CLI, `$EDITOR` is opened w/ either the message of the commit being reworded (if just rewording a single commit) or a stub message when rewording multiple commits.
 - Prompt for confirmation when appling the same message to multiple commits. (`--force` flag skips confirmation.)
 - Bails out if the edited message is identical to the input message, or if it's blank.

So, lots to love there already, but still lots to do:

 -  I'm still *very much* learning my way through Rust, so expect lots of :man_facepalming: moments if you're brave enough to read through this, especially when it comes to borrowing, scope and such.
 - This is very "happy pathy" right now. I need to go back and flesh out the error handling.
 - ~~For expediency, I implemented this by altering `r#move::r#move` (rewording is kind of just a special case of moving, at least, it seems so to me) but I just did that so that I could focus on the fun parts and not get bogged down trying to figure out the plumbing. (It's just a 4 line change in `r#move`.) I intend to break this entanglement and move the actual rebase planning into `reword`, but it's still in place at this time. Because of this, though, it's doing a restack/smartlog for every subtree that's being reworded, instead of just doing a single restack and smartlog at the end.~~ **Edit:** I've removed the coupling w/ `r#move` and rewritten the rebase planning and execution based on `sync`.
 - Also note that I did not implement this via a new `RebaseCommand`,. eg `RebaseCommand::Reword`. Instead I just updated`RebaseCommand::Pick` to support an optional message since a reword is just a pick but with a different message and the change was trivial. I'm inclined to leave this in place unless you feel otherwise.
 - B/c reword is treated as just a special case of `move`, I wanted to reuse all of the normal `MoveOptions`, *but* I wanted to reserve the shorthand `-m` flag for `--messages`, not for `merge` as in `MoveOptions` ... so I just duplicated `MoveOptions` into `RebaseOption` except w/o the `-m` flag. This is still TBD, but I'd like a way to just reuse `MoveOptions` while overriding the binding of `-m`, but I haven't delved into how/if this can be done in clap.
 - I haven't done anything to look at @epage request that it [operate independent of `branchless init`](https://github.com/arxanas/git-branchless/issues/179#issuecomment-955109646). At this time, I don't even know where to start w/ that, so any pointers would be most welcome.
 - Bulk editting? I wonder if bulk editing might be best considered a feature unto itself. If so, this existing command could be finished off and proper bulk editing support (ie different messages for different commits) could be handled via a separate PR.

I'm going to park this here for a bit while I go away and read more about borrowing, Boxes, memory mgmt, error handling etc in Rust. :smile: I hesitate to even ask for input yet, but I think it would be good to know if I'm heading in the right direction or not. (And of course even if I'm way off base and this is just totally not viable, it was still a fun learning exercise!)

Oh, and I *totally* used this to squash all of my ugly working commits. This is a slightly edited version:

```
❯ ./target/debug/git-branchless reword --message 'hacking on `reword`' <base commit on branch>
❯ ./target/debug/git-branchless reword --message 'fixup! hacking on `reword`' <lots of descendent commits>
❯ git rebase --autosquash -i master 
❯ ./target/debug/git-branchless reword --message 'feat: implement `reword` command'
```

Thanks for your consideration!