### PR TITLE
fix(revset): Fix ParseError for single quotes in complex nested expresssions

### DIFF
--- a/git-branchless/src/revset/grammar.lalrpop
+++ b/git-branchless/src/revset/grammar.lalrpop
@@ -63,8 +63,8 @@ Name: Cow<'input, str> = {
     // \x22 = double-quote.
     // \x27 = single-quote.
     // \x5c = backslash
-    <s:r"\x22([^\x22]|\x5c.)*\x22|\x27([^\x22]|\x5c.)*\x27"> => {
-        assert!(s.len() >= 2, "There should be at least quote characters in the string literal, got: {}", s);
+    <s:r"\x22([^\x22]|\x5c.)*\x22|\x27([^\x27]|\x5c.)*\x27"> => {
+        assert!(s.len() >= 2, "There should be at least 2 quote characters in the string literal, got: {}", s);
 
         let mut result = String::new();
         let mut last_char_was_backslash = false;

--- a/git-branchless/src/revset/parser.rs
+++ b/git-branchless/src/revset/parser.rs
@@ -380,6 +380,36 @@ mod tests {
             ),
         )
         "###);
+        insta::assert_debug_snapshot!(parse(r#" foo('bar') - baz(qux('qubit')) "#), @r###"
+        Ok(
+            FunctionCall(
+                "difference",
+                [
+                    FunctionCall(
+                        "foo",
+                        [
+                            Name(
+                                "bar",
+                            ),
+                        ],
+                    ),
+                    FunctionCall(
+                        "baz",
+                        [
+                            FunctionCall(
+                                "qux",
+                                [
+                                    Name(
+                                        "qubit",
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        "###);
 
         Ok(())
     }


### PR DESCRIPTION
This includes 2 trivial changes related to revsets: 
- a nitpick on an error message missing a single character
- a minor fix to the revset grammar that include single quoted strings

I ran into an issue trying to use the revset `message('wip') - roots(message('wip'))`. This look valid to me, but triggers a `ParseError` for unexpected `)`. Interestingly enough, many simpler, related revsets seem to work just fine:
- `message('wip')`
- `message('wip') - message('wip')`
- `roots(message('wip'))`
... all work.

But adding the `-` (or any bitwise op, FWIW) was causing the error. I have not checked if this breaks when using the long form of `intersection(...)` etc.

Anyway, I looked at the lalrpop grammar and noticed some asymmetry in the regex for parsing names. This change allows the example revset to parse and evaluate just fine. I've included a test for this edge case, which confirms that it parses. That test fails when run against `master`.

Thanks!