### PR TITLE
Garbage collection reachability improvements

### DIFF
--- a/git-branchless-lib/src/core/dag.rs
+++ b/git-branchless-lib/src/core/dag.rs
@@ -61,7 +61,7 @@ impl FromIterator<NonZeroOid> for CommitSet {
 
 /// Eagerly convert a `CommitSet` into a `Vec<NonZeroOid>` by iterating over it.
 #[instrument]
-pub fn commit_set_to_vec(commit_set: &CommitSet) -> eyre::Result<Vec<NonZeroOid>> {
+pub fn commit_set_to_vec_unsorted(commit_set: &CommitSet) -> eyre::Result<Vec<NonZeroOid>> {
     let mut result = Vec::new();
     for vertex in commit_set.iter().wrap_err("Iterating commit set")? {
         let vertex = vertex.wrap_err("Evaluating vertex")?;
@@ -414,7 +414,7 @@ pub fn sort_commit_set<'repo>(
     dag: &Dag,
     commit_set: &CommitSet,
 ) -> eyre::Result<Vec<Commit<'repo>>> {
-    let commit_oids = commit_set_to_vec(commit_set)?;
+    let commit_oids = commit_set_to_vec_unsorted(commit_set)?;
     let mut commits: Vec<Commit> = {
         let mut commits = Vec::new();
         for commit_oid in commit_oids {

--- a/git-branchless-lib/src/core/rewrite/plan.rs
+++ b/git-branchless-lib/src/core/rewrite/plan.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use rayon::{prelude::*, ThreadPool};
 use tracing::{instrument, warn};
 
-use crate::core::dag::{commit_set_to_vec, CommitSet, Dag};
+use crate::core::dag::{commit_set_to_vec_unsorted, CommitSet, Dag};
 use crate::core::effects::{Effects, OperationType};
 use crate::core::formatting::printable_styled_string;
 use crate::core::rewrite::{RepoPool, RepoResource};
@@ -234,7 +234,7 @@ impl BuildRebasePlanError {
                         char3,
                         printable_styled_string(
                             glyphs,
-                            repo.friendly_describe_commit_from_oid(glyphs, *oid)?
+                            repo.friendly_describe_commit_from_oid(glyphs, *oid)?,
                         )?,
                     )?;
                 }
@@ -489,7 +489,7 @@ impl<'repo> RebasePlanBuilder<'repo> {
             .query()
             .children(CommitSet::from(current_oid))?
             .intersection(visible_commits);
-        let children_oids = commit_set_to_vec(&children_oids)?;
+        let children_oids = commit_set_to_vec_unsorted(&children_oids)?;
         for child_oid in children_oids {
             acc.push(Constraint {
                 parent_oid: current_oid,

--- a/git-branchless/src/commands/move.rs
+++ b/git-branchless/src/commands/move.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 use crate::opts::{MoveOptions, Revset};
 use crate::revset::resolve_commits;
 use lib::core::config::get_restack_preserve_timestamps;
-use lib::core::dag::{commit_set_to_vec, CommitSet, Dag};
+use lib::core::dag::{commit_set_to_vec_unsorted, CommitSet, Dag};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{EventLogDb, EventReplayer};
 use lib::core::rewrite::{
@@ -110,7 +110,7 @@ pub fn r#move(
 
     let source_oid: NonZeroOid =
         match resolve_commits(effects, &repo, &mut dag, vec![source.clone()]) {
-            Ok(commit_sets) => match commit_set_to_vec(&commit_sets[0])?.as_slice() {
+            Ok(commit_sets) => match commit_set_to_vec_unsorted(&commit_sets[0])?.as_slice() {
                 [only_commit_oid] => *only_commit_oid,
                 other => {
                     let Revset(expr) = source;
@@ -129,7 +129,7 @@ pub fn r#move(
             }
         };
     let dest_oid: NonZeroOid = match resolve_commits(effects, &repo, &mut dag, vec![dest.clone()]) {
-        Ok(commit_sets) => match commit_set_to_vec(&commit_sets[0])?.as_slice() {
+        Ok(commit_sets) => match commit_set_to_vec_unsorted(&commit_sets[0])?.as_slice() {
             [only_commit_oid] => *only_commit_oid,
             other => {
                 let Revset(expr) = dest;

--- a/git-branchless/src/commands/query.rs
+++ b/git-branchless/src/commands/query.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use eden_dag::DagAlgorithm;
 use itertools::Itertools;
-use lib::core::dag::{commit_set_to_vec, Dag};
+use lib::core::dag::{commit_set_to_vec_unsorted, Dag};
 use lib::core::effects::{Effects, OperationType};
 use lib::core::eventlog::{EventLogDb, EventReplayer};
 use lib::core::repo_ext::RepoExt;
@@ -49,7 +49,7 @@ pub fn query(
 
             let commit_set = dag.query().sort(&commit_set)?;
             let commit_set = commit_set.intersection(&dag.branch_commits);
-            commit_set_to_vec(&commit_set)?
+            commit_set_to_vec_unsorted(&commit_set)?
         };
         let ref_names = commit_oids
             .into_iter()
@@ -70,7 +70,7 @@ pub fn query(
             let _effects = effects;
 
             let commit_set = dag.query().sort(&commit_set)?;
-            commit_set_to_vec(&commit_set)?
+            commit_set_to_vec_unsorted(&commit_set)?
         };
         for commit_oid in commit_oids {
             writeln!(effects.get_output_stream(), "{}", commit_oid)?;

--- a/git-branchless/src/commands/restack.rs
+++ b/git-branchless/src/commands/restack.rs
@@ -70,7 +70,7 @@ use crate::commands::smartlog::smartlog;
 use crate::opts::{MoveOptions, Revset};
 use crate::revset::resolve_commits;
 use lib::core::config::get_restack_preserve_timestamps;
-use lib::core::dag::{commit_set_to_vec, union_all, CommitSet, Dag};
+use lib::core::dag::{commit_set_to_vec_unsorted, union_all, CommitSet, Dag};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{EventCursor, EventLogDb, EventReplayer};
 use lib::core::rewrite::{
@@ -102,7 +102,7 @@ fn restack_commits(
     };
     // Don't use `sort_commit_set` since the set of obsolete commits may be very
     // large and we'll be throwing away most of them.
-    let commits = commit_set_to_vec(&commit_set)?;
+    let commits = commit_set_to_vec_unsorted(&commit_set)?;
 
     let public_commits = dag.query_public_commits()?;
     let active_heads = dag.query_active_heads(
@@ -289,7 +289,7 @@ pub fn restack(
         None
     } else {
         Some(
-            commit_set_to_vec(&union_all(&commit_sets))?
+            commit_set_to_vec_unsorted(&union_all(&commit_sets))?
                 .into_iter()
                 .collect(),
         )

--- a/git-branchless/src/commands/smartlog.rs
+++ b/git-branchless/src/commands/smartlog.rs
@@ -31,7 +31,7 @@ mod graph {
     use eden_dag::DagAlgorithm;
     use tracing::instrument;
 
-    use lib::core::dag::{commit_set_to_vec, CommitSet, Dag};
+    use lib::core::dag::{commit_set_to_vec_unsorted, CommitSet, Dag};
     use lib::core::effects::{Effects, OperationType};
     use lib::core::eventlog::{EventCursor, EventReplayer};
     use lib::core::node_descriptors::NodeObject;
@@ -175,7 +175,7 @@ mod graph {
             let mut links = Vec::new();
             for child_oid in non_main_node_oids {
                 let parent_vertexes = dag.query().parents(CommitSet::from(*child_oid))?;
-                let parent_oids = commit_set_to_vec(&parent_vertexes)?;
+                let parent_oids = commit_set_to_vec_unsorted(&parent_vertexes)?;
                 for parent_oid in parent_oids {
                     if graph.contains_key(&parent_oid) {
                         links.push((*child_oid, parent_oid))

--- a/git-branchless/src/commands/smartlog.rs
+++ b/git-branchless/src/commands/smartlog.rs
@@ -124,8 +124,6 @@ mod graph {
         effects: &Effects,
         repo: &'repo Repo,
         dag: &Dag,
-        event_replayer: &EventReplayer,
-        event_cursor: EventCursor,
         public_commits: &CommitSet,
         active_heads: &CommitSet,
     ) -> eyre::Result<SmartlogGraph<'repo>> {
@@ -244,15 +242,7 @@ mod graph {
 
             let active_heads = dag.query_active_heads(&public_commits, &observed_commits)?;
 
-            walk_from_active_heads(
-                &effects,
-                repo,
-                dag,
-                event_replayer,
-                event_cursor,
-                &public_commits,
-                &active_heads,
-            )?
+            walk_from_active_heads(&effects, repo, dag, &public_commits, &active_heads)?
         };
         sort_children(&mut graph);
         Ok(graph)

--- a/git-branchless/src/revset/eval.rs
+++ b/git-branchless/src/revset/eval.rs
@@ -35,6 +35,9 @@ pub enum EvalError {
         #[from]
         from: eden_dag::Error,
     },
+
+    #[error(transparent)]
+    OtherError(eyre::Error),
 }
 
 pub type EvalResult = Result<CommitSet, EvalError>;
@@ -132,12 +135,14 @@ fn eval_name(ctx: &mut Context, name: &str) -> EvalResult {
         }
     };
 
-    ctx.dag.sync_from_oids(
-        ctx.effects,
-        ctx.repo,
-        CommitSet::empty(),
-        commit_set.clone(),
-    )?;
+    ctx.dag
+        .sync_from_oids(
+            ctx.effects,
+            ctx.repo,
+            CommitSet::empty(),
+            commit_set.clone(),
+        )
+        .map_err(EvalError::OtherError)?;
     Ok(commit_set)
 }
 

--- a/git-branchless/src/revset/resolve.rs
+++ b/git-branchless/src/revset/resolve.rs
@@ -67,7 +67,7 @@ pub fn resolve_commits(
         if let Ok(Some(commit)) = repo.revparse_single_commit(&revset) {
             let commit_set = CommitSet::from(commit.get_oid());
             dag.sync_from_oids(effects, repo, CommitSet::empty(), commit_set.clone())
-                .map_err(|err| ResolveError::DagError { source: err })?;
+                .map_err(|err| ResolveError::OtherError { source: err })?;
             commit_sets.push(commit_set);
             continue;
         }

--- a/git-branchless/tests/command/test_move.rs
+++ b/git-branchless/tests/command/test_move.rs
@@ -2096,7 +2096,7 @@ fn test_move_orig_head_no_symbolic_reference() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_move_standalone_no_create_gc_refs() -> eyre::Result<()> {
+fn test_move_standalone_create_gc_refs() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo_with_options(&GitInitOptions {
@@ -2107,21 +2107,22 @@ fn test_move_standalone_no_create_gc_refs() -> eyre::Result<()> {
     git.run(&["checkout", "HEAD^"])?;
     git.commit_file("test2", 2)?;
 
-    let show_refs_output = {
+    {
         let (stdout, _stderr) = git.run(&["show-ref"])?;
         insta::assert_snapshot!(stdout, @"62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/heads/master
 ");
-        stdout
-    };
+    }
 
     git.run(&["branchless", "move", "-d", &test1_oid.to_string()])?;
 
     {
         let (stdout, _stderr) = git.run(&["show-ref"])?;
         insta::assert_snapshot!(stdout, @r###"
+        62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/branchless/62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        96d1c37a3d4363611c49f7e52186e189a04c531f refs/branchless/96d1c37a3d4363611c49f7e52186e189a04c531f
+        fe65c1fe15584744e649b2c79d4cf9b0d878f92e refs/branchless/fe65c1fe15584744e649b2c79d4cf9b0d878f92e
         62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/heads/master
         "###);
-        assert!(stdout == show_refs_output);
     }
 
     Ok(())


### PR DESCRIPTION
Closes #412. With this stack, any commit which appears in `git smartlog` should be marked as reachable for GC, regardless of where it came from.
