### PR TITLE
tests: ensure Git executable does not have a global config

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -292,6 +292,21 @@ stderr:
     /// with it.
     #[instrument]
     pub fn init_repo_with_options(&self, options: &GitInitOptions) -> eyre::Result<()> {
+        // The below should fail with "fatal: $HOME not set" if the environment
+        // variables propagated correctly to the `git` binary.
+        self.run_with_options(
+            &["config", "--global", "--list"],
+            &GitRunOptions {
+                expected_exit_code: 128,
+                ..Default::default()
+            },
+        )
+        .wrap_err(
+            "The Git global configuration should not exist during tests, \
+as the HOME environment variable is not set. \
+Check that the Git executable is not being wrapped in a shell script.",
+        )?;
+
         self.run(&["init"])?;
         self.run(&["config", "user.name", DUMMY_NAME])?;
         self.run(&["config", "user.email", DUMMY_EMAIL])?;

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -292,21 +292,6 @@ stderr:
     /// with it.
     #[instrument]
     pub fn init_repo_with_options(&self, options: &GitInitOptions) -> eyre::Result<()> {
-        // The below should fail with "fatal: $HOME not set" if the environment
-        // variables propagated correctly to the `git` binary.
-        self.run_with_options(
-            &["config", "--global", "--list"],
-            &GitRunOptions {
-                expected_exit_code: 128,
-                ..Default::default()
-            },
-        )
-        .wrap_err(
-            "The Git global configuration should not exist during tests, \
-as the HOME environment variable is not set. \
-Check that the Git executable is not being wrapped in a shell script.",
-        )?;
-
         self.run(&["init"])?;
         self.run(&["config", "user.name", DUMMY_NAME])?;
         self.run(&["config", "user.email", DUMMY_EMAIL])?;

--- a/git-branchless/tests/test_git.rs
+++ b/git-branchless/tests/test_git.rs
@@ -1,0 +1,26 @@
+use eyre::WrapErr;
+use lib::testing::{make_git, GitRunOptions};
+
+#[test]
+fn test_git_is_not_a_wrapper() -> eyre::Result<()> {
+    let git = make_git()?;
+    {
+        let (_stdout, stderr) = git
+            .run_with_options(
+                &["config", "--global", "--list"],
+                &GitRunOptions {
+                    expected_exit_code: 128,
+                    ..Default::default()
+                },
+            )
+            .wrap_err(
+                "The Git global configuration should not exist during tests, \
+as the HOME environment variable is not set. \
+Check that the Git executable is not being wrapped in a shell script.",
+            )?;
+        insta::assert_snapshot!(stderr, @r###"
+        fatal: $HOME not set
+        "###);
+    }
+    Ok(())
+}


### PR DESCRIPTION
This ensures that users are not running Git through a wrapper such as the following:

```zsh
#!/usr/bin/zsh
exec git "$@"
```

Running Git through a wrapper like this causes some very interesting behaviour and many test failures (at least on my Linux machine):

- Zsh automatically sets the `HOME` environment variable, causing the Git global config to leak into tests. This causes confusing test failures as the global config is assumed to be empty in tests (as `$HOME` should not be set).

- Zsh automatically sources `~/.profile`, so if Cargo was installed locally (as recommended), `~/.profile` will source a script to add `$HOME/.cargo/bin` to the `PATH` environment variable if it exists. Therefore, the `git` command run by the wrapper would use the local Cargo installation of `git-branchless` if it exists, not the `git-branchless` under test.

---

This unfortunately adds one extra `git` call to every test, possibly slowing down the entire test suite for an obscure error case. Is there a better place to put this check other than `init_repo_with_options`?

FWIW, I was using such a wrapper (and was very confused why the tests weren't passing). There are some Google-internal resources which recommend using a wrapper like that, so it might not just be me who stumbles across this error case.