### PR TITLE
`git move`: Add `--range` and `--exact` options (closes #176)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Forbid nocommit string
+        run: |
+          if results=$(git grep --column --line-number --only-matching '@''nocommit'); then
+            echo "$results"
+            awk <<<"$results" -F ':' '{ print "::error file=" $1 ",line=" $2 ",col=" $3 "::Illegal string: " $4 }'
+            exit 1
+          fi
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EXPERIMENTAL: (#382) Working copy snapshots are created before potentially-destructive operations in order to improve the capabilities of `git undo`.
   - Working copy snapshots are taken by default. Disable by setting `branchless.undo.createSnapshots` to `false`.
 - EXPERIMENTAL: (#391) created the `git record` command, which opens an interactive change selector for committing.
+- Numerous updates to `git branchless move`:
+  - (#400) Added `--insert` option to to insert the moved subtree, range or commit into the commit tree between the destination commit and it's children, if any.
+  - (#448) Added `--exact` option to move a single commit elsewhere in the commit tree. It will be removed from it's current location and it's children (if any) will be moved to it's parent.
+  - (#448) Added `--range` option to move a range of commits elsewhere in the commit tree. (Similar to `--exact`, but for contiguous sets of commits).
+  - (#447) `--source`, `--base`, `--range` and `--exact` options can all be provided multiple times and in any combination to move multiple subtress, ranges and/or commits to the destination.
 - Added `--yes` option to `git undo` to skip confirmation.
 - (#366) Added bulk edit mode to `git reword` to allow updating multiple, individual commit messages at once.
 - (#398) Added support for [revset expressions](https://github.com/arxanas/git-branchless/wiki/Reference:-Revsets) in most commands.

--- a/git-branchless-lib/src/git/diff.rs
+++ b/git-branchless-lib/src/git/diff.rs
@@ -75,8 +75,7 @@ pub fn process_diff_for_record(
             true
         }),
         Some(&mut |delta, hunk| {
-            let path = delta.new_file().path().unwrap(); // @nocommit should
-                                                         // we be using only new_file here?
+            let path = delta.new_file().path().unwrap();
             let mut deltas = deltas.lock().unwrap();
             match &mut deltas.get_mut(path).unwrap().content {
                 DeltaFileContent::Hunks(hunks) => {

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -209,6 +209,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             source,
             dest,
             base,
+            range,
             insert,
             move_options,
         } => r#move::r#move(
@@ -217,6 +218,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             source,
             dest,
             base,
+            range,
             insert,
             &move_options,
         )?,

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -211,6 +211,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             base,
             range,
             insert,
+            exact,
             move_options,
         } => r#move::r#move(
             &effects,
@@ -219,6 +220,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             dest,
             base,
             range,
+            exact,
             insert,
             &move_options,
         )?,

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -302,6 +302,16 @@ pub enum Command {
         )]
         range: Vec<Revset>,
 
+        /// The single commit to move. Any children of the commit will be moved
+        /// onto its parent.
+        #[clap(
+            action(clap::ArgAction::Append),
+            short = 'e',
+            long = "exact",
+            conflicts_with_all(&["source", "base", "range"])
+        )]
+        exact: Vec<Revset>,
+
         /// The destination commit to move all source commits onto. If not
         /// provided, defaults to the current commit.
         #[clap(value_parser, short = 'd', long = "dest")]

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -291,6 +291,17 @@ pub enum Command {
         )]
         base: Vec<Revset>,
 
+        /// The range of commits to move. This range must have only 1 parent, 1
+        /// root and 1 head. Any children of the range will be moved onto the
+        /// range's parent.
+        #[clap(
+            action(clap::ArgAction::Append),
+            short = 'r',
+            long = "range",
+            conflicts_with_all(&["source", "base"])
+        )]
+        range: Vec<Revset>,
+
         /// The destination commit to move all source commits onto. If not
         /// provided, defaults to the current commit.
         #[clap(value_parser, short = 'd', long = "dest")]

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -277,14 +277,19 @@ pub enum Command {
     Move {
         /// The source commit to move. This commit, and all of its descendants,
         /// will be moved.
-        #[clap(value_parser, short = 's', long = "source")]
-        source: Option<Revset>,
+        #[clap(action(clap::ArgAction::Append), short = 's', long = "source")]
+        source: Vec<Revset>,
 
         /// A commit inside a subtree to move. The entire subtree, starting from
         /// the main branch, will be moved, not just the commits descending from
         /// this commit.
-        #[clap(value_parser, short = 'b', long = "base", conflicts_with = "source")]
-        base: Option<Revset>,
+        #[clap(
+            action(clap::ArgAction::Append),
+            short = 'b',
+            long = "base",
+            conflicts_with = "source"
+        )]
+        base: Vec<Revset>,
 
         /// The destination commit to move all source commits onto. If not
         /// provided, defaults to the current commit.

--- a/git-branchless/src/revset/eval.rs
+++ b/git-branchless/src/revset/eval.rs
@@ -153,6 +153,11 @@ fn eval_inner(ctx: &mut Context, expr: &Expr) -> EvalResult {
                 Ok(ctx.dag.query().parents(expr)?)
             }
 
+            "branches" => {
+                eval0(ctx, name, args)?;
+                Ok(ctx.dag.branch_commits.clone())
+            }
+
             "draft" => {
                 eval0(ctx, name, args)?;
                 let draft_commits = ctx.query_draft_commits()?;

--- a/git-branchless/src/revset/eval.rs
+++ b/git-branchless/src/revset/eval.rs
@@ -60,9 +60,7 @@ impl Context<'_> {
             Ok(self
                 .dag
                 .query()
-                // @nocommit FIXME: use `only`?
-                .range(public_commits.clone(), active_heads.clone())?
-                .difference(public_commits))
+                .only(active_heads.clone(), public_commits.clone())?)
         })
     }
 }

