### PR TITLE
fix(hide): Checkout commit of deleted HEAD branch (close #423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `--yes` option to `git undo` to skip confirmation.
 - Added bulk edit mode to `git reword` to allow updating multiple, individual commit messages at once.
+- Added `--delete-branches` option to `git hide`.
 
 ### Fixed
 

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -346,7 +346,7 @@ impl Repo {
     }
 
     /// Detach `HEAD` by making it point directly to its current OID, rather
-    /// than to a branch. If `HEAD` is already detached, logs a warning.
+    /// than to a branch. If `HEAD` is unborn, logs a warning.
     #[instrument]
     pub fn detach_head(&self, head_info: &ResolvedReferenceInfo) -> eyre::Result<()> {
         match head_info.oid {


### PR DESCRIPTION
This is a stab at #423; does this look like it would handle the issue you encountered? I admit that I didn't explore the area too much to see if there might be other issues lurking.

Question: Is `check_out::check_out_commit()` the right way to go about this?

This is draft b/c I still need to deal w/ the `_exit_code` from `check_out_commit()`. I'm thinking that we'll throw an error explaining the situation if `!exit_code.is_success()`, but I've never dealt with unborn branches, so I'm not familiar with recovery from that state. I'll tinker this weekend and push what I come up with.