### PR TITLE
Use git2 hash-shortening function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (#267) Aliases like `git amend` are now installed only if the user does not already have aliases with the same name. Thanks to @rslabbert for implementing this.
 - Improved performance up to 15x for `git restack` on large commit histories.
+- (#280) Use git2's get_short_oid function to avoide commit hash collision.
 
 ## [0.3.9] - 2022-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (#267) Aliases like `git amend` are now installed only if the user does not already have aliases with the same name. Thanks to @rslabbert for implementing this.
 - Improved performance up to 15x for `git restack` on large commit histories.
-- (#280) Use git2's get_short_oid function to avoide commit hash collision.
+- (#280) Ambiguous commit hashes are no longer printed in output. (Additional characters of the hash will be appended as necessary.) Thanks to @yujonglee for fixing this.
 
 ## [0.3.9] - 2022-02-08
 

--- a/src/core/node_descriptors.rs
+++ b/src/core/node_descriptors.rs
@@ -55,6 +55,16 @@ impl<'repo> NodeObject<'repo> {
             NodeObject::GarbageCollected { oid } => *oid,
         }
     }
+
+    fn get_short_oid(&self) -> eyre::Result<String> {
+        match self {
+            NodeObject::Commit { commit } => Ok(commit.get_short_oid()?),
+            NodeObject::GarbageCollected { oid } => {
+                // `7` is the default value for config setting `core.abbrev`.
+                Ok(oid.to_string()[..7].to_string())
+            }
+        }
+    }
 }
 
 /// Object responsible for redacting sensitive information, so that it can be
@@ -187,8 +197,7 @@ impl NodeDescriptor for CommitOidDescriptor {
         _glyphs: &Glyphs,
         object: &NodeObject,
     ) -> eyre::Result<Option<StyledString>> {
-        let oid = object.get_oid();
-        let oid = &oid.to_string()[..8];
+        let oid = object.get_short_oid()?;
         let oid = if self.use_color {
             StyledString::styled(oid, BaseColor::Yellow.dark())
         } else {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1354,6 +1354,11 @@ impl<'repo> Commit<'repo> {
         }
     }
 
+    /// Get the short object ID of the commit.
+    pub fn get_short_oid(&self) -> eyre::Result<String> {
+        Ok(String::from_utf8_lossy(&self.inner.clone().into_object().short_id()?).to_string())
+    }
+
     /// Get the object IDs of the parents of this commit.
     pub fn get_parent_oids(&self) -> Vec<NonZeroOid> {
         self.inner.parent_ids().map(make_non_zero_oid).collect()

--- a/src/git/run.rs
+++ b/src/git/run.rs
@@ -477,7 +477,7 @@ mod tests {
             let (stdout, stderr) = git.run(&["commit", "--amend", "-m", "foo"])?;
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 2 updates: branch master, ref HEAD
-            branchless: processed commit: f23bf8f7 foo
+            branchless: processed commit: f23bf8f foo
             Check if test1.txt exists
             test1.txt exists
             "###);

--- a/tests/command/test_amend.rs
+++ b/tests/command/test_amend.rs
@@ -22,18 +22,18 @@ fn test_amend_with_children() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> reset
         Attempting rebase in-memory...
-        [1/1] Committed as: b51f01b6 create test3.txt
+        [1/1] Committed as: b51f01b create test3.txt
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
         Finished restacking commits.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 7ac317b9 create test2.txt
+        @ 7ac317b create test2.txt
         |
-        o b51f01b6 create test3.txt
+        o b51f01b create test3.txt
         Amended with 1 uncommitted change.
         "###);
     }
@@ -52,7 +52,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
-        - (1 conflicting file) b51f01b6 create test3.txt
+        - (1 conflicting file) b51f01b create test3.txt
         To resolve merge conflicts, retry this operation with the --merge option.
         "###);
     }
@@ -76,11 +76,11 @@ fn test_amend_rename() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ f6b25538 create test2.txt
+        @ f6b2553 create test2.txt
         Amended with 2 staged changes.
         "###);
     }
@@ -112,11 +112,11 @@ fn test_amend_delete() -> eyre::Result<()> {
         branchless: running command: <git-executable> reset
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ f0f07277 create test2.txt
+        @ f0f0727 create test2.txt
         Amended with 1 uncommitted change.
         "###);
     }
@@ -155,11 +155,11 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ f8e4ba1b create test2.txt
+        @ f8e4ba1 create test2.txt
         Amended with 1 staged change. (Some uncommitted changes were not amended.)
         "###);
     }
@@ -170,11 +170,11 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
         branchless: running command: <git-executable> reset
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 2e69581c create test2.txt
+        @ 2e69581 create test2.txt
         Amended with 1 uncommitted change.
         "###);
     }
@@ -201,9 +201,9 @@ fn test_amend_head() -> eyre::Result<()> {
         branchless: running command: <git-executable> reset
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 3b98a960 create test1.txt
+        @ 3b98a96 create test1.txt
         Amended with 1 uncommitted change.
         "###);
     }
@@ -223,9 +223,9 @@ fn test_amend_head() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 685ef311 create test1.txt
+        @ 685ef31 create test1.txt
         Amended with 1 staged change.
         "###);
     }
@@ -256,11 +256,11 @@ fn test_amend_executable() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         No abandoned commits to restack.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ f00ec4b5 create test2.txt
+        @ f00ec4b create test2.txt
         Amended with 1 staged change.
         "###);
     }

--- a/tests/command/test_bug_report.rs
+++ b/tests/command/test_bug_report.rs
@@ -44,7 +44,7 @@ fn test_bug_report() -> eyre::Result<()> {
         1. `CommitEvent { timestamp: <redacted for test>, event_tx_id: EventTransactionId(4), commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f) }`
         ```
         :
-        @ 96d1c37a (> master) xxxxxx xxxxxxxxx
+        @ 96d1c37 (> master) xxxxxx xxxxxxxxx
         ```
         ##### Event ID: 4, transaction ID: 3
 
@@ -52,14 +52,14 @@ fn test_bug_report() -> eyre::Result<()> {
         1. `RefUpdateEvent { timestamp: <redacted for test>, event_tx_id: EventTransactionId(3), ref_name: "refs/heads/master", old_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e, new_oid: 96d1c37a3d4363611c49f7e52186e189a04c531f, message: None }`
         ```
         :
-        @ 96d1c37a (> master) xxxxxx xxxxxxxxx
+        @ 96d1c37 (> master) xxxxxx xxxxxxxxx
         ```
         ##### Event ID: 3, transaction ID: 2
 
         1. `CommitEvent { timestamp: <redacted for test>, event_tx_id: EventTransactionId(2), commit_oid: NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e) }`
         ```
         :
-        @ 96d1c37a (> master) xxxxxx xxxxxxxxx
+        @ 96d1c37 (> master) xxxxxx xxxxxxxxx
         ```
         ##### Event ID: 1, transaction ID: 1
 
@@ -67,12 +67,12 @@ fn test_bug_report() -> eyre::Result<()> {
         1. `RefUpdateEvent { timestamp: <redacted for test>, event_tx_id: EventTransactionId(1), ref_name: "refs/heads/master", old_oid: f777ecc9b0db5ed372b2615695191a8a17f79f24, new_oid: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e, message: None }`
         ```
         :
-        @ 96d1c37a (> master) xxxxxx xxxxxxxxx
+        @ 96d1c37 (> master) xxxxxx xxxxxxxxx
         ```
         There are no previous available events.
         ```
         :
-        @ 96d1c37a (> master) xxxxxx xxxxxxxxx
+        @ 96d1c37 (> master) xxxxxx xxxxxxxxx
         ```
 
         </details>

--- a/tests/command/test_hide.rs
+++ b/tests/command/test_hide.rs
@@ -14,18 +14,18 @@ fn test_hide_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |\
-            | o 62fc20d2 create test1.txt
-            |
-            @ fe65c1fe create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
     }
 
     {
         let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Hid commit: 62fc20d2 create test1.txt
+        Hid commit: 62fc20d create test1.txt
         To unhide this 1 commit, run: git undo
         "###);
     }
@@ -33,10 +33,10 @@ fn test_hide_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |
-            @ fe65c1fe create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
     }
 
     Ok(())
@@ -74,7 +74,7 @@ fn test_hide_already_hidden_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["hide", &test1_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Hid commit: 62fc20d2 create test1.txt
+        Hid commit: 62fc20d create test1.txt
         (It was already hidden, so this operation had no effect.)
         To unhide this 1 commit, run: git undo
         "###);
@@ -95,10 +95,10 @@ fn test_hide_current_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |
-            % 3df4b935 (manually hidden) create test.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |
+        % 3df4b93 (manually hidden) create test.txt
+        "###);
     }
 
     Ok(())
@@ -121,12 +121,12 @@ fn test_hidden_commit_with_head_as_child() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |
-            x 62fc20d2 (manually hidden) create test1.txt
-            |
-            @ 96d1c37a create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |
+        x 62fc20d (manually hidden) create test1.txt
+        |
+        @ 96d1c37 create test2.txt
+        "###);
     }
 
     Ok(())
@@ -150,7 +150,7 @@ fn test_hide_master_commit_with_hidden_children() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 20230db7 (> master) create test5.txt
+        @ 20230db (> master) create test5.txt
         "###);
     }
 
@@ -172,18 +172,18 @@ fn test_branches_always_visible() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        x 62fc20d2 (manually hidden) create test1.txt
+        x 62fc20d (manually hidden) create test1.txt
         |
-        x 96d1c37a (manually hidden) (test) create test2.txt
+        x 96d1c37 (manually hidden) (test) create test2.txt
         "###);
     }
 
     git.run(&["branch", "-D", "test"])?;
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc9 (> master) create initial.txt
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
 ");
     }
 
@@ -203,7 +203,7 @@ fn test_unhide() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Unhid commit: 96d1c37a create test2.txt
+        Unhid commit: 96d1c37 create test2.txt
         (It was not hidden, so this operation had no effect.)
         To hide this 1 commit, run: git undo
         "###);
@@ -213,16 +213,16 @@ fn test_unhide() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         "###);
     }
 
     {
         let (stdout, _stderr) = git.run(&["unhide", &test2_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Unhid commit: 96d1c37a create test2.txt
+        Unhid commit: 96d1c37 create test2.txt
         To hide this 1 commit, run: git undo
         "###);
     }
@@ -230,11 +230,11 @@ fn test_unhide() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         "###);
     }
 
@@ -255,21 +255,21 @@ fn test_hide_recursive() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         "###);
     }
 
     {
         let (stdout, _stderr) = git.run(&["hide", "-r", &test2_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Hid commit: 96d1c37a create test2.txt
-        Hid commit: 70deb1e2 create test3.txt
+        Hid commit: 96d1c37 create test2.txt
+        Hid commit: 70deb1e create test3.txt
         To unhide these 2 commits, run: git undo
         "###);
     }
@@ -277,17 +277,17 @@ fn test_hide_recursive() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         "###);
     }
 
     {
         let (stdout, _stderr) = git.run(&["unhide", "-r", &test2_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        Unhid commit: 96d1c37a create test2.txt
-        Unhid commit: 70deb1e2 create test3.txt
+        Unhid commit: 96d1c37 create test2.txt
+        Unhid commit: 70deb1e create test3.txt
         To hide these 2 commits, run: git undo
         "###);
     }
@@ -295,13 +295,13 @@ fn test_hide_recursive() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         "###);
     }
 

--- a/tests/command/test_init.rs
+++ b/tests/command/test_init.rs
@@ -54,7 +54,7 @@ echo Hello, world
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 2 updates: branch master, ref HEAD
         Hello, world
-        branchless: processed commit: 4cd1a9ba test
+        branchless: processed commit: 4cd1a9b test
         "###);
     }
 
@@ -69,13 +69,13 @@ fn test_alias_installed() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc9 (> master) create initial.txt
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
 ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["sl"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc9 (> master) create initial.txt
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
 ");
     }
 
@@ -285,7 +285,7 @@ fn test_init_prompt_for_main_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc9 (> bespoke) create initial.txt
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> bespoke) create initial.txt
 ");
     }
 
