### PR TITLE
ci: don't override nixpkgs version (use the lock file's version)

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -20,4 +20,4 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - run: nix flake check --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs
+      - run: nix flake check --print-build-logs --show-trace

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -27,4 +27,4 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - run: nix flake check --print-build-logs --show-trace --override-input nixpkgs github:NixOS/nixpkgs
+      - run: nix flake check --print-build-logs --show-trace


### PR DESCRIPTION
This should avoid surprises like martinvonz/jj#299, I hope.