### PR TITLE
fix(undo): show up-to-date smartlog after `git undo`

### DIFF
--- a/git-branchless/tests/command/test_undo.rs
+++ b/git-branchless/tests/command/test_undo.rs
@@ -404,12 +404,12 @@ fn test_undo_move_refs() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 96d1c37 create test2.txt
-                       to 62fc20d create test1.txt
-        2. Hide commit 96d1c37 create test2.txt
+        1. Hide commit 96d1c37 create test2.txt
 
-        3. Move branch master from 96d1c37 create test2.txt
+        2. Move branch master from 96d1c37 create test2.txt
                                 to 62fc20d create test1.txt
+        3. Check out from 96d1c37 create test2.txt
+                       to 62fc20d create test1.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --detach
         Applied 3 inverse events.
         "###);
@@ -625,14 +625,14 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 62fc20d create test1.txt
-                       to f777ecc create initial.txt
-        2. Delete branch bar at 62fc20d create test1.txt
+        1. Delete branch bar at 62fc20d create test1.txt
 
-        3. Hide commit 62fc20d create test1.txt
+        2. Hide commit 62fc20d create test1.txt
 
-        4. Move branch master from 62fc20d create test1.txt
+        3. Move branch master from 62fc20d create test1.txt
                                 to f777ecc create initial.txt
+        4. Check out from 62fc20d create test1.txt
+                       to f777ecc create initial.txt
         5. Delete branch foo at f777ecc create initial.txt
 
         Confirm? [yN] branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --detach
@@ -787,15 +787,14 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 62fc20d create test1.txt
-                       to <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>
+        1. Move branch master from 62fc20d create test1.txt
+                                to 62fc20d create test1.txt
         2. Move branch master from 62fc20d create test1.txt
                                 to 62fc20d create test1.txt
-        3. Move branch master from 62fc20d create test1.txt
-                                to 62fc20d create test1.txt
+        3. Check out from 62fc20d create test1.txt
+                       to <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>
         Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
-        Applied 3 inverse events.
         "###);
         assert!(exit_code > 0);
     }
@@ -836,14 +835,14 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         let stdout = trim_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 9ed8f9a bad message
-                       to 96d1c37 create test2.txt
-        2. Rewrite commit 9ed8f9a bad message
+        1. Rewrite commit 9ed8f9a bad message
                       as 96d1c37 create test2.txt
-        3. Hide commit 9ed8f9a bad message
+        2. Hide commit 9ed8f9a bad message
 
-        4. Move branch master from 9ed8f9a bad message
+        3. Move branch master from 9ed8f9a bad message
                                 to 96d1c37 create test2.txt
+        4. Check out from 9ed8f9a bad message
+                       to 96d1c37 create test2.txt
         Confirm? [yN] Aborted.
         "###);
     }
@@ -867,21 +866,17 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         let stdout = trim_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Check out from 9ed8f9a bad message
-                       to 96d1c37 create test2.txt
-        2. Rewrite commit 9ed8f9a bad message
+        1. Rewrite commit 9ed8f9a bad message
                       as 96d1c37 create test2.txt
-        3. Hide commit 9ed8f9a bad message
+        2. Hide commit 9ed8f9a bad message
 
-        4. Move branch master from 9ed8f9a bad message
+        3. Move branch master from 9ed8f9a bad message
                                 to 96d1c37 create test2.txt
+        4. Check out from 9ed8f9a bad message
+                       to 96d1c37 create test2.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach
         :
-        O 62fc20d create test1.txt
-        |\
-        | % 96d1c37 (rewritten as 9ed8f9a2) create test2.txt
-        |
-        O 9ed8f9a (master) bad message
+        @ 96d1c37 (master) create test2.txt
         Applied 4 inverse events.
         "###);
     }


### PR DESCRIPTION
Closes #351.
