### PR TITLE
`git move`: Add `--exact` option (closes #176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EXPERIMENTAL: (#382) Working copy snapshots are created before potentially-destructive operations in order to improve the capabilities of `git undo`.
   - Working copy snapshots are taken by default. Disable by setting `branchless.undo.createSnapshots` to `false`.
 - EXPERIMENTAL: (#391) created the `git record` command, which opens an interactive change selector for committing.
+- Numerous updates to `git branchless move`:
+  - (#400) Added `--insert` option to to insert the moved subtree or commits into the commit tree between the destination commit and its children, if any.
+  - (#450) Added `--exact` option to move a specific set of commits elsewhere in the commit tree. They will be removed from their current location and any unmoved children (if any) will be moved to their closest unmoved ancestor. The moved commits will maintain their overall ancestry structure.
+  - (#447) `--source`, `--base` and `--exact` options can all be provided multiple times to move multiple subtress, ranges and/or commits to the destination.
 - Added `--yes` option to `git undo` to skip confirmation.
 - (#366) Added bulk edit mode to `git reword` to allow updating multiple, individual commit messages at once.
 - (#398) Added support for [revset expressions](https://github.com/arxanas/git-branchless/wiki/Reference:-Revsets) in most commands.

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -209,6 +209,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             source,
             dest,
             base,
+            exact,
             insert,
             move_options,
         } => r#move::r#move(
@@ -217,6 +218,7 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             source,
             dest,
             base,
+            exact,
             insert,
             &move_options,
         )?,

--- a/git-branchless/src/commands/move.rs
+++ b/git-branchless/src/commands/move.rs
@@ -171,7 +171,7 @@ pub fn r#move(
         if insert {
             let source_head = {
                 let source_heads: CommitSet =
-                    dag.query().heads(dag.query().descendants(source_oids)?)?;
+                    dag.query().heads(dag.query().descendants(source_oids.clone())?)?;
                 match commit_set_to_vec_unsorted(&source_heads)?[..] {
                     [oid] => oid,
                     _ => {
@@ -187,7 +187,9 @@ pub fn r#move(
             let dest_children: CommitSet = dag
                 .query()
                 .children(CommitSet::from(dest_oid))?
-                .difference(&dag.obsolete_commits);
+                .difference(&dag.obsolete_commits)
+                // In case a source OID is already a child of dest_oid.
+                .difference(&source_oids);
 
             for dest_child in commit_set_to_vec_unsorted(&dest_children)? {
                 for source_root in commit_set_to_vec_unsorted(&source_roots)? {

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -291,6 +291,17 @@ pub enum Command {
         )]
         base: Vec<Revset>,
 
+        /// A set of specific commits to move. These will be removed from their
+        /// current locations and any unmoved children will be moved to their
+        /// nearest unmoved ancestor.
+        #[clap(
+            action(clap::ArgAction::Append),
+            short = 'x',
+            long = "exact",
+            conflicts_with_all(&["source", "base"])
+        )]
+        exact: Vec<Revset>,
+
         /// The destination commit to move all source commits onto. If not
         /// provided, defaults to the current commit.
         #[clap(value_parser, short = 'd', long = "dest")]

--- a/git-branchless/tests/command/test_move.rs
+++ b/git-branchless/tests/command/test_move.rs
@@ -412,7 +412,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_move_exact_noncontiguous_singles_stick() -> eyre::Result<()> {
+fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
     let git = make_git()?;
     if !git.supports_committer_date_is_author_date()? {
         return Ok(());
@@ -740,6 +740,465 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
         o b1f9efa create test5.txt
         |
         o 500c9b3 create test6.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_exact_insert_stick() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    @ 355e173 create test4.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--insert",
+            "--exact",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--insert",
+            "--exact",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_exact_insert_swap() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+
+    let test2_oid = git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.commit_file("test4", 4)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    @ 355e173 create test4.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--insert",
+            "--exact",
+            &test2_oid.to_string(),
+            "-d",
+            &test3_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--insert",
+            "--exact",
+            &test2_oid.to_string(),
+            "-d",
+            &test3_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.commit_file("test4", 4)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |\
+    | o 70deb1e create test3.txt
+    |
+    @ f57e36f create test4.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--insert",
+            "--exact",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--insert",
+            "--exact",
+            &test3_oid.to_string(),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o d742fb9 create test2.txt
+        |
+        @ 8fcf7dd create test4.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_insert_range_stick() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    let test2_oid = git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    let test4_oid = git.commit_file("test4", 4)?;
+    git.commit_file("test5", 5)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    o 355e173 create test4.txt
+    |
+    @ f81d55c create test5.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--insert",
+            "--exact",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o bf0d52a create test4.txt
+        |
+        o 44352d0 create test2.txt
+        |
+        o cf5eb24 create test3.txt
+        |
+        @ 4acfdad create test5.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--insert",
+            "--exact",
+            &format!("{}:{}", test2_oid, test3_oid),
+            "-d",
+            &test4_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o bf0d52a create test4.txt
+        |
+        o 44352d0 create test2.txt
+        |
+        o cf5eb24 create test3.txt
+        |
+        @ 4acfdad create test5.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_committer_date_is_author_date()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    let test3_oid = git.commit_file("test3", 3)?;
+    let test4_oid = git.commit_file("test4", 4)?;
+    git.commit_file("test5", 5)?;
+    let test6_oid = git.commit_file("test6", 6)?;
+    let test7_oid = git.commit_file("test7", 7)?;
+    git.commit_file("test8", 8)?;
+    let test9_oid = git.commit_file("test9", 9)?;
+    let test10_oid = git.commit_file("test10", 10)?;
+    git.commit_file("test11", 11)?;
+
+    let (stdout, _stderr) = git.run(&["smartlog"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (master) create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    o 355e173 create test4.txt
+    |
+    o f81d55c create test5.txt
+    |
+    o 2831fb5 create test6.txt
+    |
+    o c8933b3 create test7.txt
+    |
+    o 1edbaa1 create test8.txt
+    |
+    o 384010f create test9.txt
+    |
+    o 52ebfa0 create test10.txt
+    |
+    @ b22a15b create test11.txt
+    "###);
+
+    // --on-disk
+    {
+        let git = git.duplicate_repo()?;
+        git.run(&[
+            "move",
+            "--on-disk",
+            "--insert",
+            "--exact",
+            &format!(
+                "{}:{} + {}:{} + {}:{}",
+                test3_oid, test4_oid, test6_oid, test7_oid, test9_oid, test10_oid
+            ),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o a248207 create test4.txt
+        |
+        o 133f783 create test6.txt
+        |
+        o c603422 create test7.txt
+        |
+        o 9c7387c create test9.txt
+        |
+        o fed2ec4 create test10.txt
+        |
+        o 324a4c2 create test2.txt
+        |
+        o e7c49ca create test5.txt
+        |
+        o acad4bd create test8.txt
+        |
+        @ 85ceeac create test11.txt
+        "###);
+    }
+
+    // --in-memory
+    {
+        git.run(&[
+            "move",
+            "--in-memory",
+            "--insert",
+            "--exact",
+            &format!(
+                "{}:{} + {}:{} + {}:{}",
+                test3_oid, test4_oid, test6_oid, test7_oid, test9_oid, test10_oid
+            ),
+            "-d",
+            &test1_oid.to_string(),
+        ])?;
+
+        let (stdout, _stderr) = git.run(&["smartlog"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o 4838e49 create test3.txt
+        |
+        o a248207 create test4.txt
+        |
+        o 133f783 create test6.txt
+        |
+        o c603422 create test7.txt
+        |
+        o 9c7387c create test9.txt
+        |
+        o fed2ec4 create test10.txt
+        |
+        o 324a4c2 create test2.txt
+        |
+        o e7c49ca create test5.txt
+        |
+        o acad4bd create test8.txt
+        |
+        @ 85ceeac create test11.txt
         "###);
     }
 


### PR DESCRIPTION
_[reopening #448]_

Still a WIP, but seems to be working. I've rebased my work onto #447 (which is also WIP) and I'll update this as that PR develops. I'll probably add some more tests, too, as I wrote all of these w/ a pre-revset mindset, so I was only thinking about moving single ranges/commits. 

- ~~Adds a `git move --range <revset>` option to move ranges of commits.~~
- Adds a `git move --exact <revset>` option (shorthand: `-x`) to move single commits and/or ranges of commits.
- Updates CHANGELOG for #400, #447 and #448