### PR TITLE
feat(move): Add `--fixup` to squash moved commits into the destination

### DIFF
--- a/git-branchless-lib/src/core/rewrite/execute.rs
+++ b/git-branchless-lib/src/core/rewrite/execute.rs
@@ -435,7 +435,7 @@ mod in_memory {
     use crate::core::rewrite::move_branches;
     use crate::core::rewrite::plan::{OidOrLabel, RebaseCommand, RebasePlan};
     use crate::git::{
-        CherryPickFastError, CherryPickFastOptions, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
+        CherryPickFastOptions, CreateCommitFastError, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
     };
     use crate::util::EyreExitOr;
 
@@ -598,7 +598,7 @@ mod in_memory {
                         },
                     ) {
                         Ok(rebased_commit) => rebased_commit,
-                        Err(CherryPickFastError::MergeConflict { conflicting_paths }) => {
+                        Err(CreateCommitFastError::MergeConflict { conflicting_paths }) => {
                             return Ok(RebaseInMemoryResult::MergeFailed(
                                 FailedMergeInfo::Conflict {
                                     commit_oid: *commit_to_apply_oid,

--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -22,7 +22,7 @@ pub use reference::{
     Branch, BranchType, CategorizedReferenceName, Reference, ReferenceName, ReferenceTarget,
 };
 pub use repo::{
-    message_prettify, AmendFastOptions, CherryPickFastError, CherryPickFastOptions,
+    message_prettify, AmendFastOptions, CherryPickFastOptions, CreateCommitFastError,
     Error as RepoError, GitVersion, PatchId, Repo, ResolvedReferenceInfo, Result as RepoResult,
     Time,
 };

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -513,6 +513,10 @@ pub enum Command {
         #[clap(flatten)]
         move_options: MoveOptions,
 
+        /// Combine the moved commits and squash them into the destination commit.
+        #[clap(action, short = 'F', long = "fixup", conflicts_with = "insert")]
+        fixup: bool,
+
         /// Insert the subtree between the destination and it's children, if any.
         /// Only supported if the moved subtree has a single head.
         #[clap(action, short = 'I', long = "insert")]

--- a/git-branchless/src/commands/amend.rs
+++ b/git-branchless/src/commands/amend.rs
@@ -373,6 +373,9 @@ pub fn amend(
                 "Amended with {uncommitted_changes}.",
             )?;
         }
+        AmendFastOptions::FromCommit { .. } => {
+            unreachable!("BUG: AmendFastOptions::FromCommit should not have been constructed.")
+        }
     }
 
     Ok(Ok(()))

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -93,6 +93,7 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
             exact,
             resolve_revset_options,
             move_options,
+            fixup,
             insert,
         } => git_branchless_move::r#move(
             &effects,
@@ -103,6 +104,7 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
             exact,
             &resolve_revset_options,
             &move_options,
+            fixup,
             insert,
         )?,
 

--- a/git-branchless/tests/test_move.rs
+++ b/git-branchless/tests/test_move.rs
@@ -71,14 +71,18 @@ fn test_move_stick() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                        commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
-                        commit_to_apply_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        commits_to_apply_oids: [
+                            NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -202,21 +206,27 @@ fn test_move_insert_stick() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                        commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
-                        commit_to_apply_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        commits_to_apply_oids: [
+                            NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
-                        commit_to_apply_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
@@ -2280,14 +2290,18 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
                         },
                         Pick {
                             original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                            commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                            commits_to_apply_oids: [
+                                NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                            ],
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
                         },
                         Pick {
                             original_commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
-                            commit_to_apply_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                            commits_to_apply_oids: [
+                                NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
+                            ],
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(355e173bf9c5d2efac2e451da0cdad3fb82b869a),
@@ -2388,7 +2402,9 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
-                        commit_to_apply_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
+                        commits_to_apply_oids: [
+                            NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(e85d25c772a05b5c73ea8ec43881c12bbf588848),
@@ -2460,14 +2476,18 @@ fn test_move_base() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
-                        commit_to_apply_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
-                        commit_to_apply_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(70deb1e28791d8e7dd5a1f0c871a51b91282562f),
@@ -2596,7 +2616,9 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
-                        commit_to_apply_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                        commits_to_apply_oids: [
+                            NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
@@ -2670,7 +2692,9 @@ fn test_move_branch() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
-                        commit_to_apply_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
+                        commits_to_apply_oids: [
+                            NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(98b9119d16974f372e76cb64a3b77c528fc0b18b),
@@ -2884,7 +2908,9 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
-                        commit_to_apply_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        commits_to_apply_oids: [
+                            NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
@@ -3684,7 +3710,9 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                         },
                         Pick {
                             original_commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
-                            commit_to_apply_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                            commits_to_apply_oids: [
+                                NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
+                            ],
                         },
                         DetectEmptyCommit {
                             commit_oid: NonZeroOid(fe65c1fe15584744e649b2c79d4cf9b0d878f92e),
@@ -4065,7 +4093,9 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(50eef922b99bc8a8829a1ded374231f9a025d28c),
-                        commit_to_apply_oid: NonZeroOid(50eef922b99bc8a8829a1ded374231f9a025d28c),
+                        commits_to_apply_oids: [
+                            NonZeroOid(50eef922b99bc8a8829a1ded374231f9a025d28c),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(50eef922b99bc8a8829a1ded374231f9a025d28c),
@@ -4075,7 +4105,9 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(00aa7adb4f38b8b1c04b062a1fdc897fcc6c471d),
-                        commit_to_apply_oid: NonZeroOid(00aa7adb4f38b8b1c04b062a1fdc897fcc6c471d),
+                        commits_to_apply_oids: [
+                            NonZeroOid(00aa7adb4f38b8b1c04b062a1fdc897fcc6c471d),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(00aa7adb4f38b8b1c04b062a1fdc897fcc6c471d),
@@ -4090,7 +4122,9 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(af1a4cee7c63ea7eba381967223d17a6386e5a4c),
-                        commit_to_apply_oid: NonZeroOid(af1a4cee7c63ea7eba381967223d17a6386e5a4c),
+                        commits_to_apply_oids: [
+                            NonZeroOid(af1a4cee7c63ea7eba381967223d17a6386e5a4c),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(af1a4cee7c63ea7eba381967223d17a6386e5a4c),
@@ -4113,7 +4147,9 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
                     },
                     Pick {
                         original_commit_oid: NonZeroOid(7f5857ec34dab5bf7991da2512bf529789204413),
-                        commit_to_apply_oid: NonZeroOid(7f5857ec34dab5bf7991da2512bf529789204413),
+                        commits_to_apply_oids: [
+                            NonZeroOid(7f5857ec34dab5bf7991da2512bf529789204413),
+                        ],
                     },
                     DetectEmptyCommit {
                         commit_oid: NonZeroOid(7f5857ec34dab5bf7991da2512bf529789204413),


### PR DESCRIPTION
**Summary**  
As the title says, this adds a `move --fixup` flag to squash commits into the destination, in memory or on disk. With this, both of these use cases:
- `rebase -i` + reordering & marking as `fixup!`
- `reword --fixup <dest> <revset> ; rebase -i --autosquash`

Can be replaced with just
- `move -d <dest> -x <revset> --fixup`

Add'l examples:
- Oops, used `commit` instead of `amend`, lets squash HEAD into it's parent: `move -d @~ -x @ --fixup`
- Squash a branch onto a single commit: `move -d head(stack()) -s children(head(stack())) --fixup`
    - Useful perhaps for cases like https://github.com/arxanas/git-branchless/discussions/965#discussioncomment-6453119

The original idea came from https://github.com/arxanas/git-branchless/pull/538#pullrequestreview-1105180957 and it's taken me most of a year of on and (mostly) off work to get it working. 

**Status**  
- In memory squashing seems to be working flawlessly. In the current state, I've yet to encounter any issues with this.
- On disk squashing seems to be working well **with one caveat**:
    - For some reason, the intermediate squashed commits aren't reliably cleaned up after the rebase, so the smartlog ends up with lots of `# This is a combination of ...` commits leftover.
    - This does not seem to be an issue for non-branchless triggered rebases. In other words, if I do `add --updated ; absorb ; rebase -i --autosquash`, it seems to work fine w/o leftover commits.
    - I've not been able to repro, but my current suspicion is that it's somehow related to merge conflicts and the usage of `--fixup -m` to kick things out to disk; and thus probably the rebase plan that I'm creating for on disk rebases or some of the changes related to that.
    - In all cases, the leftover commits can be safely discarded with some thing like `hide 'stack() - main..branches()'`

**Review request**  
- This is a big PR (`13 files changed, 2479 insertions(+), 204 deletions(-)`), but most of these (1929 insertions) are new tests.
- The summary of how this works is:
    - sort the commits (inc the destination) topologically
    - apply all commits to the 'rootiest' of these, one after the other in topological order
    - remove all moved commits from the tree
    - replace the dest commit w/ the final squashed commit
    - For in-memory, this is all done in Rust/git2, creating a new in-mem commit for each squash but only writing the final one to disk. I think that this is "right", but I don't know if it's the fastest approach.
    - For on-disk, this is all done via `git` commands fed to `rebase -i`. This involved lots of manual commit rewriting and hiding to get the order and final tree right. This works (mostly, see above) but feels really clunky and heavy handed.
- There are 4 `FIXME` comments that I left in place w/ questions and/or concerns about my implementation. 
    - I think that most of these are along the lines of "well this is working, but is it the right way to be doing it"
- I would love feedback on the names in the UI (`--fixup`) and API (structs and such). 

As always, I welcome any feedback, guidance or suggestions. This has been tricky to get my head around, but I've found it very satisfying to use. I'm pretty happy w/ how it works, and I'd love to get it polished up and merged. Thank you!


<details><summary>Original description</summary>
@arxanas I could use some help with this.

This seems to be working for simple cases (ie in memory sticks) but I think I could use some guidance to get unblocked on where to go next. Specifically, I'm having a hard time getting my head around how to handle on-disk fixup rebases and having some issues with fixing up complicated commit graphs. I feel like I'm playing whack-a-mole with errors and conditions: if I get one test working, another breaks; when I get that working, the other one breaks; etc, and I'm left wondering if my approach is heading in the wrong direction and/or is too rigid or something.

-  This is still pretty "draft"; please don't be too alarmed by the ugly bits that I need to go back through and clean up! :smile:

-  I added some code that uses `git2::Tree::iter()` directly
  -  I started to work on this, but it felt very copy-pasty and boilerplate-y and seemed to add a lot more code than I was expecting compared to just using `tree.inner.iter()`, plus other parts of `repo.rs` already use `tree.inner.iter()`, so I gave up and moved on to more fun stuff. :laughing: Does it seem OK to leave that as is, or would you prefer that it be wrapped?
-  In-memory fix ups seem to work for stick stacks, but fixup rebases that involve trees are being left in a "needs restack" state.
  -  Is this inevitable, or is there is a convenient way to recognize and automatically restack in cases like these? (See `test_move_fixup_complicated`.
- ~~On disk rebase is not working~~ **Update** On disk fixup rebases are working.
  - As noted, the last commit in this stack is me hacking around to try to get on-disk fixup rebases to work. It's incomplete and breaks many/most of the in-memory fixup rebase tests.
  - I have tried doing `SkipUpstreamAppliedCommit` after every `FixUp`. This helps in some cases, but not all, and it makes in-memory fixups involving multiple fixup commits complicated b/c it's hard to keep track of the target/fixed-up commit as it's always being "rewritten to zero".
  - Perhaps I need to be sorting the `RebaseCommands` differently, so that `SkipUpstreamAppliedCommit` is only called at the end of the rebase?
  - Or could it be that I'm not giving the `post-rewrite` etc hooks the info they need to figure things out?
</details>