@@ -467,7 +467,7 @@ fn test_init_explicit_main_branch_name() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (> foo) create test1.txt
+        @ 62fc20d (> foo) create test1.txt
         "###);
     }
 
@@ -494,7 +494,7 @@ fn test_init_repo_default_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (> repo-default-branch) create test1.txt
+        @ 62fc20d (> repo-default-branch) create test1.txt
         "###);
     }
 

--- a/tests/command/test_move.rs
+++ b/tests/command/test_move.rs
@@ -35,13 +35,13 @@ fn test_move_stick() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | o 4838e49b create test3.txt
+        | o 4838e49 create test3.txt
         | |
-        | @ a2482074 create test4.txt
+        | @ a248207 create test4.txt
         |
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         "###);
     }
 
@@ -83,32 +83,32 @@ fn test_move_stick() -> eyre::Result<()> {
             },
         )
         Attempting rebase in-memory...
-        [1/2] Committed as: 4838e49b create test3.txt
-        [2/2] Committed as: a2482074 create test4.txt
+        [1/2] Committed as: 4838e49 create test3.txt
+        [2/2] Committed as: a248207 create test4.txt
         branchless: processing 2 rewritten commits
         branchless: running command: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | o 4838e49b create test3.txt
+        | o 4838e49 create test3.txt
         | |
-        | @ a2482074 create test4.txt
+        | @ a248207 create test4.txt
         |
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         In-memory rebase succeeded.
         "###);
 
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            :
-            O 62fc20d2 create test1.txt
-            |\
-            | o 4838e49b create test3.txt
-            | |
-            | @ a2482074 create test4.txt
-            |
-            O 96d1c37a (master) create test2.txt
-            "###);
+        :
+        O 62fc20d create test1.txt
+        |\
+        | o 4838e49 create test3.txt
+        | |
+        | @ a248207 create test4.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "###);
     }
 
     Ok(())
@@ -146,17 +146,17 @@ fn test_move_tree() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        O 62fc20d2 create test1.txt
-        |\
-        | o 4838e49b create test3.txt
-        | |\
-        | | o a2482074 create test4.txt
-        | |
-        | @ b1f9efa0 create test5.txt
-        |
-        O 96d1c37a (master) create test2.txt
-        "###);
+            :
+            O 62fc20d create test1.txt
+            |\
+            | o 4838e49 create test3.txt
+            | |\
+            | | o a248207 create test4.txt
+            | |
+            | @ b1f9efa create test5.txt
+            |
+            O 96d1c37 (master) create test2.txt
+            "###);
         }
     }
 
@@ -172,17 +172,17 @@ fn test_move_tree() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        O 62fc20d2 create test1.txt
-        |\
-        | o 4838e49b create test3.txt
-        | |\
-        | | o a2482074 create test4.txt
-        | |
-        | @ b1f9efa0 create test5.txt
-        |
-        O 96d1c37a (master) create test2.txt
-        "###);
+            :
+            O 62fc20d create test1.txt
+            |\
+            | o 4838e49 create test3.txt
+            | |\
+            | | o a248207 create test4.txt
+            | |
+            | @ b1f9efa create test5.txt
+            |
+            O 96d1c37 (master) create test2.txt
+            "###);
         }
     }
 
@@ -221,11 +221,11 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            : o 96d1c37a create test2.txt
+            : o 96d1c37 create test2.txt
             :
-            @ a2482074 (> master) create test4.txt
+            @ a248207 (> master) create test4.txt
             "###);
         }
     }
@@ -269,17 +269,17 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
                 },
             )
             Attempting rebase in-memory...
-            [1/2] Committed as: 4838e49b create test3.txt
-            [2/2] Committed as: a2482074 create test4.txt
+            [1/2] Committed as: 4838e49 create test3.txt
+            [2/2] Committed as: a248207 create test4.txt
             branchless: processing 1 update: branch master
             branchless: processing 2 rewritten commits
             branchless: running command: <git-executable> checkout master
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            : o 96d1c37a create test2.txt
+            : o 96d1c37 create test2.txt
             :
-            @ a2482074 (> master) create test4.txt
+            @ a248207 (> master) create test4.txt
             In-memory rebase succeeded.
             "###);
         }
@@ -288,11 +288,11 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            : o 96d1c37a create test2.txt
+            : o 96d1c37 create test2.txt
             :
-            @ a2482074 (> master) create test4.txt
+            @ a248207 (> master) create test4.txt
             "###);
         }
     }
@@ -326,7 +326,7 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
-        - (1 conflicting file) e85d25c7 create conflict.txt
+        - (1 conflicting file) e85d25c create conflict.txt
         To resolve merge conflicts, retry this operation with the --merge option.
         "###);
     }
@@ -369,7 +369,7 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
         )
         Attempting rebase in-memory...
         There was a merge conflict, which currently can't be resolved when rebasing in-memory.
-        The conflicting commit was: e85d25c7 create conflict.txt
+        The conflicting commit was: e85d25c create conflict.txt
         Trying again on-disk...
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
@@ -391,11 +391,11 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        @ 202143f2 create conflict.txt
+        @ 202143f create conflict.txt
         |
-        o 42951b5f create conflict.txt
+        o 42951b5 create conflict.txt
         "###);
     }
 
@@ -449,16 +449,16 @@ fn test_move_base() -> eyre::Result<()> {
             },
         )
         Attempting rebase in-memory...
-        [1/2] Committed as: 44352d00 create test2.txt
-        [2/2] Committed as: cf5eb244 create test3.txt
+        [1/2] Committed as: 44352d0 create test2.txt
+        [2/2] Committed as: cf5eb24 create test3.txt
         branchless: processing 2 rewritten commits
         branchless: running command: <git-executable> checkout master
         :
-        @ bf0d52a6 (> master) create test4.txt
+        @ bf0d52a (> master) create test4.txt
         |
-        o 44352d00 create test2.txt
+        o 44352d0 create test2.txt
         |
-        o cf5eb244 create test3.txt
+        o cf5eb24 create test3.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -467,11 +467,11 @@ fn test_move_base() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ bf0d52a6 (> master) create test4.txt
+        @ bf0d52a (> master) create test4.txt
         |
-        o 44352d00 create test2.txt
+        o 44352d0 create test2.txt
         |
-        o cf5eb244 create test3.txt
+        o cf5eb24 create test3.txt
         "###);
     }
 
@@ -506,19 +506,19 @@ fn test_move_base_shared() -> eyre::Result<()> {
         "###);
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/2] Committed as: 70deb1e2 create test3.txt
-        [2/2] Committed as: 355e173b create test4.txt
+        [1/2] Committed as: 70deb1e create test3.txt
+        [2/2] Committed as: 355e173 create test4.txt
         branchless: processing 2 rewritten commits
         branchless: running command: <git-executable> checkout 355e173bf9c5d2efac2e451da0cdad3fb82b869a
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        @ 355e173b create test4.txt
+        @ 355e173 create test4.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -526,15 +526,15 @@ fn test_move_base_shared() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        @ 355e173b create test4.txt
+        @ 355e173 create test4.txt
         "###);
     }
 
@@ -574,13 +574,13 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
             },
         )
         Attempting rebase in-memory...
-        [1/1] Committed as: 96d1c37a create test2.txt
+        [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        @ 96d1c37a create test2.txt
+        @ 96d1c37 create test2.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -588,11 +588,11 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            :
-            O 62fc20d2 (master) create test1.txt
-            |
-            @ 96d1c37a create test2.txt
-            "###);
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        @ 96d1c37 create test2.txt
+        "###);
     }
 
     Ok(())
@@ -644,12 +644,12 @@ fn test_move_branch() -> eyre::Result<()> {
             },
         )
         Attempting rebase in-memory...
-        [1/1] Committed as: 70deb1e2 create test3.txt
+        [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 update: branch master
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout master
         :
-        @ 70deb1e2 (> master) create test3.txt
+        @ 70deb1e (> master) create test3.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -658,7 +658,7 @@ fn test_move_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 70deb1e2 (> master) create test3.txt
+        @ 70deb1e (> master) create test3.txt
         "###);
     }
 
@@ -697,9 +697,9 @@ fn test_move_base_onto_head() -> eyre::Result<()> {
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
         This operation failed because it would introduce a cycle:
-        ,-> 70deb1e2 create test3.txt
-        |   96d1c37a create test2.txt
-        `-- 70deb1e2 create test3.txt
+        ,-> 70deb1e create test3.txt
+        |   96d1c37 create test2.txt
+        `-- 70deb1e create test3.txt
         "###);
     }
 
@@ -707,11 +707,11 @@ fn test_move_base_onto_head() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -744,7 +744,7 @@ fn test_move_force_in_memory() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
         There was a merge conflict, which currently can't be resolved when rebasing in-memory.
-        The conflicting commit was: 081b474b conflicting test2
+        The conflicting commit was: 081b474 conflicting test2
         Aborting since an in-memory rebase was requested.
         "###);
     }
@@ -833,14 +833,14 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
             },
         )
         Attempting rebase in-memory...
-        [1/1] Committed as: fe65c1fe create test2.txt
+        [1/1] Committed as: fe65c1f create test2.txt
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout fe65c1fe15584744e649b2c79d4cf9b0d878f92e
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         |
-        @ fe65c1fe create test2.txt
+        @ fe65c1f create test2.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -851,11 +851,11 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
         let (stdout, stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | @ 62fc20d2 create test1.txt
+        | @ 62fc20d create test1.txt
         |
-        o fe65c1fe create test2.txt
+        o fe65c1f create test2.txt
         "###);
     }
 
@@ -865,11 +865,11 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
         let (stdout, stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | @ 62fc20d2 create test1.txt
+        | @ 62fc20d create test1.txt
         |
-        o fe65c1fe create test2.txt
+        o fe65c1f create test2.txt
         "###);
     }
 
@@ -902,18 +902,18 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
         ])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/3] Committed as: 4838e49b create test3.txt
-        [2/3] Committed as: a2482074 create test4.txt
-        [3/3] Committed as: 566e4341 create test5.txt
+        [1/3] Committed as: 4838e49 create test3.txt
+        [2/3] Committed as: a248207 create test4.txt
+        [3/3] Committed as: 566e434 create test5.txt
         branchless: processing 1 update: branch master
         branchless: processing 3 rewritten commits
         branchless: running command: <git-executable> checkout master
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        : o 96d1c37a create test2.txt
+        : o 96d1c37 create test2.txt
         :
-        @ 566e4341 (> master) create test5.txt
+        @ 566e434 (> master) create test5.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -922,11 +922,11 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        : o 96d1c37a create test2.txt
+        : o 96d1c37 create test2.txt
         :
-        @ 566e4341 (> master) create test5.txt
+        @ 566e434 (> master) create test5.txt
         "###);
     }
 
@@ -1009,13 +1009,13 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 4838e49b create test3.txt
+            branchless: processed commit: 4838e49 create test3.txt
             Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: a2482074 create test4.txt
