### PR TITLE
feat(switch): change `--branch` to `--create`

### DIFF
--- a/git-branchless/src/opts.rs
+++ b/git-branchless/src/opts.rs
@@ -138,7 +138,7 @@ pub struct SwitchOptions {
 
     /// When checking out the target commit, also create a branch with the
     /// provided name pointing to that commit.
-    #[clap(value_parser, short = 'b', long = "branch")]
+    #[clap(value_parser, short = 'c', long = "create")]
     pub branch_name: Option<String>,
 
     /// Forcibly switch commits, discarding any working copy changes if

--- a/git-branchless/tests/command/test_navigation.rs
+++ b/git-branchless/tests/command/test_navigation.rs
@@ -769,7 +769,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
     {
         let git = git.duplicate_repo()?;
         {
-            let (stdout, _stderr) = git.run(&["branchless", "switch", "-b", "foo", "HEAD^"])?;
+            let (stdout, _stderr) = git.run(&["branchless", "switch", "-c", "foo", "HEAD^"])?;
             insta::assert_snapshot!(stdout, @r###"
             branchless: running command: <git-executable> checkout HEAD^ -b foo
             :
@@ -780,7 +780,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         }
 
         {
-            let (stdout, _stderr) = git.run(&["branchless", "switch", "-b", "bar"])?;
+            let (stdout, _stderr) = git.run(&["branchless", "switch", "-c", "bar"])?;
             insta::assert_snapshot!(stdout, @r###"
             branchless: running command: <git-executable> checkout -b bar
             :


### PR DESCRIPTION
`git branch` uses `--branch` to create a new branch, but `git switch` uses `--create`. This PR changes `git-branchless switch` to match `git switch`.