### PR TITLE
Fix lint error

### DIFF
--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -107,14 +107,14 @@ pub enum Error {
     #[error("could not create commit: {0}")]
     CreateCommit(#[source] git2::Error),
 
-    #[error("could not cherry-pick commit {commit} onto {onto}: {0}")]
+    #[error("could not cherry-pick commit {commit} onto {onto}: {source}")]
     CherryPickCommit {
         source: git2::Error,
         commit: NonZeroOid,
         onto: NonZeroOid,
     },
 
-    #[error("could not fast-cherry-pick commit {commit} onto {onto}: {0}")]
+    #[error("could not fast-cherry-pick commit {commit} onto {onto}: {source}")]
     CherryPickFast {
         source: git2::Error,
         commit: NonZeroOid,


### PR DESCRIPTION
I believe this is what was intended.  I think the linter caught a genuine error here, because I believe `0` actually would refer to `commit` here.  At least that's what the linter suggests would be equivalent.  Guessing maybe the map gets sorted alphabetically, so then `0` would refer to `commit`?

Looks like there's no tests for this error message, though, as the tests passed whether I put `{commit}` or `{source}` here