### PR TITLE
tests: don't propagate environment into `GitRunInfo`

### DIFF
--- a/src/git/run.rs
+++ b/src/git/run.rs
@@ -500,7 +500,7 @@ mod tests {
         let git_run_info = GitRunInfo {
             path_to_git: git.path_to_git.clone(),
             working_directory: git.repo_path.clone(),
-            env: std::env::vars_os().collect(),
+            env: Default::default(),
         };
 
         let result = git_run_info.run_silent(


### PR DESCRIPTION
When I ran the tests with `LANG=sv_SE.UTF-8` exported in my shell,
`test_run_silent_failures` failed. This patch fixes it. yujong-lee@
reported many more language-related failures but I wasn't able to
reproduce those.