### PR TITLE
feat(revset): Support custom revset aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (#508) Added `exactly(<revset>, n)` revset function to allow assertions on the number of commits within a set.
+- (#509) User defined [revset aliases](https://github.com/arxanas/git-branchless/wiki/Reference:-Revsets#Aliases).
 
 ### Changed
 


### PR DESCRIPTION
This was fun to implement, and was pretty easy. Considering how flexible and powerful it could be ... I'm sort of concerned I'm overlooking something! 😄  As always, I'm 100% open to suggestions here.

- This does nothing to check for -- let alone prevent -- recursion in aliases. If someone defines a `foo` alias that itself calls `foo()` ... they're out of luck.
- This only allows aliasing functions; I did not consider allowing aliases for names, though it would be easy to add. 
  - I kind of feel like it's not necessary, though. Aliasing names risks conflicting w/ commits and refs, while functions have no such conflict. And aliases feel a little more "functiony" anyway.
- I made no attempt to include the defined aliases in the `EvalError::UnboundFunction` output. It wasn't immediately obvious to me how to list all config keys defined in the section, but I should admit that I didn't look very hard. :smile: Including them would certainly be kinder and would aid in discoverability.
- This has me wondering about `git branchless` shipping w/ some predefined aliases of it's own, which would be installed via `init`. Doing so would allow us to use Rust for functions that need some intricate logic, while aliases could be used for queries composable from the Rust-based "building block" functions. I'm thinking of something like `siblings=children(parents($1)) - $1`, `onlyParent=exactly(parents($1), 1)`, `sole=exactly($1, 1)`, etc
  - One downside to this, though, is that errors might end up being surprising. For example, if I call `siblings(foo)` but get an error about `children` or `parents`, perhaps that could be confusing?
  - Anyway, just an idea, not in scope for this PR.
- I chose `branchless.revsets.alias` as the config key, and this shows up in the `.config/git/config` file like so:
```
[branchless "revsets.alias"]
    grandChildren = children(children($1))
    oldest = sole(roots(intersection(ancestors($1), descendants($1))))
    sole = exactly($1, 1)
    onlyChild = sole(children($1))
```
  - I don't have strong feelings about the config key, and I'm happy to change to match whatever you'd prefer. ~~As I write this, though, I see that I should drop the `git-` and just use `branchless.revsets.alias` ... I'll have to fix that tomorrow~~ Fixed.

Thank you!