### PR TITLE
build: bump indicatif from 0.17.0-beta.1 to 0.17.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,14 +1114,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0-beta.1"
+version = "0.17.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500f7e5a63596852b9bf7583fe86f9ad08e0df9b4eb58d12e9729071cb4952ca"
+checksum = "088977cb4de4e09ea0232bd51c844490475ad94344fb0c60784f1fb380059b6d"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "unicode-width",
 ]
 
 [[package]]

--- a/src/core/effects.rs
+++ b/src/core/effects.rs
@@ -300,13 +300,13 @@ impl OperationState {
         lazy_static! {
             static ref CHECKMARK: String = console::style("✓").green().to_string();
             static ref IN_PROGRESS_SPINNER_STYLE: ProgressStyle =
-                ProgressStyle::default_spinner().template("{prefix}{spinner} {wide_msg}");
+                ProgressStyle::default_spinner().template("{prefix}{spinner} {wide_msg}").unwrap();
             static ref IN_PROGRESS_BAR_STYLE: ProgressStyle =
                 // indicatif places the cursor at the end of the line, which may
                 // be visible in the terminal, so we add a space at the end of
                 // the line so that the length number isn't overlapped by the
                 // cursor.
-                ProgressStyle::default_bar().template("{prefix}{spinner} {wide_msg} {bar} {pos}/{len} ");
+                ProgressStyle::default_bar().template("{prefix}{spinner} {wide_msg} {bar} {pos}/{len} ").unwrap();
             static ref FINISHED_PROGRESS_STYLE: ProgressStyle = IN_PROGRESS_SPINNER_STYLE
                 .clone()
                 // Requires at least two tick values, so just pass the same one twice.


### PR DESCRIPTION
Supersedes https://github.com/arxanas/git-branchless/pull/321. Closes #317.