### PR TITLE
fix(revset): Ignore ending newline in `message(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (#512) Fixed so that the setting for `--color` is now respected.
 - (#512) Fixed so that you can pass `--color` anywhere in the command-line, not just before the subcommand.
+- (#507) The `messages()` revset function now ignores trailing newlines in commit messages.
 
 ## [0.4.0] - 2022-08-09
 

--- a/git-branchless/src/revset/eval.rs
+++ b/git-branchless/src/revset/eval.rs
@@ -691,6 +691,44 @@ mod tests {
 
         {
             let expr = Expr::FunctionCall(
+                Cow::Borrowed("message"),
+                vec![Expr::Name(Cow::Borrowed("exact:create test4.txt"))],
+            );
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            Ok(
+                [
+                    Commit {
+                        inner: Commit {
+                            id: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                            summary: "create test4.txt",
+                        },
+                    },
+                ],
+            )
+            "###);
+        }
+
+        {
+            let expr = Expr::FunctionCall(
+                Cow::Borrowed("message"),
+                vec![Expr::Name(Cow::Borrowed("regex:^create test4.txt$"))],
+            );
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            Ok(
+                [
+                    Commit {
+                        inner: Commit {
+                            id: bf0d52a607f693201512a43b6b5a70b2a275e0ad,
+                            summary: "create test4.txt",
+                        },
+                    },
+                ],
+            )
+            "###);
+        }
+
+        {
+            let expr = Expr::FunctionCall(
                 Cow::Borrowed("paths.changed"),
                 vec![Expr::Name(Cow::Borrowed("glob:test[1-3].txt"))],
             );

--- a/git-branchless/src/revset/pattern.rs
+++ b/git-branchless/src/revset/pattern.rs
@@ -54,6 +54,7 @@ pub enum PatternError {
 
 impl Pattern {
     pub fn matches_text(&self, subject: &str) -> bool {
+        let subject = subject.strip_suffix('\n').unwrap_or(subject);
         match self {
             Pattern::Exact(pattern) => pattern == subject,
             Pattern::Substring(pattern) => subject.contains(pattern),


### PR DESCRIPTION
As discussed in discord, this trims ending newlines from commit messages when they are compared with `message()`. In particular, this provides for more intuitive (to me) usage of `message(exact:...)` and `message(regex:...)` because I feel that most folks would assume that the commit message would not include the trailing newline anyway. This is a 1 line change and includes supporting tests.

Behavior without this change (on `master`):

```sh
❯ git commit -am 'My commit'
❯ git query 'message(exact:My commit)'
# nothing found
❯ git query 'message(regex:My commit$)'
# nothing found
❯ git query 'message(exact:My commit\n)'
abc123 My commit
❯ git query 'message(regex:My commit\n$)'
abc123 My commit
```

With this change:

```sh
❯ git commit -am 'My commit'
❯ git query 'message(exact:My commit)'
abc123 My commit
❯ git query 'message(regex:My commit$)'
abc123 My commit
```

**Notes**

- This only trims the subject (commit message), not the pattern. With this change `exact:My commit\n` **will not** work b/c the pattern will include the newline but the commit message won't. Trying to alter the pattern seemed like a can of worms, and I think that stripping just the message will make *most* usages more intuitive.
- I'm only stripping newlines from the end of the string. I considered trimming all whitespace but that felt unnecessary since git does that to commit messages already, and this just targets something that git *adds* on it's own.
- I have not done anything to consider line endings on Windows. Can you remind me if there's anything special I should be doing for those?

Thank you!