### PR TITLE
Display correct flag name about rewriting public commits (#515)

### DIFF
--- a/git-branchless-lib/src/core/rewrite/plan.rs
+++ b/git-branchless-lib/src/core/rewrite/plan.rs
@@ -544,7 +544,7 @@ impl BuildRebasePlanError {
 You are trying to rewrite {}, such as: {}
 It is generally not advised to rewrite public commits, because your
 collaborators will have difficulty merging your changes.
-Retry with -f/--force to proceed anyways.",
+Retry with -f/--force-rewrite to proceed anyways.",
                     Pluralize {
                         determiner: None,
                         amount: public_commits_to_move.count()?,

--- a/git-branchless/tests/command/test_move.rs
+++ b/git-branchless/tests/command/test_move.rs
@@ -4476,7 +4476,7 @@ fn test_move_public_commit() -> eyre::Result<()> {
         You are trying to rewrite 2 public commits, such as: 96d1c37 create test2.txt
         It is generally not advised to rewrite public commits, because your
         collaborators will have difficulty merging your changes.
-        Retry with -f/--force to proceed anyways.
+        Retry with -f/--force-rewrite to proceed anyways.
         "###);
     }
 


### PR DESCRIPTION
I think this fixes (one of) the issue raised in #515: the error message displayed when attempting to rewrite public commits was out of sync w/ the actual name of the flag.