### PR TITLE
feat(revset): Add `exactly` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- (#508) Added `exactly(<revset>, n)` revset function to allow assertions on the number of commits within a set.
+
 ### Changed
 
 - (#512) Fixed so that the setting for `--color` is now respected.

--- a/git-branchless/src/revset/builtins.rs
+++ b/git-branchless/src/revset/builtins.rs
@@ -48,6 +48,7 @@ lazy_static! {
             ("committer.name", &fn_committer_name),
             ("committer.email", &fn_committer_email),
             ("committer.date", &fn_committer_date),
+            ("exactly", &fn_exactly),
         ];
         functions.iter().cloned().collect()
     };
@@ -376,4 +377,22 @@ fn fn_committer_date(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult
             Ok(pattern.matches_date(&time))
         }),
     )
+}
+
+fn fn_exactly(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
+    let (lhs, expected_len) = eval_number_rhs(ctx, name, args)?;
+    let actual_len: usize = lhs
+        .count()
+        .wrap_err("Counting commit set")
+        .map_err(EvalError::OtherError)?;
+
+    if actual_len == expected_len {
+        Ok(lhs)
+    } else {
+        Err(EvalError::UnexpectedSetLength {
+            expr: format!("{}", args[0]),
+            expected_len,
+            actual_len,
+        })
+    }
 }

--- a/git-branchless/tests/command/test_query.rs
+++ b/git-branchless/tests/command/test_query.rs
@@ -84,7 +84,7 @@ fn test_query_eval_error() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @r###"
-        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, descendants, difference, draft, heads, intersection, message, none, not, only, parents, parents.nth, paths.changed, range, roots, stack, union
+        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, descendants, difference, draft, exactly, heads, intersection, message, none, not, only, parents, parents.nth, paths.changed, range, roots, stack, union
         "###);
         insta::assert_snapshot!(stdout, @"");
     }


### PR DESCRIPTION
As discussed in discord, this adds an `exactly` revset function. This returns the given revset only if it contains the expected number of commits. Otherwise it errors out. This was very straightforward to implement and includes tests.

**Notes**

- I considered creating a more general usage `count` function that would behave like the text/date matchers, for example:
  - `count(<revset>, exactly:1)`
  - `count(<revset>, greater_than:2)`
  - `count(<revset>, less_than_or_equal_to:3)`, etc. 
  - While that would be cool, it was more than I needed at this time.
- At first I had also added a `sole()` function, but I removed that in favor of making it an alias for `exactly($1, 1)` using the revset aliases PR.
- I have already found this useful in scripting to give me added confidence that some automated task won't target more than I expect it to. I didn't expect this, but I like where it's going; for example I might write a script guard like `if ! git query exactly(parents($INPUT), 1) ; then exit ; fi` to prevent myself from accidentally operating on a merge commit.
- The `ExpectedSingletonSet` appears to be unused. Should it be removed or would you like to keep it around?




