### PR TITLE
smartlog: Abbreviate rewritten OIDs to 7 characters

### DIFF
--- a/git-branchless-lib/src/core/node_descriptors.rs
+++ b/git-branchless-lib/src/core/node_descriptors.rs
@@ -271,7 +271,8 @@ impl<'a> NodeDescriptor for ObsolescenceExplanationDescriptor<'a> {
                     find_rewrite_target(self.event_replayer, self.event_cursor, object.get_oid());
                 rewrite_target.map(|rewritten_oid| {
                     StyledString::styled(
-                        format!("(rewritten as {})", &rewritten_oid.to_string()[..8]),
+                        // `7` is the default value for config setting `core.abbrev`.
+                        format!("(rewritten as {})", &rewritten_oid.to_string()[..7]),
                         BaseColor::Black.light(),
                     )
                 })

--- a/git-branchless-lib/src/core/rewrite/plan.rs
+++ b/git-branchless-lib/src/core/rewrite/plan.rs
@@ -2004,14 +2004,14 @@ mod tests {
         | |
         | o 22cf458 create test4.txt
         |
-        x 70deb1e (rewritten as b8f27a86) create test3.txt
+        x 70deb1e (rewritten as b8f27a8) create test3.txt
         |\
-        | x 355e173 (rewritten as 22cf4586) create test4.txt
+        | x 355e173 (rewritten as 22cf458) create test4.txt
         | & (merge) 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
         |
-        x 9ea1b36 (rewritten as 2b47b505) create test5.txt
+        x 9ea1b36 (rewritten as 2b47b50) create test5.txt
         |
-        | & (merge) 355e173 (rewritten as 22cf4586) create test4.txt
+        | & (merge) 355e173 (rewritten as 22cf458) create test4.txt
         |/
         o 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
         hint: there is 1 abandoned commit in your commit graph

--- a/git-branchless/tests/test_amend.rs
+++ b/git-branchless/tests/test_amend.rs
@@ -71,7 +71,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
             |
             o 62fc20d create test1.txt
             |\
-            | x 7ac317b (rewritten as 7c5e8578) create test2.txt
+            | x 7ac317b (rewritten as 7c5e857) create test2.txt
             | |
             | o b51f01b create test3.txt
             |
@@ -99,7 +99,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
             |
             o 62fc20d create test1.txt
             |\
-            | x 7ac317b (rewritten as 7c5e8578) create test2.txt
+            | x 7ac317b (rewritten as 7c5e857) create test2.txt
             | |
             | o b51f01b create test3.txt
             |

--- a/git-branchless/tests/test_move.rs
+++ b/git-branchless/tests/test_move.rs
@@ -1967,16 +1967,16 @@ fn test_move_exact_range_one_side_of_merged_stack_without_base_and_merge_commits
     |\
     | o 96d1c37 create test2.txt
     | |\
-    | | x 70deb1e (rewritten as 4838e49b) create test3.txt
+    | | x 70deb1e (rewritten as 4838e49) create test3.txt
     | | |
-    | | x 355e173 (rewritten as a2482074) create test4.txt
+    | | x 355e173 (rewritten as a248207) create test4.txt
     | | & (merge) 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     | |
     | o d2e18e3 create test5.txt
     | |
     | o d43fec8 create test6.txt
     | |
-    | | & (merge) 355e173 (rewritten as a2482074) create test4.txt
+    | | & (merge) 355e173 (rewritten as a248207) create test4.txt
     | |/
     | @ 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     |
@@ -2052,9 +2052,9 @@ fn test_move_exact_range_one_side_of_merged_stack_including_base_and_merge_commi
     | | o 355e173 create test4.txt
     | | & (merge) 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     | |
-    | x d2e18e3 (rewritten as ea7aa064) create test5.txt
+    | x d2e18e3 (rewritten as ea7aa06) create test5.txt
     | |
-    | x d43fec8 (rewritten as da42aeb4) create test6.txt
+    | x d43fec8 (rewritten as da42aeb) create test6.txt
     | |
     | | & (merge) 355e173 create test4.txt
     | |/
@@ -2137,14 +2137,14 @@ fn test_move_exact_range_two_partial_components_of_merged_stack() -> eyre::Resul
     | |\
     | | o 70deb1e create test3.txt
     | | |
-    | | x 355e173 (rewritten as bf0d52a6) create test4.txt
+    | | x 355e173 (rewritten as bf0d52a) create test4.txt
     | | & (merge) 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     | |\
-    | | x d2e18e3 (rewritten as ea7aa064) create test5.txt
+    | | x d2e18e3 (rewritten as ea7aa06) create test5.txt
     | | |
-    | | x d43fec8 (rewritten as d071649c) create test6.txt
+    | | x d43fec8 (rewritten as d071649) create test6.txt
     | | |
-    | | | & (merge) 355e173 (rewritten as bf0d52a6) create test4.txt
+    | | | & (merge) 355e173 (rewritten as bf0d52a) create test4.txt
     | | |/
     | | @ 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     | |
@@ -3887,14 +3887,14 @@ fn test_move_merge_commit_both_parents() -> eyre::Result<()> {
         |\
         | o 96d1c37 create test2.txt
         | |
-        | x 70deb1e (rewritten as 4838e49b) create test3.txt
+        | x 70deb1e (rewritten as 4838e49) create test3.txt
         | |\
-        | | x 355e173 (rewritten as a2482074) create test4.txt
+        | | x 355e173 (rewritten as a248207) create test4.txt
         | | & (merge) 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
         | |
-        | x 9ea1b36 (rewritten as b1f9efa0) create test5.txt
+        | x 9ea1b36 (rewritten as b1f9efa) create test5.txt
         | |
-        | | & (merge) 355e173 (rewritten as a2482074) create test4.txt
+        | | & (merge) 355e173 (rewritten as a248207) create test4.txt
         | |/
         | @ 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
         |

--- a/git-branchless/tests/test_restack.rs
+++ b/git-branchless/tests/test_restack.rs
@@ -24,7 +24,7 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
         |\
         | @ 024c35c amend test1.txt
         |
-        x 62fc20d (rewritten as 024c35ce) create test1.txt
+        x 62fc20d (rewritten as 024c35c) create test1.txt
         |
         o 96d1c37 create test2.txt
         |
@@ -337,11 +337,11 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         |\
         | o 7357d2b updated test2
         |\
-        | x 96d1c37 (rewritten as 7357d2b7) create test2.txt
+        | x 96d1c37 (rewritten as 7357d2b) create test2.txt
         | |
         | o 70deb1e create test3.txt
         |
-        x bf0d52a (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d) create test4.txt
         |
         o 848121c create test5.txt
         hint: there are 2 abandoned commits in your commit graph
@@ -374,7 +374,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         | |
         | o 944f78d create test3.txt
         |
-        x bf0d52a (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d) create test4.txt
         |
         o 848121c create test5.txt
         hint: there is 1 abandoned commit in your commit graph
@@ -397,7 +397,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         | |
         | o 944f78d create test3.txt
         |
-        x bf0d52a (rewritten as 3bd716d5) create test4.txt
+        x bf0d52a (rewritten as 3bd716d) create test4.txt
         |
         o 848121c create test5.txt
         hint: there is 1 abandoned commit in your commit graph
@@ -535,9 +535,9 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         O f777ecc create initial.txt
         |\
-        : x 62fc20d (rewritten as 14042005) create test1.txt
+        : x 62fc20d (rewritten as 1404200) create test1.txt
         : |
-        : % 96d1c37 (rewritten as 59e75818) (> foo) create test2.txt
+        : % 96d1c37 (rewritten as 59e7581) (> foo) create test2.txt
         :
         O 59e7581 (master) create test2.txt
         "###);

--- a/git-branchless/tests/test_smartlog.rs
+++ b/git-branchless/tests/test_smartlog.rs
@@ -355,7 +355,7 @@ fn test_show_rewritten_commit_hash() -> eyre::Result<()> {
         |\
         | @ 2ebe095 test1 version 2
         |
-        x 62fc20d (rewritten as 2ebe0950) create test1.txt
+        x 62fc20d (rewritten as 2ebe095) create test1.txt
         |
         o 96d1c37 create test2.txt
         hint: there is 1 abandoned commit in your commit graph
@@ -414,7 +414,7 @@ fn test_show_hidden_commits() -> eyre::Result<()> {
         |\
         | x cb8137a (manually hidden) amended test2
         |
-        x 96d1c37 (rewritten as cb8137ad) create test2.txt
+        x 96d1c37 (rewritten as cb8137a) create test2.txt
         "###);
     }
 
@@ -551,7 +551,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
         |\
         | @ ae94dc2 amended test1
         |
-        x 62fc20d (rewritten as ae94dc2a) create test1.txt
+        x 62fc20d (rewritten as ae94dc2) create test1.txt
         |
         o 96d1c37 create test2.txt
         hint: there is 1 abandoned commit in your commit graph
@@ -570,7 +570,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
         |\
         | @ ae94dc2 amended test1
         |
-        x 62fc20d (rewritten as ae94dc2a) create test1.txt
+        x 62fc20d (rewritten as ae94dc2) create test1.txt
         |
         o 96d1c37 create test2.txt
         "###);
@@ -597,7 +597,7 @@ fn test_smartlog_hint_abandoned_except_current_commit() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         O f777ecc create initial.txt
         |\
-        | % 62fc20d (rewritten as ae94dc2a) create test1.txt
+        | % 62fc20d (rewritten as ae94dc2) create test1.txt
         |
         O ae94dc2 (master) amended test1
         "###);
@@ -740,7 +740,7 @@ fn test_smartlog_hidden() -> eyre::Result<()> {
         |\
         | @ ae94dc2 amended test1
         |
-        x 62fc20d (rewritten as ae94dc2a) create test1.txt
+        x 62fc20d (rewritten as ae94dc2) create test1.txt
         "###);
     }
 


### PR DESCRIPTION
This matches the default `core.abbrev` config setting.

I was confused as to why I couldn't find the rewritten commit in my smartlog, but it turns out there was one extra character at the end of the commit OID.