### PR TITLE
feat(revset): Add `rewritten` revset function

### DIFF
--- a/git-branchless/tests/command/test_query.rs
+++ b/git-branchless/tests/command/test_query.rs
@@ -84,7 +84,7 @@ fn test_query_eval_error() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @r###"
-        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, descendants, difference, draft, exactly, heads, intersection, message, none, not, only, parents, parents.nth, paths.changed, range, roots, stack, union
+        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, current, descendants, difference, draft, exactly, heads, intersection, message, none, not, only, parents, parents.nth, paths.changed, range, roots, stack, union
         "###);
         insta::assert_snapshot!(stdout, @"");
     }


### PR DESCRIPTION
This is my first take on a `rewritten()` revset that resolves possibly-outdated commit hashes into their most current version. First discussed here https://github.com/arxanas/git-branchless/discussions/48#discussioncomment-3718889

The primary use case is being able to do things like `git move -x abc123 -d deb456 && git reword 'rewritten(abc123)'`, ie to avoid having to lookup the new SHA of the moved commit. If I understand the docs of `find_rewrite_target()` correctly, this should be able to work across many rebase/move/reword/restack/etc operations, so long as the specified SHA hasn't been gc'd.

I have only exercised this a little bit, so I'm not 100% certain of the implementation. I also note that there's *a lot* of `.wrap_err("...").map_err(EvalError::OtherError)` going on in here. They seemed like they should maybe "other errors", but I'd be happy to change those if another error type makes more sense.