### PR TITLE
fix(submit): Prefer remote.pushDefault

### DIFF
--- a/git-branchless/src/commands/submit.rs
+++ b/git-branchless/src/commands/submit.rs
@@ -181,6 +181,10 @@ To create and push them, retry this operation with the --create option."
 }
 
 fn get_default_remote(repo: &Repo) -> eyre::Result<Option<String>> {
+    if let Some(push_default_remote) = repo.get_readonly_config()?.get("remote.pushDefault")? {
+        return Ok(Some(push_default_remote));
+    }
+
     let main_branch_reference = repo.get_main_branch_reference()?;
     let main_branch_name = main_branch_reference.get_name()?;
     match CategorizedReferenceName::new(&main_branch_name) {
@@ -206,6 +210,5 @@ fn get_default_remote(repo: &Repo) -> eyre::Result<Option<String>> {
         }
     }
 
-    let push_default_remote_opt = repo.get_readonly_config()?.get("remote.pushDefault")?;
-    Ok(push_default_remote_opt)
+    Ok(None)
 }


### PR DESCRIPTION
Hi there. I'm just opening this for discussion's sake. I tried out the sweet new `git submit` command for #545 and found that either I'm misunderstanding how to use it, or it might not be set up correctly to handle the "triangle" or forked remote workflow, as it pushed my branch directly to `origin` (this repo) instead of my fork as I had intended.

In my case, `master` branch is tracking `origin/master`, but I've got `remote.pushDefault` set to `claytonrcarter`, which is my fork. As I understand the current code, `git submit` will prefer whatever remote is being tracked by the main branch, in my case `origin`, and will only use `pushDefault` if there is no main tracking branch. Unless I'm misreading this, this seems like it might make `pushDefault` useful only before a remote is added ... maybe?

Anyway, I'm suggesting that we prefer `pushDefault` over whatever the main branch is using. I tried this out to push this change, and it worked as expected.

If this is not correct, please feel free to close and, if you don't mind, give me a little hint about how/why I'm misusing and/or misunderstanding this. Thanks!