### PR TITLE
feat(hide): Display (and optionally delete) abandoned branches

### DIFF
--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -130,7 +130,11 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             ExitCode(0)
         }
 
-        Command::Hide { commits, recursive } => hide::hide(&effects, commits, recursive)?,
+        Command::Hide {
+            commits,
+            delete_branches,
+            recursive,
+        } => hide::hide(&effects, &git_run_info, commits, delete_branches, recursive)?,
 
         Command::HookDetectEmptyCommit { old_commit_oid } => {
             let old_commit_oid: NonZeroOid = old_commit_oid.parse()?;

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -157,6 +157,10 @@ pub enum Command {
         /// Can either be hashes, like `abc123`, or ref-specs, like `HEAD^`.
         commits: Vec<String>,
 
+        /// Also delete any branches that are abandoned as a result of this hide.
+        #[clap(short = 'D', long = "delete-branches")]
+        delete_branches: bool,
+
         /// Also recursively hide all visible children commits of the provided
         /// commits.
         #[clap(short = 'r', long = "recursive")]

--- a/git-branchless/tests/command/test_hide.rs
+++ b/git-branchless/tests/command/test_hide.rs
@@ -168,7 +168,14 @@ fn test_branches_always_visible() -> eyre::Result<()> {
     git.run(&["branch", "test"])?;
     git.run(&["checkout", "master"])?;
 
-    git.run(&["hide", "test", "test^"])?;
+    let (stdout, _stderr) = git.run(&["hide", "test", "test^"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    Hid commit: 62fc20d create test1.txt
+    Hid commit: 96d1c37 create test2.txt
+    Abandoned 1 branch: test
+    To unhide these 2 commits, run: git undo
+    "###);
+
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stdout, @r###"

--- a/git-branchless/tests/test_branchless.rs
+++ b/git-branchless/tests/test_branchless.rs
@@ -22,6 +22,7 @@ fn test_commands() -> eyre::Result<()> {
         let (stdout, _stderr) = git.run(&["hide", "3df4b935"])?;
         insta::assert_snapshot!(stdout, @r###"
         Hid commit: 3df4b93 create test.txt
+        Abandoned 1 branch: master
         To unhide this 1 commit, run: git undo
         "###);
     }


### PR DESCRIPTION
Changes in this PR:
- Display a list of branches abandoned during a `git hide` operation
- Add `-D/--delete-branches` flag to delete branches abandoned during a `git hide` operation
  - The `-D` short flag was chosen for parity w/ `git branch -D <branch name>`

See discussion at https://github.com/arxanas/git-branchless/discussions/283#discussioncomment-2298871
