### PR TITLE
tests: explicitly set an initial git branch during init

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -292,7 +292,10 @@ stderr:
     /// with it.
     #[instrument]
     pub fn init_repo_with_options(&self, options: &GitInitOptions) -> eyre::Result<()> {
-        self.run(&["init"])?;
+        // Ensure that the branch "master" is created for tests, regardless of
+        // the `init.defaultBranch` configuration variable, or git defaults.
+        self.run(&["init", "--initial-branch=master"])?;
+
         self.run(&["config", "user.name", DUMMY_NAME])?;
         self.run(&["config", "user.email", DUMMY_EMAIL])?;
 


### PR DESCRIPTION
Some tests assume a "master" branch exists during tests, which is assumed to be created on the git repo initialization. This assumption might be incorrect - from the `git-init` man page:

> the default [branch] name [is] currently `master`, but this is subject
> to change in the future; the name can be customized via the
> `init.defaultBranch` configuration variable

We cannot rely on the default branch name as it may be different - `init.defaultBranch` could be set in the global git config to something other than "master", or it could change in a git version increase.

This commit explicitly sets the initial branch so tests relying on a "master" branch will work, even if the default branch name changes or `init.defaultBranch` is set to something different.