+            branchless: processed commit: a248207 create test4.txt
             Executing: git branchless hook-detect-empty-commit 355e173bf9c5d2efac2e451da0cdad3fb82b869a
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 566e4341 create test5.txt
+            branchless: processed commit: 566e434 create test5.txt
             Executing: git branchless hook-detect-empty-commit f81d55c0d520ff8d02ef9294d95156dcb78a5255
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 3 rewritten commits
@@ -1032,17 +1032,17 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        O 62fc20d2 create test1.txt
-        |\
-        | o 4838e49b (foo) create test3.txt
-        | |
-        | o a2482074 create test4.txt
-        | |
-        | @ 566e4341 (bar) create test5.txt
-        |
-        O 96d1c37a (master) create test2.txt
-        "###);
+            :
+            O 62fc20d create test1.txt
+            |\
+            | o 4838e49 (foo) create test3.txt
+            | |
+            | o a248207 create test4.txt
+            | |
+            | @ 566e434 (bar) create test5.txt
+            |
+            O 96d1c37 (master) create test2.txt
+            "###);
         }
 
         {
@@ -1057,15 +1057,15 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             No abandoned commits to restack.
             No abandoned branches to restack.
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            | o 4838e49b (foo) create test3.txt
+            | o 4838e49 (foo) create test3.txt
             | |
-            | o a2482074 create test4.txt
+            | o a248207 create test4.txt
             | |
-            | @ 566e4341 (bar) create test5.txt
+            | @ 566e434 (bar) create test5.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             "###);
         }
     }
@@ -1088,22 +1088,22 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             "###);
             insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
-            [1/3] Committed as: 4838e49b create test3.txt
-            [2/3] Committed as: a2482074 create test4.txt
-            [3/3] Committed as: 566e4341 create test5.txt
+            [1/3] Committed as: 4838e49 create test3.txt
+            [2/3] Committed as: a248207 create test4.txt
+            [3/3] Committed as: 566e434 create test5.txt
             branchless: processing 2 updates: branch bar, branch foo
             branchless: processing 3 rewritten commits
             branchless: running command: <git-executable> checkout 566e4341a4a9a930fc2bf7ccdfa168e9f266c34a
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            | o 4838e49b (foo) create test3.txt
+            | o 4838e49 (foo) create test3.txt
             | |
-            | o a2482074 create test4.txt
+            | o a248207 create test4.txt
             | |
-            | @ 566e4341 (bar) create test5.txt
+            | @ 566e434 (bar) create test5.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             In-memory rebase succeeded.
             "###);
         }
@@ -1112,15 +1112,15 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            | o 4838e49b (foo) create test3.txt
+            | o 4838e49 (foo) create test3.txt
             | |
-            | o a2482074 create test4.txt
+            | o a248207 create test4.txt
             | |
-            | @ 566e4341 (bar) create test5.txt
+            | @ 566e434 (bar) create test5.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             "###);
         }
 
@@ -1131,15 +1131,15 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             No abandoned commits to restack.
             No abandoned branches to restack.
             :
-            O 62fc20d2 create test1.txt
+            O 62fc20d create test1.txt
             |\
-            | o 4838e49b (foo) create test3.txt
+            | o 4838e49 (foo) create test3.txt
             | |
-            | o a2482074 create test4.txt
+            | o a248207 create test4.txt
             | |
-            | @ 566e4341 (bar) create test5.txt
+            | @ 566e434 (bar) create test5.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             "###);
         }
     }
@@ -1175,7 +1175,7 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-skip-upstream-applied-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: fa466332 create test2.txt
+            branchless: processed commit: fa46633 create test2.txt
             Executing: git branchless hook-detect-empty-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 2 rewritten commits
@@ -1183,20 +1183,20 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
             Successfully rebased and updated detached HEAD.
             "###);
             insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        Skipping commit (was already applied upstream): 62fc20d2 create test1.txt
-        "###);
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            Skipping commit (was already applied upstream): 62fc20d create test1.txt
+            "###);
         }
 
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 047b7ad7 (master) create test1.txt
+            O 047b7ad (master) create test1.txt
             |
-            @ fa466332 create test2.txt
+            @ fa46633 create test2.txt
             "###);
         }
     }
@@ -1214,15 +1214,15 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
         "###);
             insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
-            [1/2] Skipped commit (was already applied upstream): 62fc20d2 create test1.txt
-            [2/2] Committed as: fa466332 create test2.txt
+            [1/2] Skipped commit (was already applied upstream): 62fc20d create test1.txt
+            [2/2] Committed as: fa46633 create test2.txt
             branchless: processing 1 update: branch should-be-deleted
             branchless: processing 2 rewritten commits
             branchless: running command: <git-executable> checkout fa46633239bfa767036e41a77b67258286e4ddb9
             :
-            O 047b7ad7 (master) create test1.txt
+            O 047b7ad (master) create test1.txt
             |
-            @ fa466332 create test2.txt
+            @ fa46633 create test2.txt
             In-memory rebase succeeded.
             "###);
         }
@@ -1230,11 +1230,11 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        O 047b7ad7 (master) create test1.txt
-        |
-        @ fa466332 create test2.txt
-        "###);
+            :
+            O 047b7ad (master) create test1.txt
+            |
+            @ fa46633 create test2.txt
+            "###);
         }
     }
     Ok(())
@@ -1266,13 +1266,13 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 create initial.txt
+            O f777ecc create initial.txt
             |\
-            | o 62fc20d2 create test1.txt
+            | o 62fc20d create test1.txt
             | |
-            | o 96d1c37a create test2.txt
+            | o 96d1c37 create test2.txt
             |
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             "###);
         }
 
@@ -1293,10 +1293,10 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: e7bcdd60 create test1.txt
+            branchless: processed commit: e7bcdd6 create test1.txt
             Executing: git branchless hook-detect-empty-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 12d361aa create test2.txt
+            branchless: processed commit: 12d361a create test2.txt
             Executing: git branchless hook-detect-empty-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 4 rewritten commits
@@ -1304,23 +1304,23 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             Switched to branch 'master'
             branchless: processing checkout
             :
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             Successfully rebased and updated detached HEAD.
             "###);
             insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        Skipped now-empty commit: e7bcdd60 create test1.txt
-        Skipped now-empty commit: 12d361aa create test2.txt
-        "###);
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            Skipped now-empty commit: e7bcdd6 create test1.txt
+            Skipped now-empty commit: 12d361a create test2.txt
+            "###);
         }
 
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             "###);
         }
 
@@ -1335,13 +1335,13 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 create initial.txt
+            O f777ecc create initial.txt
             |\
-            | o 62fc20d2 create test1.txt
+            | o 62fc20d create test1.txt
             | |
-            | o 96d1c37a create test2.txt
+            | o 96d1c37 create test2.txt
             |
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             "###);
         }
 
@@ -1360,12 +1360,12 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
         "###);
             insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
-            [1/2] Skipped now-empty commit: e7bcdd60 create test1.txt
-            [2/2] Skipped now-empty commit: 12d361aa create test2.txt
+            [1/2] Skipped now-empty commit: e7bcdd6 create test1.txt
+            [2/2] Skipped now-empty commit: 12d361a create test2.txt
             branchless: processing 2 rewritten commits
             branchless: running command: <git-executable> checkout master
             :
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             In-memory rebase succeeded.
             "###);
         }
@@ -1374,7 +1374,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            @ de4a1fe8 (> master) squashed test1 and test2
+            @ de4a1fe (> master) squashed test1 and test2
             "###);
         }
     }
@@ -1406,15 +1406,15 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 create initial.txt
+        O f777ecc create initial.txt
         |\
-        : o 62fc20d2 create test1.txt
+        : o 62fc20d create test1.txt
         : |
-        : o 96d1c37a (work) create test2.txt
+        : o 96d1c37 (work) create test2.txt
         : |
-        : o ffcba554 (more-work) create test3.txt
+        : o ffcba55 (more-work) create test3.txt
         :
-        @ 91c5ce63 (> master) create test2.txt
+        @ 91c5ce6 (> master) create test2.txt
         "###);
     }
 
@@ -1430,7 +1430,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             Executing: git branchless hook-skip-upstream-applied-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             Executing: git branchless hook-skip-upstream-applied-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 012efd6e create test3.txt
+            branchless: processed commit: 012efd6 create test3.txt
             Executing: git branchless hook-detect-empty-commit ffcba554683d83de283de084a7d3896e332bbcdb
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 3 rewritten commits
@@ -1441,28 +1441,28 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             HEAD is now at 91c5ce6 create test2.txt
             branchless: processing checkout
             :
-            @ 91c5ce63 (master) create test2.txt
+            @ 91c5ce6 (master) create test2.txt
             |
-            o 012efd6e (more-work) create test3.txt
+            o 012efd6 (more-work) create test3.txt
             Successfully rebased and updated detached HEAD.
             "###);
             insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        Skipping commit (was already applied upstream): 62fc20d2 create test1.txt
-        Skipping commit (was already applied upstream): 96d1c37a create test2.txt
-        "###);
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            Skipping commit (was already applied upstream): 62fc20d create test1.txt
+            Skipping commit (was already applied upstream): 96d1c37 create test2.txt
+            "###);
         }
 
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        @ 91c5ce63 (master) create test2.txt
-        |
-        o 012efd6e (more-work) create test3.txt
-        "###);
+            :
+            @ 91c5ce6 (master) create test2.txt
+            |
+            o 012efd6 (more-work) create test3.txt
+            "###);
         }
     }
     // --in-memory
@@ -1479,16 +1479,16 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
         "###);
             insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
-            [1/3] Skipped commit (was already applied upstream): 62fc20d2 create test1.txt
-            [2/3] Skipped commit (was already applied upstream): 96d1c37a create test2.txt
-            [3/3] Committed as: 012efd6e create test3.txt
+            [1/3] Skipped commit (was already applied upstream): 62fc20d create test1.txt
+            [2/3] Skipped commit (was already applied upstream): 96d1c37 create test2.txt
+            [3/3] Committed as: 012efd6 create test3.txt
             branchless: processing 2 updates: branch more-work, branch work
             branchless: processing 3 rewritten commits
             branchless: running command: <git-executable> checkout 91c5ce63686889388daec1120bf57bea8a744bc2
             :
-            @ 91c5ce63 (master) create test2.txt
+            @ 91c5ce6 (master) create test2.txt
             |
-            o 012efd6e (more-work) create test3.txt
+            o 012efd6 (more-work) create test3.txt
             In-memory rebase succeeded.
             "###);
         }
@@ -1496,11 +1496,11 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        :
-        @ 91c5ce63 (master) create test2.txt
-        |
-        o 012efd6e (more-work) create test3.txt
-        "###);
+            :
+            @ 91c5ce6 (master) create test2.txt
+            |
+            o 012efd6 (more-work) create test3.txt
+            "###);
         }
     }
 
@@ -1560,17 +1560,17 @@ fn test_move_merge_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 create initial.txt
+        O f777ecc create initial.txt
         |\
-        | o fe65c1fe create test2.txt
+        | o fe65c1f create test2.txt
         | |
-        | o 28790c73 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+        | o 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
         |\
-        | @ 98b9119d create test3.txt
+        | @ 98b9119 create test3.txt
         | |
-        | o 28790c73 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+        | o 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
         |
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         "###);
     }
 
@@ -1649,7 +1649,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 96d1c37a create test2.txt
+            branchless: processed commit: 96d1c37 create test2.txt
             Executing: git branchless hook-detect-empty-commit fe65c1fe15584744e649b2c79d4cf9b0d878f92e
             branchless: processing 1 update: ref refs/rewritten/merge-parent-3
             Executing: git branchless hook-register-extra-post-rewrite-hook
@@ -1659,17 +1659,17 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             branchless: processing 1 update: ref HEAD
             HEAD is now at 98b9119 create test3.txt
             branchless: processing checkout
-            O f777ecc9 create initial.txt
+            O f777ecc create initial.txt
             |\
-            | @ 98b9119d create test3.txt
+            | @ 98b9119 create test3.txt
             | |
-            | o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            | o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             |
-            O 62fc20d2 (master) create test1.txt
+            O 62fc20d (master) create test1.txt
             |
