### PR TITLE
feat(reword): Add `--fixup` flag to `git branchless reword`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (#508) Added `exactly(<revset>, n)` revset function to allow assertions on the number of commits within a set.
 - (#509) User defined [revset aliases](https://github.com/arxanas/git-branchless/wiki/Reference:-Revsets#Aliases).
 - (#534) `git record` accepts a `--detach` option to avoid moving the current branch.
+- (#538) `git reword` accepts a `--fixup` option to convert regular commits into `fixup!` commits (for use with `git rebase --autosquash`)
 
 ### Changed
 

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -271,9 +271,12 @@ fn do_main_and_drop_locals() -> eyre::Result<i32> {
             messages,
             force_rewrite_public_commits,
             discard,
+            commit_to_fixup,
         } => {
             let messages = if discard {
                 InitialCommitMessages::Discard
+            } else if let Some(commit_to_fixup) = commit_to_fixup {
+                InitialCommitMessages::FixUp(commit_to_fixup)
             } else {
                 InitialCommitMessages::Messages(messages)
             };

--- a/git-branchless/src/commands/reword.rs
+++ b/git-branchless/src/commands/reword.rs
@@ -119,7 +119,7 @@ pub fn reword(
                     writeln!(
                         effects.get_error_stream(),
                         "--fixup expects exactly 1 commit, but '{}' evaluated to {}.\nAborting.",
-                        revset.0,
+                        revset,
                         commits.len()
                     )?;
                     return Ok(ExitCode(1));

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -3,6 +3,7 @@
 use clap::{ArgEnum, Args, Command as ClapCommand, IntoApp, Parser};
 use lib::git::NonZeroOid;
 use man::Arg;
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -16,6 +17,12 @@ impl FromStr for Revset {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.to_string()))
+    }
+}
+
+impl Display for Revset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -399,8 +399,6 @@ pub enum Command {
     /// Reword commits.
     Reword {
         /// Zero or more commits to reword. If not provided, defaults to "HEAD".
-        ///
-        /// Can either be hashes, like `abc123`, or ref-specs, like `HEAD^`.
         #[clap(value_parser)]
         revsets: Vec<Revset>,
 
@@ -420,6 +418,11 @@ pub enum Command {
         /// that; otherwise, the editor starts empty.
         #[clap(action, short = 'd', long = "discard", conflicts_with("messages"))]
         discard: bool,
+
+        /// A commit to "fix up". The reworded commits will become `fixup!` commits (suitable for
+        /// use with `git rebase --autosquash`) targeting the supplied commit.
+        #[clap(value_parser, long = "fixup", conflicts_with_all(&["messages", "discard"]))]
+        commit_to_fixup: Option<Revset>,
     },
 
     /// Display a nice graph of the commits you've recently worked on.


### PR DESCRIPTION
This adds a `--fixup` option to `git reword`, providing a convenient way to turn existing commits into `fixup!` commit. With this, instead of doing something like `git reword <commits to reword> -m 'fixup! <paste title of commit to fixup>'`, you can now do `git reword <commits to reword> --fixup <commit to fixup>` and `reword` will handle the rest, including some error checking.

I've been using this for a few weeks and it's been working well. My only remaining concern about this is that the CLI option docs and error messages feel a little clunky because it's hard to talk to about "the commit being fixed up" vs "the commits that will become `fixup!` commits". As usual, suggestions are welcome!