--- a/git-branchless/tests/command/test_move.rs
+++ b/git-branchless/tests/command/test_move.rs
@@ -252,6 +252,89 @@ fn test_move_insert_stick() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_move_range_stick() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    let test4_oid = git.commit_file("test4", 4)?;
+    git.commit_file("test5", 5)?;
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    o 355e173 create test4.txt
+    |
+    @ f81d55c create test5.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--range",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o bf0d52a create test4.txt
+        |\
+        | o 44352d0 create test2.txt
+        | |
+        | o cf5eb24 create test3.txt
+        |
+        @ 848121c create test5.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--range",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o bf0d52a create test4.txt
+        |\
+        | o 44352d0 create test2.txt
+        | |
+        | o cf5eb24 create test3.txt
+        |
+        @ 848121c create test5.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_move_tree() -> eyre::Result<()> {
     let git = make_git()?;
 
@@ -403,6 +486,94 @@ fn test_move_insert_tree() -> eyre::Result<()> {
             | o 44352d0 create test2.txt
             |
             o 0a4a701 create test3.txt
+            "###);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_range_tree() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    let test4_oid = git.commit_file("test4", 4)?;
+    git.run(&["checkout", &test3_oid.to_string()])?;
+    git.commit_file("test5", 5)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |\
+    | o 355e173 create test4.txt
+    |
+    @ 9ea1b36 create test5.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--range",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+        {
+            git.run(&["restack"])?;
+
+            let (stdout, _stderr) = git.run(&["smartlog"])?;
+            insta::assert_snapshot!(stdout, @r###"
+            :
+            O 62fc20d (master) create test1.txt
+            |\
+            | o bf0d52a create test4.txt
+            | |
+            | o 44352d0 create test2.txt
+            | |
+            | o cf5eb24 create test3.txt
+            |
+            @ ea7aa06 create test5.txt
+            "###);
+        }
+    }
+
+    // in-memory
+    {
+        git.run(&[
+            "move",
+            "--range",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+        {
+            let (stdout, _stderr) = git.run(&["smartlog"])?;
+            insta::assert_snapshot!(stdout, @r###"
+            :
+            O 62fc20d (master) create test1.txt
+            |\
+            | o bf0d52a create test4.txt
+            | |
+            | o 44352d0 create test2.txt
+            | |
+            | o cf5eb24 create test3.txt
+            |
+            @ ea7aa06 create test5.txt
             "###);
         }
     }

--- a/git-branchless/tests/command/test_query.rs
+++ b/git-branchless/tests/command/test_query.rs
@@ -125,6 +125,14 @@ fn test_query_branches() -> eyre::Result<()> {
         "###);
     }
 
+    {
+        let (stdout, _stderr) = git.run(&["branchless", "query", "branches()"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        "###);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Still a WIP, but seems to be working. I've rebased my work onto #447 (which is also WIP) and I'll update this as that PR develops. I'll probably add some more tests, too, as I wrote all of these w/ a pre-revset mindset, so I was only thinking about moving single ranges/commits. 

- Adds a `git move --range <revset>` option to move ranges of commits.
- Adds a `git move --exact <revset>` option to move single commits.
- Updates CHANGELOG for #400, #447 and #448