-            o 96d1c37a create test2.txt
+            o 96d1c37 create test2.txt
             |
-            o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             Successfully rebased and updated detached HEAD.
             branchless: processing 1 update: ref refs/rewritten/merge-parent-3
             "###);
@@ -1678,18 +1678,18 @@ fn test_move_merge_commit() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 create initial.txt
-        |\
-        | @ 98b9119d create test3.txt
-        | |
-        | o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        |
-        O 62fc20d2 (master) create test1.txt
-        |
-        o 96d1c37a create test2.txt
-        |
-        o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        "###);
+            O f777ecc create initial.txt
+            |\
+            | @ 98b9119 create test3.txt
+            | |
+            | o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            |
+            O 62fc20d (master) create test1.txt
+            |
+            o 96d1c37 create test2.txt
+            |
+            o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            "###);
         }
     }
 
@@ -1713,11 +1713,11 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                 },
             )?;
             insta::assert_snapshot!(stdout, @r###"
-        Attempting rebase in-memory...
-        Merge commits currently can't be rebased in-memory.
-        The merge commit was: 28790c73 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        Aborting since an in-memory rebase was requested.
-        "###);
+            Attempting rebase in-memory...
+            Merge commits currently can't be rebased in-memory.
+            The merge commit was: 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            Aborting since an in-memory rebase was requested.
+            "###);
         }
     }
 
@@ -1727,18 +1727,18 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             let (stdout, stderr) =
                 git.run(&["move", "-s", &test2_oid.to_string(), "-d", "master"])?;
             insta::assert_snapshot!(stdout, @r###"
-        Attempting rebase in-memory...
-        Merge commits currently can't be rebased in-memory.
-        The merge commit was: 28790c73 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        Trying again on-disk...
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        "###);
+            Attempting rebase in-memory...
+            Merge commits currently can't be rebased in-memory.
+            The merge commit was: 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            Trying again on-disk...
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            "###);
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 96d1c37a create test2.txt
+            branchless: processed commit: 96d1c37 create test2.txt
             Executing: git branchless hook-detect-empty-commit fe65c1fe15584744e649b2c79d4cf9b0d878f92e
             branchless: processing 1 update: ref refs/rewritten/merge-parent-3
             Executing: git branchless hook-register-extra-post-rewrite-hook
@@ -1748,17 +1748,17 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             branchless: processing 1 update: ref HEAD
             HEAD is now at 98b9119 create test3.txt
             branchless: processing checkout
-            O f777ecc9 create initial.txt
+            O f777ecc create initial.txt
             |\
-            | @ 98b9119d create test3.txt
+            | @ 98b9119 create test3.txt
             | |
-            | o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            | o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             |
-            O 62fc20d2 (master) create test1.txt
+            O 62fc20d (master) create test1.txt
             |
-            o 96d1c37a create test2.txt
+            o 96d1c37 create test2.txt
             |
-            o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             Successfully rebased and updated detached HEAD.
             branchless: processing 1 update: ref refs/rewritten/merge-parent-3
             "###);
@@ -1767,18 +1767,18 @@ fn test_move_merge_commit() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 create initial.txt
-        |\
-        | @ 98b9119d create test3.txt
-        | |
-        | o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        |
-        O 62fc20d2 (master) create test1.txt
-        |
-        o 96d1c37a create test2.txt
-        |
-        o 96a2c4be Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-        "###);
+            O f777ecc create initial.txt
+            |\
+            | @ 98b9119 create test3.txt
+            | |
+            | o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            |
+            O 62fc20d (master) create test1.txt
+            |
+            o 96d1c37 create test2.txt
+            |
+            o 96a2c4b Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
+            "###);
         }
     }
 
@@ -1804,7 +1804,7 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         "###);
     }
 
@@ -1814,9 +1814,9 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
         // FIXME: the smartlog handling for unrelated roots is wrong. There
         // should be no relation between these two commits.
         insta::assert_snapshot!(stdout, @r###"
-        @ da90168b (> new-root) new root
+        @ da90168 (> new-root) new root
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         "###);
     }
 
@@ -1831,10 +1831,10 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 270b681e new root
+            branchless: processed commit: 270b681 new root
             Executing: git branchless hook-detect-empty-commit da90168b4835f97f1a10bcc12833140056df9157
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 70deb1e2 create test3.txt
+            branchless: processed commit: 70deb1e create test3.txt
             Executing: git branchless hook-detect-empty-commit fc09f3d9f0b7370dc38e761e3730a856dc5025c2
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 3 rewritten commits
@@ -1843,26 +1843,26 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             Switched to branch 'new-root'
             branchless: processing checkout
             :
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             |
-            @ 70deb1e2 (> new-root) create test3.txt
+            @ 70deb1e (> new-root) create test3.txt
             Successfully rebased and updated detached HEAD.
             "###);
             insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        Skipped now-empty commit: 270b681e new root
-        "###);
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            Skipped now-empty commit: 270b681 new root
+            "###);
         }
 
         {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             |
-            @ 70deb1e2 (> new-root) create test3.txt
+            @ 70deb1e (> new-root) create test3.txt
             "###);
         }
 
@@ -1883,15 +1883,15 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             "###);
             insta::assert_snapshot!(stdout, @r###"
             Attempting rebase in-memory...
-            [1/2] Skipped now-empty commit: 270b681e new root
-            [2/2] Committed as: 70deb1e2 create test3.txt
+            [1/2] Skipped now-empty commit: 270b681 new root
+            [2/2] Committed as: 70deb1e create test3.txt
             branchless: processing 1 update: branch new-root
             branchless: processing 2 rewritten commits
             branchless: running command: <git-executable> checkout new-root
             :
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             |
-            @ 70deb1e2 (> new-root) create test3.txt
+            @ 70deb1e (> new-root) create test3.txt
             In-memory rebase succeeded.
             "###);
         }
@@ -1900,9 +1900,9 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             let (stdout, _stderr) = git.run(&["smartlog"])?;
             insta::assert_snapshot!(stdout, @r###"
             :
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             |
-            @ 70deb1e2 (> new-root) create test3.txt
+            @ 70deb1e (> new-root) create test3.txt
             "###);
         }
     }
@@ -1924,7 +1924,7 @@ fn test_move_no_extra_checkout() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["move", "--in-memory", "-s", "HEAD", "-d", "HEAD^"])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/1] Committed as: 96d1c37a create test2.txt
+        [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
         "###);
@@ -1935,7 +1935,7 @@ fn test_move_no_extra_checkout() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["move", "--in-memory", "-s", "HEAD", "-d", "HEAD^"])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/1] Committed as: 96d1c37a create test2.txt
+        [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 update: branch foo
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
@@ -1974,13 +1974,13 @@ fn test_move_dest_not_in_dag() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["move", "-d", "origin/master"])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/1] Committed as: 70deb1e2 create test3.txt
+        [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 2 updates: branch other-branch, remote branch origin/other-branch
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout other-branch
         Your branch is up to date with 'origin/other-branch'.
         :
-        @ 70deb1e2 (> other-branch, remote origin/other-branch) create test3.txt
+        @ 70deb1e (> other-branch, remote origin/other-branch) create test3.txt
         In-memory rebase succeeded.
         "###);
     }
@@ -2049,7 +2049,7 @@ fn test_move_orig_head_no_symbolic_reference() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 96d1c37a (foo, master) create test2.txt
+        @ 96d1c37 (foo, master) create test2.txt
         "###);
     }
 
@@ -2064,9 +2064,9 @@ fn test_move_orig_head_no_symbolic_reference() -> eyre::Result<()> {
         // `foo` should be unmoved here, rather than moved to
         // `create test1.txt`.
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 create initial.txt
+        @ f777ecc create initial.txt
         :
-        O 96d1c37a (foo, master) create test2.txt
+        O 96d1c37 (foo, master) create test2.txt
         "###);
     }
 
@@ -2135,7 +2135,7 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
         let (stdout, stderr) = git.run(&["rebase", "--continue"])?;
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 1 update: ref HEAD
-        branchless: processed commit: 3632ef43 create test1.txt
+        branchless: processed commit: 3632ef4 create test1.txt
         Executing: git branchless hook-detect-empty-commit aec59174640c3e3dbb92fdade0bc44ca31552a85
         Executing: git branchless hook-register-extra-post-rewrite-hook
         branchless: processing 1 rewritten commit
@@ -2144,11 +2144,11 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
         Switched to branch 'master'
         branchless: processing checkout
         :
-        @ 62fc20d2 (> master) create test1.txt
+        @ 62fc20d (> master) create test1.txt
         |\
-        | o 6002762d create test1.txt
+        | o 6002762 create test1.txt
         |
-        o 3632ef43 create test1.txt
+        o 3632ef4 create test1.txt
         Successfully rebased and updated detached HEAD.
         "###);
         insta::assert_snapshot!(stdout, @r###"
@@ -2161,11 +2161,11 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (> master) create test1.txt
+        @ 62fc20d (> master) create test1.txt
         |\
-        | o 6002762d create test1.txt
+        | o 6002762 create test1.txt
         |
-        o 3632ef43 create test1.txt
+        o 3632ef4 create test1.txt
         "###);
     }
 

--- a/tests/command/test_navigation.rs
+++ b/tests/command/test_navigation.rs
@@ -23,9 +23,9 @@ fn test_prev() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24
-        @ f777ecc9 create initial.txt
+        @ f777ecc create initial.txt
         |
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         "###);
     }
 
@@ -45,9 +45,9 @@ fn test_prev() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc9 create initial.txt
+        @ f777ecc create initial.txt
         |
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         "###);
     }
 
@@ -66,9 +66,9 @@ fn test_prev_multiple() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24
-        @ f777ecc9 create initial.txt
+        @ f777ecc create initial.txt
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         "###);
     }
 
@@ -89,11 +89,11 @@ fn test_next_multiple() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 96d1c37a create test2.txt
+        @ 96d1c37 create test2.txt
         "###);
     }
 
@@ -125,9 +125,9 @@ fn test_next_ambiguous() -> eyre::Result<()> {
         )?;
         insta::assert_snapshot!(stdout, @r###"
         Found multiple possible child commits to go to after traversing 0 children:
-          - 62fc20d2 create test1.txt (oldest)
-          - fe65c1fe create test2.txt
-          - 98b9119d create test3.txt (newest)
+          - 62fc20d create test1.txt (oldest)
+          - fe65c1f create test2.txt
+          - 98b9119 create test3.txt (newest)
         (Pass --oldest (-o), --newest (-n), or --interactive (-i) to select between ambiguous commits)
         "###);
     }
@@ -136,13 +136,13 @@ fn test_next_ambiguous() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "--oldest"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | @ 62fc20d2 create test1.txt
+        | @ 62fc20d create test1.txt
         |\
-        | o fe65c1fe create test2.txt
+        | o fe65c1f create test2.txt
         |
-        o 98b9119d create test3.txt
+        o 98b9119 create test3.txt
         "###);
     }
 
@@ -151,13 +151,13 @@ fn test_next_ambiguous() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "--newest"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 98b9119d16974f372e76cb64a3b77c528fc0b18b
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         |\
-        | o fe65c1fe create test2.txt
+        | o fe65c1f create test2.txt
         |
-        @ 98b9119d create test3.txt
+        @ 98b9119 create test3.txt
         "###);
     }
 
@@ -187,7 +187,7 @@ fn test_next_ambiguous_interactive() -> eyre::Result<()> {
             PtyAction::WaitUntilContains("> "),
             PtyAction::Write("test2"),
             PtyAction::WaitUntilContains("> test2"),
-            PtyAction::WaitUntilContains("> fe65c1fe"),
+            PtyAction::WaitUntilContains("> fe65c1f"),
             PtyAction::Write(CARRIAGE_RETURN),
         ],
     )?;
