### PR TITLE
feat(reword): implement bulk editting mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--yes` option to `git undo` to skip confirmation.
+- Added bulk edit mode to `git reword` to allow updating multiple, individual commit messages at once.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bugreport",
+ "chrono",
  "clap 3.1.12",
  "color-eyre",
  "console",

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -48,10 +48,16 @@ pub(super) fn wrap_git_error(error: git2::Error) -> eyre::Error {
 
 /// Clean up a message, removing extraneous whitespace plus comment lines starting with
 /// `comment_char`, and ensure that the message ends with a newline.
-pub fn message_prettify(message: &str, comment_char: char) -> eyre::Result<String> {
-    let comment_char = u32::from(comment_char);
-    let comment_char = u8::try_from(comment_char).wrap_err("comment char was not ASCII")?;
-    let message = git2::message_prettify(message, Some(comment_char))?;
+pub fn message_prettify(message: &str, comment_char: Option<char>) -> eyre::Result<String> {
+    let comment_char = match comment_char {
+        Some(ch) => {
+            let ch = u32::from(ch);
+            let ch = u8::try_from(ch).wrap_err("comment char was not ASCII")?;
+            Some(ch)
+        }
+        None => None,
+    };
+    let message = git2::message_prettify(message, comment_char)?;
     Ok(message)
 }
 

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.3.12"
 
 [dependencies]
 bugreport = "0.5.0"
+chrono = "0.4.19"
 clap = { version = "3.1.12", features = ["derive"] }
 color-eyre = "0.6.1"
 console = "0.15.0"

--- a/git-branchless/src/commands/reword.rs
+++ b/git-branchless/src/commands/reword.rs
@@ -343,9 +343,16 @@ fn prepare_messages(
     };
 
     let mut message = if discard_messages {
-        // TODO how should this work w/ bulk editing & --discard? just repeat the template, or perhaps show
-        // template w/ original message commented out?
-        message
+        // FIXME should this also show the original message (commented out)?
+        commits
+            .iter()
+            .map(|commit| match commit.get_short_oid() {
+                Ok(oid) => oid,
+                Err(_) => panic!("Could not get short OID for commit: {:?}", commit.get_oid()),
+            })
+            .map(|hash| format!("++ reword {}\n{}", hash, message.clone()))
+            .collect::<Vec<String>>()
+            .join("\n")
     } else {
         // TODO what order are they listed in? (dag.sort()?)
         commits
@@ -612,6 +619,8 @@ mod tests {
                 &[head_commit.clone()],
                 |message| {
                     insta::assert_snapshot!(message.trim(), @r###"
+                    ++ reword 62fc20d
+
                     # Rewording: Please enter the commit message to apply to this 1 commit. Lines
                     # starting with '#' will be ignored, and an empty message aborts rewording.
                     "###);
@@ -636,6 +645,7 @@ This is a template!
                 &[head_commit],
                 |message| {
                     insta::assert_snapshot!(message.trim(), @r###"
+                    ++ reword 62fc20d
                     This is a template!
 
                     # Rewording: Please enter the commit message to apply to this 1 commit. Lines

--- a/git-branchless/src/commands/reword.rs
+++ b/git-branchless/src/commands/reword.rs
@@ -16,7 +16,7 @@ use tracing::{instrument, warn};
 use lib::core::config::{
     get_comment_char, get_commit_template, get_editor, get_restack_preserve_timestamps,
 };
-use lib::core::dag::{resolve_commits, CommitSet, Dag, ResolveCommitsResult};
+use lib::core::dag::{resolve_commits, sort_commit_set, CommitSet, Dag, ResolveCommitsResult};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{EventLogDb, EventReplayer};
 use lib::core::formatting::{printable_styled_string, Glyphs, Pluralize};
@@ -279,6 +279,10 @@ fn resolve_commits_from_hashes<'repo>(
             return Ok(None);
         }
     };
+
+    let commit_set = commits.iter().map(|c| c.get_oid()).collect::<CommitSet>();
+    let commits = sort_commit_set(repo, dag, &commit_set)?;
+
     Ok(Some(commits))
 }
 


### PR DESCRIPTION
This implements a bulk editing mode for `git reword`, as discussed in #179. I feel pretty good about the features, but I'm still learning Rust and it feels like there is still some clean up needed for some of the implementation code, though to be honest *exactly what* clean up is needed isn't entirely clear to me right now. Some of it just has a subtle smell to it, like there's a simpler way that I'm not yet familiar with. Any pointers would be appreciated!

The format of the bulk edit message is as discussed in #179, and is very similar to `git revise` (though I've yet to use `revise`):

```
++ reword <commit 1 hash>
<commit 1 message>

++ reword <commit 2 hash>
<commit 2 message>

# etc ...

# Rewording: Please enter the commit message to apply to these X commits. Lines
# starting with '#' will be ignored, and an empty message aborts rewording.
```

When called with `--discard`, the original messages are included (commented out) along w/ the commit template:

```
++ reword <commit 1 hash>
<commit template>

# Original message:
# <commit 1 message>

++ reword <commit 2 hash>
<commit template>

# Original message:
# <commit 2 message>

# etc ...

# Rewording: Please enter the commit message to apply to these X commits. Lines
# starting with '#' will be ignored, and an empty message aborts rewording.
```




Most of the work was in error states and edge cases, matching the commits from the CLI to the commits found in the edited message. (These would only happen, as far as I can tell, if the user altered/added/removed commits and markers (eg `++ reword abc123`) while editing.) The following all generate errors and abort rewording:

- If a commit is given on the CLI but not found in the message.
- If a commit is found in the message but not found on the CLI.
- If a commit is found in the message multiple times.

When one of these errors is detected, the edited message is saved to `.git/REWORD_EDITMSG` and the user is notified that their work has been saved. I *have not* made any attempt to recover an existing `REWORD_EDITMSG`, as trying to figure out if an existing file is appropriate for a particular call to `git reword` felt like it would be more complicated than we wanted to get into, though I have some possible ideas about this, if you'd like to consider it.

A couple of other changes:

- Input commits are sorted so that they show up in "rebase plan"/topological order in the editor, regardless of the order they were specified on the CLI.
- Editing a single commit via the editor is just handled via "bulk edit" mode, too, so single commit editor sessions now include a `++ reword <hash>` marker.

Finally, this also includes some refactoring of the `build_messages` function (now renamed to `prepare_messages`) to avoid some of the repetitive conditionals related to `if load_editor`. Since the "messages from the CLI" mode is so simple, I just handle that w/ an early return, which lets the rest of the function focus exclusively on the editor mode.

~~There is one flakey test that I can't figure out: `test_reword_parses_bulk_edit_message` in `reword.rs` seems to flip-flop the order of the two OIDs if the code has recently been changed (thus recompiled). *Most* of the time the test is fine, but sometimes it needs to be re-run a couple of times in order to pass, at which point it then passes reliably. Any help of debugging that would be greatly appreciated.  I wonder if it has something to do w/ threads and the CPU having some load?~~ **Edit:** I rewrote the tests without snapshots so that the specific order of the ids is no longer relevant.
