### PR TITLE
tests: ignore global config in tests

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -166,6 +166,8 @@ impl Git {
 
         let new_path = self.get_path_for_env();
         let envs = vec![
+            ("GIT_CONFIG_GLOBAL", OsString::from("")),
+            ("GIT_CONFIG_SYSTEM", OsString::from("")),
             ("GIT_CONFIG_NOSYSTEM", OsString::from("1")),
             ("GIT_AUTHOR_DATE", date.clone()),
             ("GIT_COMMITTER_DATE", date),

--- a/git-branchless/tests/command/test_init.rs
+++ b/git-branchless/tests/command/test_init.rs
@@ -101,10 +101,16 @@ fn test_dont_install_existing_aliases() -> eyre::Result<()> {
     std::fs::create_dir(&fake_home_dir)?;
     std::fs::write(&fake_home_git_config, "[alias]\n\tsl = status\n")?;
 
-    let env = HashMap::from([(
-        "HOME".to_string(),
-        fake_home_dir.to_string_lossy().to_string(),
-    )]);
+    let env = HashMap::from([
+        (
+            "HOME".to_string(),
+            fake_home_dir.to_string_lossy().to_string(),
+        ),
+        (
+            "GIT_CONFIG_GLOBAL".to_string(),
+            fake_home_git_config.to_string_lossy().to_string(),
+        ),
+    ]);
     let git_run_options = GitRunOptions {
         env,
         ..GitRunOptions::default()


### PR DESCRIPTION
Global configs such as `merge.conflictStyle = diff3` interfere with tests. This uses `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` introduced in Git 2.32, but keeps the prior use of `GIT_CONFIG_NOGLOBAL` as older git
versions might not support these new environment variables. See https://stackoverflow.com/a/67512433 for more details.

While the documentation for this feature both mention setting the environment variables to "/dev/null" to ignore the system and global configs, this is not portable as Windows does not have a /dev/null file. An empty string works the same way and should be portable.