@@ -195,13 +195,13 @@ fn test_next_ambiguous_interactive() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         |\
-        | @ fe65c1fe create test2.txt
+        | @ fe65c1f create test2.txt
         |
-        o 98b9119d create test3.txt
+        o 98b9119 create test3.txt
         "###);
     }
 
@@ -224,9 +224,9 @@ fn test_next_on_master() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -249,11 +249,11 @@ fn test_next_on_master2() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -277,9 +277,9 @@ fn test_next_no_more_children() -> eyre::Result<()> {
         No more child commits to go to after traversing 2 children.
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -306,20 +306,20 @@ fn test_checkout_pty() -> eyre::Result<()> {
             PtyAction::WaitUntilContains("> "),
             PtyAction::Write("test1"),
             PtyAction::WaitUntilContains("> test1"),
-            PtyAction::WaitUntilContains("> 62fc20d2"),
+            PtyAction::WaitUntilContains("> 62fc20d"),
             PtyAction::Write(CARRIAGE_RETURN),
         ],
     )?;
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | @ 62fc20d2 create test1.txt
+        | @ 62fc20d create test1.txt
         | |
-        | o 96d1c37a create test2.txt
+        | o 96d1c37 create test2.txt
         |
-        o 98b9119d create test3.txt
+        o 98b9119 create test3.txt
         "###);
     }
 
@@ -330,20 +330,20 @@ fn test_checkout_pty() -> eyre::Result<()> {
             PtyAction::WaitUntilContains("> "),
             PtyAction::Write("test3"),
             PtyAction::WaitUntilContains("> test3"),
-            PtyAction::WaitUntilContains("> 98b9119d"),
+            PtyAction::WaitUntilContains("> 98b9119"),
             PtyAction::Write(CARRIAGE_RETURN),
         ],
     )?;
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         | |
-        | o 96d1c37a create test2.txt
+        | o 96d1c37 create test2.txt
         |
-        @ 98b9119d create test3.txt
+        @ 98b9119 create test3.txt
         "###);
     }
 
@@ -371,11 +371,11 @@ fn test_checkout_abort() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 142901d5 create test2.txt
+        @ 142901d create test2.txt
         "###);
     }
 
@@ -519,13 +519,13 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev", "-a"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         "###);
     }
 
@@ -533,13 +533,13 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "-a"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -564,49 +564,49 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev", "-b", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout foo
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 96d1c37a (> foo) create test2.txt
+        @ 96d1c37 (> foo) create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        o 355e173b (bar) create test4.txt
+        o 355e173 (bar) create test4.txt
         |
-        o f81d55c0 create test5.txt
+        o f81d55c create test5.txt
         "###);
 
         let (stdout, _stderr) = git.run(&["prev", "-a", "-b"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout foo
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        @ 96d1c37a (> foo) create test2.txt
+        @ 96d1c37 (> foo) create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        o 355e173b (bar) create test4.txt
+        o 355e173 (bar) create test4.txt
         |
-        o f81d55c0 create test5.txt
+        o f81d55c create test5.txt
         "###);
 
         let (stdout, _stderr) = git.run(&["prev", "-b"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout master
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a (foo) create test2.txt
+        o 96d1c37 (foo) create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        o 355e173b (bar) create test4.txt
+        o 355e173 (bar) create test4.txt
         |
-        o f81d55c0 create test5.txt
+        o f81d55c create test5.txt
         "###);
     }
 
@@ -614,17 +614,17 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "-b", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout bar
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a (foo) create test2.txt
+        o 96d1c37 (foo) create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        @ 355e173b (> bar) create test4.txt
+        @ 355e173 (> bar) create test4.txt
         |
-        o f81d55c0 create test5.txt
+        o f81d55c create test5.txt
         "###);
     }
 
@@ -632,17 +632,17 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["next", "-a", "-b"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout bar
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 62fc20d2 create test1.txt
+        o 62fc20d create test1.txt
         |
-        o 96d1c37a (foo) create test2.txt
+        o 96d1c37 (foo) create test2.txt
         |
-        o 70deb1e2 create test3.txt
+        o 70deb1e create test3.txt
         |
-        @ 355e173b (> bar) create test4.txt
+        @ 355e173 (> bar) create test4.txt
         |
-        o f81d55c0 create test5.txt
+        o f81d55c create test5.txt
         "###);
     }
 
@@ -664,11 +664,11 @@ fn test_traverse_branches_ambiguous() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev", "--all", "--branch"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 62fc20d2 (bar, foo) create test1.txt
+        @ 62fc20d (bar, foo) create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         "###);
     }
 
@@ -730,11 +730,11 @@ fn test_checkout_pty_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (master) create test1.txt
+        @ 62fc20d (master) create test1.txt
         |\
-        | o 96d1c37a create test2.txt
+        | o 96d1c37 create test2.txt
         |
-        o 4838e49b create test3.txt
+        o 4838e49 create test3.txt
         "###);
     }
 
@@ -762,11 +762,11 @@ fn test_checkout_pty_initial_query() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         |
-        o 96d1c37a create test2.txt
+        o 96d1c37 create test2.txt
         "###);
     }
 
@@ -808,11 +808,11 @@ fn test_navigation_merge() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --merge
         M	conflicting.txt
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 25497cb0 create conflicting.txt
+        @ 25497cb create conflicting.txt
         |
-        o 6dd50913 create conflicting.txt
+        o 6dd5091 create conflicting.txt
         "###);
     }
 
@@ -870,11 +870,11 @@ fn test_navigation_force() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev", "--force"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --force
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 25497cb0 create conflicting.txt
+        @ 25497cb create conflicting.txt
         |
-        o 6dd50913 create conflicting.txt
+        o 6dd5091 create conflicting.txt
         "###);
     }
 
@@ -901,9 +901,9 @@ fn test_navigation_checkout_flags() -> eyre::Result<()> {
             insta::assert_snapshot!(stdout, @r###"
             branchless: running command: <git-executable> checkout HEAD^ -b foo
             :
-            @ 62fc20d2 (> foo) create test1.txt
+            @ 62fc20d (> foo) create test1.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             "###);
         }
 
@@ -912,9 +912,9 @@ fn test_navigation_checkout_flags() -> eyre::Result<()> {
             insta::assert_snapshot!(stdout, @r###"
             branchless: running command: <git-executable> checkout -b bar
             :
-            @ 62fc20d2 (> bar, foo) create test1.txt
+            @ 62fc20d (> bar, foo) create test1.txt
             |
-            O 96d1c37a (master) create test2.txt
+            O 96d1c37 (master) create test2.txt
             "###);
         }
     }
@@ -928,9 +928,9 @@ fn test_navigation_checkout_flags() -> eyre::Result<()> {
             insta::assert_snapshot!(stdout, @r###"
             branchless: running command: <git-executable> checkout HEAD~2 -f
             :
-            @ 62fc20d2 create test1.txt
+            @ 62fc20d create test1.txt
             :
-            O 5b738c1c (master) create test1.txt
+            O 5b738c1 (master) create test1.txt
             "###);
         }
     }
@@ -943,9 +943,9 @@ fn test_navigation_checkout_flags() -> eyre::Result<()> {
         branchless: running command: <git-executable> checkout HEAD~2 -m
         M	test1.txt
         :
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         :
-        O 5b738c1c (master) create test1.txt
+        O 5b738c1 (master) create test1.txt
         "###);
     }
 
@@ -961,7 +961,7 @@ fn test_navigation_checkout_target_only() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["branchless", "checkout", "master"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout master
-        @ f777ecc9 (> master) create initial.txt
+        @ f777ecc (> master) create initial.txt
         "###);
     }
 

--- a/tests/command/test_restack.rs
+++ b/tests/command/test_restack.rs
@@ -41,16 +41,16 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |\
-            | @ 024c35ce amend test1.txt
-            |
-            x 62fc20d2 (rewritten as 024c35ce) create test1.txt
-            |
-            o 96d1c37a create test2.txt
-            |
-            o 70deb1e2 create test3.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |\
+        | @ 024c35c amend test1.txt
+        |
+        x 62fc20d (rewritten as 024c35ce) create test1.txt
+        |
+        o 96d1c37 create test2.txt
+        |
+        o 70deb1e create test3.txt
+        "###);
     }
 
     {
@@ -62,13 +62,13 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Finished restacking commits.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 024c35ce amend test1.txt
+        @ 024c35c amend test1.txt
         |
-        o 8cd7de68 create test2.txt
+        o 8cd7de6 create test2.txt
         |
-        o b9a0491a create test3.txt
+        o b9a0491 create test3.txt
         "###);
     }
 
@@ -103,13 +103,13 @@ fn test_restack_consecutive_rewrites() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Finished restacking commits.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 662b451f amend test1.txt v2
+        @ 662b451 amend test1.txt v2
         |
-        o 8e9bbde3 create test2.txt
+        o 8e9bbde create test2.txt
         |
-        o 9dc6dd07 create test3.txt
+        o 9dc6dd0 create test3.txt
         "###)
     }
 
@@ -135,7 +135,7 @@ fn test_move_abandoned_branch() -> eyre::Result<()> {
         branchless: processing 1 update: branch master
         Finished restacking branches.
         :
-        @ 662b451f (master) amend test1.txt v2
+        @ 662b451 (master) amend test1.txt v2
         "###);
     }
 
@@ -160,12 +160,12 @@ fn test_amended_initial_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            @ 9a9f929a new initial commit
+        @ 9a9f929 new initial commit
 
-            X f777ecc9 (rewritten as 9a9f929a) create initial.txt
-            |
-            O 62fc20d2 (master) create test1.txt
-            "###);
+        X f777ecc (rewritten as 9a9f929a) create initial.txt
+        |
+        O 62fc20d (master) create test1.txt
+        "###);
     }
 
     {
@@ -177,9 +177,9 @@ fn test_amended_initial_commit() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Finished restacking commits.
         No abandoned branches to restack.
-        @ 9a9f929a new initial commit
+        @ 9a9f929 new initial commit
         |
-        O 6d85943b (master) create test1.txt
+        O 6d85943 (master) create test1.txt
         "###);
     }
 
@@ -212,9 +212,9 @@ fn test_restack_amended_master() -> eyre::Result<()> {
         Finished restacking commits.
         No abandoned branches to restack.
         :
-        @ ae94dc2a amended test1
+        @ ae94dc2 amended test1
         |
-        O 51452b55 (master) create test2.txt
+        O 51452b5 (master) create test2.txt
         "###);
     }
 
@@ -246,7 +246,7 @@ fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
-        - (1 conflicting file) 96d1c37a create test2.txt
+        - (1 conflicting file) 96d1c37 create test2.txt
         To resolve merge conflicts, retry this operation with the --merge option.
         "###);
     }
@@ -264,7 +264,7 @@ fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
         There was a merge conflict, which currently can't be resolved when rebasing in-memory.
-        The conflicting commit was: 96d1c37a create test2.txt
+        The conflicting commit was: 96d1c37 create test2.txt
         Trying again on-disk...
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
@@ -307,15 +307,15 @@ fn test_restack_multiple_amended() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Finished restacking commits.
         No abandoned branches to restack.
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         |
-        o 22f39285 test2 amended
+        o 22f3928 test2 amended
         |
-        o 8e06b96d test3 amended
+        o 8e06b96 test3 amended
         |
-        o f5644e32 create test4.txt
+        o f5644e3 create test4.txt
         "###);
     }
 
@@ -349,19 +349,19 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |\
-        | @ 3bd716d5 updated test4
+        | @ 3bd716d updated test4
         |\
-        | o 7357d2b7 updated test2
+        | o 7357d2b updated test2
         |\
-        | x 96d1c37a (rewritten as 7357d2b7) create test2.txt
+        | x 96d1c37 (rewritten as 7357d2b7) create test2.txt
         | |
