### PR TITLE
ci: bump nixpkgs version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638371214,
-        "narHash": "sha256-0kE6KhgH7n0vyuX4aUoGsGIQOqjIx2fJavpCWtn73rc=",
+        "lastModified": 1654682581,
+        "narHash": "sha256-Jb1PQCwKgwdNAp907eR5zPzuxV+kRroA3UIxUxCMJ9s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a640d8394f34714578f3e6335fc767d0755d78f9",
+        "rev": "e0169d7a9d324afebf5679551407756c77af8930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the version of nixpkgs to https://github.com/NixOS/nixpkgs/commit/e0169d7a9d324afebf5679551407756c77af8930 which is the current HEAD of the nixos-unstable branch. This will change the default version of Rust to 1.61.0 for the Nix build.