-        | o 70deb1e2 create test3.txt
+        | o 70deb1e create test3.txt
         |
-        x bf0d52a6 (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d5) create test4.txt
         |
-        o 848121cb create test5.txt
+        o 848121c create test5.txt
         "###);
     }
 
@@ -370,7 +370,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: ref HEAD
-        branchless: processed commit: 944f78da create test3.txt
+        branchless: processed commit: 944f78d create test3.txt
         Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
         Executing: git branchless hook-register-extra-post-rewrite-hook
         branchless: processing 1 rewritten commit
@@ -380,17 +380,17 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         HEAD is now at 3bd716d updated test4
         branchless: processing checkout
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |\
-        | @ 3bd716d5 updated test4
+        | @ 3bd716d updated test4
         |\
-        | o 7357d2b7 updated test2
+        | o 7357d2b updated test2
         | |
-        | o 944f78da create test3.txt
+        | o 944f78d create test3.txt
         |
-        x bf0d52a6 (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d5) create test4.txt
         |
-        o 848121cb create test5.txt
+        o 848121c create test5.txt
         Successfully rebased and updated detached HEAD.
         "###);
         insta::assert_snapshot!(stdout, @r###"
@@ -400,17 +400,17 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         Finished restacking commits.
         No abandoned branches to restack.
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |\
-        | @ 3bd716d5 updated test4
+        | @ 3bd716d updated test4
         |\
-        | o 7357d2b7 updated test2
+        | o 7357d2b updated test2
         | |
-        | o 944f78da create test3.txt
+        | o 944f78d create test3.txt
         |
-        x bf0d52a6 (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d5) create test4.txt
         |
-        o 848121cb create test5.txt
+        o 848121c create test5.txt
         "###);
     }
 
@@ -438,11 +438,11 @@ fn test_restack_unobserved_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        o 96d1c37a (foo) create test2.txt
+        o 96d1c37 (foo) create test2.txt
         |
-        @ 70deb1e2 create test3.txt
+        @ 70deb1e create test3.txt
         "###);
     }
 
@@ -454,9 +454,9 @@ fn test_restack_unobserved_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        @ f4229de3 (> foo) Updated test2
+        @ f4229de (> foo) Updated test2
         "###);
     }
 
@@ -466,9 +466,9 @@ fn test_restack_unobserved_commit() -> eyre::Result<()> {
         No abandoned commits to restack.
         No abandoned branches to restack.
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         |
-        @ f4229de3 (> foo) Updated test2
+        @ f4229de (> foo) Updated test2
         "###);
     }
 
@@ -492,7 +492,7 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["restack"])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/1] Committed as: 59e75818 create test2.txt
+        [1/1] Committed as: 59e7581 create test2.txt
         branchless: processing 2 updates: branch foo, branch master
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout foo
@@ -500,7 +500,7 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
         Finished restacking commits.
         No abandoned branches to restack.
         :
-        @ 59e75818 (> foo, master) create test2.txt
+        @ 59e7581 (> foo, master) create test2.txt
         "###);
     }
 

--- a/tests/command/test_smartlog.rs
+++ b/tests/command/test_smartlog.rs
@@ -10,7 +10,7 @@ fn test_init_smartlog() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc9 (> master) create initial.txt
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
 ");
     }
 
@@ -28,9 +28,9 @@ fn test_show_reachable_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        @ 3df4b935 (> initial-branch) create test.txt
+        @ 3df4b93 (> initial-branch) create test.txt
         "###);
     }
 
@@ -51,11 +51,11 @@ fn test_tree() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         |
-        @ fe65c1fe (> initial) create test2.txt
+        @ fe65c1f (> initial) create test2.txt
         "###);
     }
 
@@ -77,12 +77,12 @@ fn test_rebase() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |
-            o 62fc20d2 (test1) create test1.txt
-            |
-            @ f8d9985b create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d (test1) create test1.txt
+        |
+        @ f8d9985 create test2.txt
+        "###);
     }
 
     Ok(())
@@ -101,7 +101,7 @@ fn test_sequential_master_commits() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 70deb1e2 (> master) create test3.txt
+        @ 70deb1e (> master) create test3.txt
         "###);
     }
 
@@ -130,17 +130,17 @@ fn test_merge_commit() -> eyre::Result<()> {
         // Rendering here is arbitrary and open to change.
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |\
-        | o 62fc20d2 (test1) create test1.txt
+        | o 62fc20d (test1) create test1.txt
         | |
-        | @ fa4e4e1a (> test2and3) Merge branch 'test1' into test2and3
+        | @ fa4e4e1 (> test2and3) Merge branch 'test1' into test2and3
         |
-        o fe65c1fe create test2.txt
+        o fe65c1f create test2.txt
         |
-        o 02067177 create test3.txt
+        o 0206717 create test3.txt
         |
-        @ fa4e4e1a (> test2and3) Merge branch 'test1' into test2and3
+        @ fa4e4e1 (> test2and3) Merge branch 'test1' into test2and3
         "###);
     }
 
@@ -171,11 +171,11 @@ fn test_rebase_conflict() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 (master) create initial.txt
+        O f777ecc (master) create initial.txt
         |
-        o 88646b56 (branch1) create test.txt
+        o 88646b5 (branch1) create test.txt
         |
-        @ 4549af33 (> branch2) create test.txt
+        @ 4549af3 (> branch2) create test.txt
         "###);
     }
 
@@ -198,14 +198,14 @@ fn test_non_adjacent_commits() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 create initial.txt
-            |\
-            : o 62fc20d2 create test1.txt
-            :
-            O 02067177 (master) create test3.txt
-            |
-            @ 8e62740b create test4.txt
-            "###);
+        O f777ecc create initial.txt
+        |\
+        : o 62fc20d create test1.txt
+        :
+        O 0206717 (master) create test3.txt
+        |
+        @ 8e62740 create test4.txt
+        "###);
     }
 
     Ok(())
@@ -228,16 +228,16 @@ fn test_non_adjacent_commits2() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 create initial.txt
-            |\
-            : o 62fc20d2 create test1.txt
-            : |
-            : o 96d1c37a create test2.txt
-            :
-            O 2b633ed7 (master) create test4.txt
-            |
-            @ 13932989 create test5.txt
-            "###);
+        O f777ecc create initial.txt
+        |\
+        : o 62fc20d create test1.txt
+        : |
+        : o 96d1c37 create test2.txt
+        :
+        O 2b633ed (master) create test4.txt
+        |
+        @ 1393298 create test5.txt
+        "###);
     }
 
     Ok(())
@@ -263,15 +263,15 @@ fn test_non_adjacent_commits3() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | o 96d1c37a create test2.txt
+        | o 96d1c37 create test2.txt
         |
-        O 4838e49b create test3.txt
+        O 4838e49 create test3.txt
         |\
-        : o a2482074 create test4.txt
+        : o a248207 create test4.txt
         :
-        @ 500c9b3e (> master) create test6.txt
+        @ 500c9b3 (> master) create test6.txt
         "###);
     }
 
@@ -292,11 +292,11 @@ fn test_custom_main_branch() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            :
-            O 62fc20d2 (main) create test1.txt
-            |
-            @ 96d1c37a create test2.txt
-            "###);
+        :
+        O 62fc20d (main) create test1.txt
+        |
+        @ 96d1c37 create test2.txt
+        "###);
     }
 
     Ok(())
@@ -331,7 +331,7 @@ fn test_main_remote_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (remote origin/master) create test1.txt
+        @ 62fc20d (remote origin/master) create test1.txt
         "###);
     }
 
@@ -344,9 +344,9 @@ fn test_main_remote_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         |
-        O 96d1c37a (remote origin/master) create test2.txt
+        O 96d1c37 (remote origin/master) create test2.txt
         "###);
     }
 
@@ -367,14 +367,14 @@ fn test_show_rewritten_commit_hash() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 create initial.txt
-            |\
-            | @ 2ebe0950 test1 version 2
-            |
-            X 62fc20d2 (rewritten as 2ebe0950) create test1.txt
-            |
-            O 96d1c37a (master) create test2.txt
-            "###);
+        O f777ecc create initial.txt
+        |\
+        | @ 2ebe095 test1 version 2
+        |
+        X 62fc20d (rewritten as 2ebe0950) create test1.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "###);
     }
 
     Ok(())
@@ -394,7 +394,7 @@ fn test_smartlog_orphaned_root() -> eyre::Result<()> {
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 (master) create test1.txt
+        O 62fc20d (master) create test1.txt
         "###);
     }
 
@@ -418,11 +418,11 @@ fn test_show_hidden_commits() -> eyre::Result<()> {
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (master) create test1.txt
+        @ 62fc20d (master) create test1.txt
         |\
-        | x cb8137ad (manually hidden) amended test2
+        | x cb8137a (manually hidden) amended test2
         |
-        x 96d1c37a (rewritten as cb8137ad) create test2.txt
+        x 96d1c37 (rewritten as cb8137ad) create test2.txt
         "###);
     }
 
@@ -463,19 +463,19 @@ fn test_show_only_branches() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | o 96d1c37a (branch-2) create test2.txt
+        | o 96d1c37 (branch-2) create test2.txt
         |
-        O 4838e49b create test3.txt
+        O 4838e49 create test3.txt
         |\
-        : x a2482074 (manually hidden) (branch-4) create test4.txt
+        : x a248207 (manually hidden) (branch-4) create test4.txt
         :
-        O 8577a964 create test7.txt
+        O 8577a96 create test7.txt
         |\
-        | o e8b6a382 create test8.txt
+        | o e8b6a38 create test8.txt
         |
-        @ 1b854edc (> master) create test9.txt
+        @ 1b854ed (> master) create test9.txt
         "###);
     }
 
@@ -484,15 +484,15 @@ fn test_show_only_branches() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog", "--only-branches"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | o 96d1c37a (branch-2) create test2.txt
+        | o 96d1c37 (branch-2) create test2.txt
         |
-        O 4838e49b create test3.txt
+        O 4838e49 create test3.txt
         |\
-        : x a2482074 (manually hidden) (branch-4) create test4.txt
+        : x a248207 (manually hidden) (branch-4) create test4.txt
         :
-        @ 1b854edc (> master) create test9.txt
+        @ 1b854ed (> master) create test9.txt
         "###);
     }
 
@@ -530,7 +530,7 @@ fn test_active_non_head_main_branch_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 70deb1e2 (> master, remote origin/master) create test3.txt
+        @ 70deb1e (> master, remote origin/master) create test3.txt
         "###);
     }
 
@@ -540,9 +540,9 @@ fn test_active_non_head_main_branch_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 70deb1e2 (remote origin/master) create test3.txt
+        O 70deb1e (remote origin/master) create test3.txt
         |
-        @ 355e173b (> master) create test4.txt
+        @ 355e173 (> master) create test4.txt
         "###);
     }
 

--- a/tests/command/test_sync.rs
+++ b/tests/command/test_sync.rs
@@ -24,17 +24,17 @@ fn test_sync_basic() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-        O f777ecc9 create initial.txt
+        O f777ecc create initial.txt
         |\
-        | o 62fc20d2 create test1.txt
+        | o 62fc20d create test1.txt
         | |
-        | o 96d1c37a create test2.txt
+        | o 96d1c37 create test2.txt
         |
-        O 98b9119d create test3.txt
+        O 98b9119 create test3.txt
         |\
-        | o 2b633ed7 create test4.txt
+        | o 2b633ed create test4.txt
         |
-        @ 117e0866 (> master) create test5.txt
+        @ 117e086 (> master) create test5.txt
         "###);
     }
 
@@ -48,18 +48,18 @@ fn test_sync_basic() -> eyre::Result<()> {
         "###);
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/2] Committed as: 87c7a36c create test1.txt
-        [2/2] Committed as: 8ee4f266 create test2.txt
+        [1/2] Committed as: 87c7a36 create test1.txt
+        [2/2] Committed as: 8ee4f26 create test2.txt
         branchless: processing 2 rewritten commits
         branchless: running command: <git-executable> checkout master
         In-memory rebase succeeded.
         Attempting rebase in-memory...
-        [1/1] Committed as: d7e7e6c3 create test4.txt
+        [1/1] Committed as: d7e7e6c create test4.txt
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout master
         In-memory rebase succeeded.
-        Synced 62fc20d2 create test1.txt
-        Synced 2b633ed7 create test4.txt
+        Synced 62fc20d create test1.txt
+        Synced 2b633ed create test4.txt
         "###);
     }
 
@@ -67,13 +67,13 @@ fn test_sync_basic() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 117e0866 (> master) create test5.txt
+        @ 117e086 (> master) create test5.txt
         |\
-        | o 87c7a36c create test1.txt
+        | o 87c7a36 create test1.txt
         | |
-        | o 8ee4f266 create test2.txt
+        | o 8ee4f26 create test2.txt
         |
-        o d7e7e6c3 create test4.txt
+        o d7e7e6c create test4.txt
         "###);
     }
 
@@ -94,7 +94,7 @@ fn test_sync_up_to_date() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.run(&["sync"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @"Not moving up-to-date stack at 70deb1e2 create test3.txt
+        insta::assert_snapshot!(stdout, @"Not moving up-to-date stack at 70deb1e create test3.txt
 ");
     }
 
@@ -103,11 +103,11 @@ fn test_sync_up_to_date() -> eyre::Result<()> {
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/2] Committed as: 70deb1e2 create test3.txt
-        [2/2] Committed as: 355e173b create test4.txt
+        [1/2] Committed as: 70deb1e create test3.txt
+        [2/2] Committed as: 355e173 create test4.txt
         branchless: processing 2 rewritten commits
         In-memory rebase succeeded.
-        Synced 70deb1e2 create test3.txt
+        Synced 70deb1e create test3.txt
         "###);
     }
 
@@ -143,9 +143,9 @@ fn test_sync_pull() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 96d1c37a (master, remote origin/master) create test2.txt
+        O 96d1c37 (master, remote origin/master) create test2.txt
         |
-        @ 70deb1e2 (> foo) create test3.txt
+        @ 70deb1e (> foo) create test3.txt
         "###);
     }
 
@@ -155,7 +155,7 @@ fn test_sync_pull() -> eyre::Result<()> {
         branchless: running command: <git-executable> fetch --all
         Fetching origin
         Attempting rebase in-memory...
-        [1/1] Committed as: 8e521a10 create test3.txt
+        [1/1] Committed as: 8e521a1 create test3.txt
         branchless: processing 1 update: branch foo
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout foo
@@ -163,7 +163,7 @@ fn test_sync_pull() -> eyre::Result<()> {
         and have 2 and 2 different commits each, respectively.
           (use "git pull" to merge the remote branch into yours)
         In-memory rebase succeeded.
-        Synced 70deb1e2 create test3.txt
+        Synced 70deb1e create test3.txt
         "###);
     }
 
@@ -171,11 +171,11 @@ fn test_sync_pull() -> eyre::Result<()> {
         let (stdout, _stderr) = cloned_repo.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         |
-        O d2e18e38 (remote origin/master) create test5.txt
+        O d2e18e3 (remote origin/master) create test5.txt
         |
-        @ 8e521a10 (> foo) create test3.txt
+        @ 8e521a1 (> foo) create test3.txt
         "###);
     }
 
@@ -200,13 +200,13 @@ fn test_sync_specific_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 96d1c37a create test2.txt
+        O 96d1c37 create test2.txt
         |\
-        | o 70deb1e2 (foo) create test3.txt
+        | o 70deb1e (foo) create test3.txt
         |\
-        | o f57e36f5 (bar) create test4.txt
+        | o f57e36f (bar) create test4.txt
         |
-        @ d2e18e38 (> master) create test5.txt
+        @ d2e18e3 (> master) create test5.txt
         "###);
     }
 
@@ -214,12 +214,12 @@ fn test_sync_specific_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["sync", "foo"])?;
         insta::assert_snapshot!(stdout, @r###"
         Attempting rebase in-memory...
-        [1/1] Committed as: 8e521a10 create test3.txt
+        [1/1] Committed as: 8e521a1 create test3.txt
         branchless: processing 1 update: branch foo
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout master
         In-memory rebase succeeded.
-        Synced 70deb1e2 create test3.txt
+        Synced 70deb1e create test3.txt
         "###);
     }
 
@@ -227,13 +227,13 @@ fn test_sync_specific_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 96d1c37a create test2.txt
+        O 96d1c37 create test2.txt
         |\
-        | o f57e36f5 (bar) create test4.txt
+        | o f57e36f (bar) create test4.txt
         |
-        @ d2e18e38 (> master) create test5.txt
+        @ d2e18e3 (> master) create test5.txt
         |
-        o 8e521a10 (foo) create test3.txt
+        o 8e521a1 (foo) create test3.txt
         "###);
     }
 

--- a/tests/command/test_undo.rs
+++ b/tests/command/test_undo.rs
@@ -99,7 +99,7 @@ fn test_undo_help() -> eyre::Result<()> {
         )?;
         insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
-        │O f777ecc9 (master) create initial.txt                                                                                │
+        │O f777ecc (master) create initial.txt                                                                                 │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -163,7 +163,7 @@ fn test_undo_navigate() -> eyre::Result<()> {
         insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │@ 96d1c37a (master) create test2.txt                                                                                  │
+        │@ 96d1c37 (master) create test2.txt                                                                                   │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -180,16 +180,16 @@ fn test_undo_navigate() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 3 (event 4). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Check out from 62fc20d2 create test1.txt                                                                           │
-        │               to 96d1c37a create test2.txt                                                                           │
-        │2. Move branch master from 62fc20d2 create test1.txt                                                                  │
-        │                        to 96d1c37a create test2.txt                                                                  │
+        │1. Check out from 62fc20d create test1.txt                                                                            │
+        │               to 96d1c37 create test2.txt                                                                            │
+        │2. Move branch master from 62fc20d create test1.txt                                                                   │
+        │                        to 96d1c37 create test2.txt                                                                   │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
         insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │@ 96d1c37a (master) create test2.txt                                                                                  │
+        │@ 96d1c37 (master) create test2.txt                                                                                   │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -208,7 +208,7 @@ fn test_undo_navigate() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 4 (event 6). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Commit 96d1c37a create test2.txt                                                                                   │
+        │1. Commit 96d1c37 create test2.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
@@ -246,7 +246,7 @@ fn test_go_to_event() -> eyre::Result<()> {
     insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
-    │@ 96d1c37a (master) create test2.txt                                                                                  │
+    │@ 96d1c37 (master) create test2.txt                                                                                   │
     │                                                                                                                      │
     │                                                                                                                      │
     │                                                                                                                      │
@@ -265,16 +265,16 @@ fn test_go_to_event() -> eyre::Result<()> {
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
     │Repo after transaction 4 (event 6). Press 'h' for help, 'q' to quit.                                                  │
-    │1. Commit 96d1c37a create test2.txt                                                                                   │
+    │1. Commit 96d1c37 create test2.txt                                                                                    │
     │                                                                                                                      │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     "###);
     insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
-    │@ 62fc20d2 create test1.txt                                                                                           │
+    │@ 62fc20d create test1.txt                                                                                            │
     │|                                                                                                                     │
-    │O 96d1c37a (master) create test2.txt                                                                                  │
+    │O 96d1c37 (master) create test2.txt                                                                                   │
     │                                                                                                                      │
     │                                                                                                                      │
     │                                                                                                                      │
@@ -291,8 +291,8 @@ fn test_go_to_event() -> eyre::Result<()> {
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
     │Repo after transaction 1 (event 1). Press 'h' for help, 'q' to quit.                                                  │
-    │1. Check out from f777ecc9 create initial.txt                                                                         │
-    │               to 62fc20d2 create test1.txt                                                                           │
+    │1. Check out from f777ecc create initial.txt                                                                          │
+    │               to 62fc20d create test1.txt                                                                            │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     "###);
 
@@ -319,10 +319,10 @@ fn test_undo_hide() -> eyre::Result<()> {
         let (stdout, stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |
-            @ fe65c1fe create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
     }
 
     let event_cursor = run_select_past_event(
@@ -346,25 +346,25 @@ fn test_undo_hide() -> eyre::Result<()> {
     {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
-            Will apply these actions:
-            1. Create branch test1 at 62fc20d2 create test1.txt
+        Will apply these actions:
+        1. Create branch test1 at 62fc20d create test1.txt
 
-            2. Unhide commit 62fc20d2 create test1.txt
+        2. Unhide commit 62fc20d create test1.txt
 
-            Confirm? [yN] Applied 2 inverse events.
-            "###);
+        Confirm? [yN] Applied 2 inverse events.
+        "###);
         assert_eq!(exit_code, 0);
     }
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            O f777ecc9 (master) create initial.txt
-            |\
-            | o 62fc20d2 (test1) create test1.txt
-            |
-            @ fe65c1fe create test2.txt
-            "###);
+        O f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d (test1) create test1.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
     }
 
     Ok(())
@@ -404,17 +404,17 @@ fn test_undo_move_refs() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 96d1c37a create test2.txt
-                       to 62fc20d2 create test1.txt
-        2. Hide commit 96d1c37a create test2.txt
+        1. Check out from 96d1c37 create test2.txt
+                       to 62fc20d create test1.txt
+        2. Hide commit 96d1c37 create test2.txt
 
-        3. Move branch master from 96d1c37a create test2.txt
-                                to 62fc20d2 create test1.txt
+        3. Move branch master from 96d1c37 create test2.txt
+                                to 62fc20d create test1.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --detach
         :
-        @ 62fc20d2 create test1.txt
+        @ 62fc20d create test1.txt
         |
-        O 96d1c37a (master) create test2.txt
+        O 96d1c37 (master) create test2.txt
         Applied 3 inverse events.
         "###);
         assert_eq!(exit_code, 0);
@@ -423,9 +423,9 @@ fn test_undo_move_refs() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-            :
-            @ 62fc20d2 (master) create test1.txt
-            "###);
+        :
+        @ 62fc20d (master) create test1.txt
+        "###);
     }
 
     Ok(())
@@ -455,7 +455,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │% 62fc20d2 (manually hidden) (master) create test1.txt                                                                │
+        │% 62fc20d (manually hidden) (master) create test1.txt                                                                 │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -474,14 +474,14 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 3 (event 4). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Hide commit 62fc20d2 create test1.txt                                                                              │
+        │1. Hide commit 62fc20d create test1.txt                                                                               │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
         insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │@ 62fc20d2 (master) create test1.txt                                                                                  │
+        │@ 62fc20d (master) create test1.txt                                                                                   │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -500,7 +500,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 2 (event 3). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Commit 62fc20d2 create test1.txt                                                                                   │
+        │1. Commit 62fc20d create test1.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
@@ -508,7 +508,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │% 62fc20d2 (manually hidden) (master) create test1.txt                                                                │
+        │% 62fc20d (manually hidden) (master) create test1.txt                                                                 │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -527,14 +527,14 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 2 (event 2). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Hide commit 62fc20d2 create test1.txt                                                                              │
+        │1. Hide commit 62fc20d create test1.txt                                                                               │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
         insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
-        │@ 62fc20d2 (master) create test1.txt                                                                                  │
+        │@ 62fc20d (master) create test1.txt                                                                                   │
         │                                                                                                                      │
         │                                                                                                                      │
         │                                                                                                                      │
@@ -553,7 +553,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │Repo after transaction 1 (event 1). Press 'h' for help, 'q' to quit.                                                  │
-        │1. Commit 62fc20d2 create test1.txt                                                                                   │
+        │1. Commit 62fc20d create test1.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
         "###);
@@ -594,7 +594,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
     insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
-    │O 62fc20d2 (master) create test1.txt                                                                                  │
+    │O 62fc20d (master) create test1.txt                                                                                   │
     │                                                                                                                      │
     │                                                                                                                      │
     │                                                                                                                      │
@@ -629,20 +629,20 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 62fc20d2 create test1.txt
-                       to f777ecc9 create initial.txt
-        2. Delete branch bar at 62fc20d2 create test1.txt
+        1. Check out from 62fc20d create test1.txt
+                       to f777ecc create initial.txt
+        2. Delete branch bar at 62fc20d create test1.txt
 
-        3. Hide commit 62fc20d2 create test1.txt
+        3. Hide commit 62fc20d create test1.txt
 
-        4. Move branch master from 62fc20d2 create test1.txt
-                                to f777ecc9 create initial.txt
-        5. Delete branch foo at f777ecc9 create initial.txt
+        4. Move branch master from 62fc20d create test1.txt
+                                to f777ecc create initial.txt
+        5. Delete branch foo at f777ecc create initial.txt
 
         Confirm? [yN] branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --detach
-        @ f777ecc9 (foo) create initial.txt
+        @ f777ecc (foo) create initial.txt
         |
-        O 62fc20d2 (bar, master) create test1.txt
+        O 62fc20d (bar, master) create test1.txt
         Applied 5 inverse events.
         "###);
         assert_eq!(exit_code, 0);
@@ -684,7 +684,7 @@ fn test_git_bisect_produces_empty_event() -> eyre::Result<()> {
     insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
-    │@ 62fc20d2 (master) create test1.txt                                                                                  │
+    │@ 62fc20d (master) create test1.txt                                                                                   │
     │                                                                                                                      │
     │                                                                                                                      │
     │                                                                                                                      │
@@ -746,7 +746,7 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d2 (master) create test1.txt
+        @ 62fc20d (master) create test1.txt
         "###);
     }
 
@@ -765,9 +765,9 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
     insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
-    │O 62fc20d2 (master) create test1.txt                                                                                  │
+    │O 62fc20d (master) create test1.txt                                                                                   │
     │|                                                                                                                     │
-    │% 96d1c37a (manually hidden) <garbage collected>                                                                      │
+    │% 96d1c37 (manually hidden) <garbage collected>                                                                       │
     │                                                                                                                      │
     │                                                                                                                      │
     │                                                                                                                      │
@@ -794,12 +794,12 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 62fc20d2 create test1.txt
+        1. Check out from 62fc20d create test1.txt
                        to <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>
-        2. Move branch master from 62fc20d2 create test1.txt
-                                to 62fc20d2 create test1.txt
-        3. Move branch master from 62fc20d2 create test1.txt
-                                to 62fc20d2 create test1.txt
+        2. Move branch master from 62fc20d create test1.txt
+                                to 62fc20d create test1.txt
+        3. Move branch master from 62fc20d create test1.txt
+                                to 62fc20d create test1.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
         Applied 3 inverse events.
@@ -842,14 +842,14 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         )?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 9ed8f9a2 bad message
-                       to 96d1c37a create test2.txt
-        2. Rewrite commit 9ed8f9a2 bad message
-                      as 96d1c37a create test2.txt
-        3. Hide commit 9ed8f9a2 bad message
+        1. Check out from 9ed8f9a bad message
+                       to 96d1c37 create test2.txt
+        2. Rewrite commit 9ed8f9a bad message
+                      as 96d1c37 create test2.txt
+        3. Hide commit 9ed8f9a bad message
            
-        4. Move branch master from 9ed8f9a2 bad message
-                                to 96d1c37a create test2.txt
+        4. Move branch master from 9ed8f9a bad message
+                                to 96d1c37 create test2.txt
         Confirm? [yN] Aborted.
         "###);
     }
@@ -858,7 +858,7 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 9ed8f9a2 (> master) bad message
+        @ 9ed8f9a (> master) bad message
         "###);
     }
 
@@ -873,21 +873,21 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         let stdout = trim_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 9ed8f9a2 bad message
-                       to 96d1c37a create test2.txt
-        2. Rewrite commit 9ed8f9a2 bad message
-                      as 96d1c37a create test2.txt
-        3. Hide commit 9ed8f9a2 bad message
+        1. Check out from 9ed8f9a bad message
+                       to 96d1c37 create test2.txt
+        2. Rewrite commit 9ed8f9a bad message
+                      as 96d1c37 create test2.txt
+        3. Hide commit 9ed8f9a bad message
 
-        4. Move branch master from 9ed8f9a2 bad message
-                                to 96d1c37a create test2.txt
+        4. Move branch master from 9ed8f9a bad message
+                                to 96d1c37 create test2.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach
         :
-        O 62fc20d2 create test1.txt
+        O 62fc20d create test1.txt
         |\
-        | % 96d1c37a (rewritten as 9ed8f9a2) create test2.txt
+        | % 96d1c37 (rewritten as 9ed8f9a2) create test2.txt
         |
-        O 9ed8f9a2 (master) bad message
+        O 9ed8f9a (master) bad message
         Applied 4 inverse events.
         "###);
     }
@@ -896,7 +896,7 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 96d1c37a (master) create test2.txt
+        @ 96d1c37 (master) create test2.txt
         "###);
     }
 

--- a/tests/core/test_gc.rs
+++ b/tests/core/test_gc.rs
@@ -22,10 +22,10 @@ fn test_gc() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
-@ f777ecc9 (master) create initial.txt
-|
-o 62fc20d2 create test1.txt
-"###);
+        @ f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        "###);
     }
 
     git.run(&["hide", "62fc20d2"])?;
@@ -40,9 +40,8 @@ o 62fc20d2 create test1.txt
     git.run(&["gc", "--prune=now"])?;
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @r###"
-@ f777ecc9 (master) create initial.txt
-"###);
+        insta::assert_snapshot!(stdout, @"@ f777ecc (master) create initial.txt
+");
     }
 
     {

--- a/tests/core/test_hooks.rs
+++ b/tests/core/test_hooks.rs
@@ -23,7 +23,7 @@ fn test_abandoned_commit_message() -> eyre::Result<()> {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 2 updates: branch master, ref HEAD
-        branchless: processed commit: 9e8dbe91 amend test1
+        branchless: processed commit: 9e8dbe9 amend test1
         branchless: processing 1 rewritten commit
         "###);
     }
@@ -36,7 +36,7 @@ fn test_abandoned_commit_message() -> eyre::Result<()> {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1 again"])?;
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 1 update: ref HEAD
-        branchless: processed commit: c1e22fd6 amend test1 again
+        branchless: processed commit: c1e22fd amend test1 again
         branchless: processing 1 rewritten commit
         branchless: This operation abandoned 1 commit and 1 branch (master)!
         branchless: Consider running one of the following:
@@ -69,7 +69,7 @@ fn test_abandoned_branch_message() -> eyre::Result<()> {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
         insta::assert_snapshot!(stderr, @r###"
         branchless: processing 1 update: ref HEAD
-        branchless: processed commit: 9e8dbe91 amend test1
+        branchless: processed commit: 9e8dbe9 amend test1
         branchless: processing 1 rewritten commit
         branchless: This operation abandoned 2 branches (abc, master)!
         branchless: Consider running one of the following:
@@ -107,9 +107,9 @@ fn test_fixup_no_abandoned_commit_message() -> eyre::Result<()> {
         if git_version < GitVersion(2, 35, 0) {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: a84541d7 # This is a combination of 2 commits. # This is the 1st commit message:
+            branchless: processed commit: a84541d # This is a combination of 2 commits. # This is the 1st commit message:
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: 7f023a10 create test1.txt
+            branchless: processed commit: 7f023a1 create test1.txt
             branchless: processing 3 rewritten commits
             Successfully rebased and updated detached HEAD.
             "###);
@@ -139,7 +139,7 @@ fn test_rebase_individual_commit() -> eyre::Result<()> {
         if git_version < GitVersion(2, 35, 0) {
             insta::assert_snapshot!(stderr, @r###"
             branchless: processing 1 update: ref HEAD
-            branchless: processed commit: f8d9985b create test2.txt
+            branchless: processed commit: f8d9985 create test2.txt
             branchless: processing 1 rewritten commit
             branchless: This operation abandoned 1 commit!
             branchless: Consider running one of the following:

--- a/tests/test_branchless.rs
+++ b/tests/test_branchless.rs
@@ -14,14 +14,14 @@ fn test_commands() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 3df4b935 (> master) create test.txt
+        @ 3df4b93 (> master) create test.txt
         "###);
     }
 
     {
         let (stdout, _stderr) = git.run(&["hide", "3df4b935"])?;
         insta::assert_snapshot!(stdout, @r###"
-        Hid commit: 3df4b935 create test.txt
+        Hid commit: 3df4b93 create test.txt
         To unhide this 1 commit, run: git undo
         "###);
     }
@@ -29,7 +29,7 @@ fn test_commands() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["unhide", "3df4b935"])?;
         insta::assert_snapshot!(stdout, @r###"
-        Unhid commit: 3df4b935 create test.txt
+        Unhid commit: 3df4b93 create test.txt
         To hide this 1 commit, run: git undo
         "###);
     }
@@ -38,9 +38,9 @@ fn test_commands() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["prev"])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24
-        @ f777ecc9 create initial.txt
+        @ f777ecc create initial.txt
         |
-        O 3df4b935 (master) create test.txt
+        O 3df4b93 (master) create test.txt
         "###);
     }
 
@@ -49,7 +49,7 @@ fn test_commands() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> checkout 3df4b9355b3b072aa6c50c6249bf32e289b3a661
         :
-        @ 3df4b935 (master) create test.txt
+        @ 3df4b93 (master) create test.txt
         "###);
     }
 


### PR DESCRIPTION
I am interested in this project and I want to contribute to code although I'm not good at rust. I think I can be better by contributing this project.

Can you help me with this?

I was trying to pick up #280.

I thought `oid` in this function should be calculated using `git2`.
https://github.com/arxanas/git-branchless/blob/45ace45579804697f8daeb551750424bf8e8538b/src/core/node_descriptors.rs#L183-L199

Then I might have to change constructor.

https://github.com/arxanas/git-branchless/blob/45ace45579804697f8daeb551750424bf8e8538b/src/core/node_descriptors.rs#L178


So my current status in ccc277c37c6f138bb17e2d0ac19898bcc82fc3f3 is I brought `&Repo` to constructor.
```rust
    pub fn new(repo: &Repo, use_color: bool) -> eyre::Result<Self> {
        Ok(CommitOidDescriptor { use_color })
    }
```

And I got 3 problems.

1. I was thinking [this](https://github.com/arxanas/git-branchless/discussions/279#discussioncomment-2221208), but  `repo: &Repo` don't have `raw()`. Which is strange. Because it is wrapper around `git2::Repository` and I thought `git2::Repository` has `raw()`.
2.  To enable `describe_node` to access to `repo` as `self.repo`, I need to do something like this.
```rust
pub struct CommitOidDescriptor<'a> {
    repo: &'a Repo,
    use_color: bool,
}
```
But It makes error message all around. If this is right way to do it, then I will study about `lifetime` and go forward. But I am not sure about it because of `1`.

3. `bugreport!` error.  I don't know what should I do.
<img width="400" alt="스크린샷 2022-03-23 오후 2 05 49" src="https://user-images.githubusercontent.com/61503739/159628076-ac2c19f0-8b63-4022-a161-80d6c72ee27f.png">

