### PR TITLE
fix(init): expand tilde from core.hooksPath

### DIFF
--- a/git-branchless-lib/src/core/config.rs
+++ b/git-branchless-lib/src/core/config.rs
@@ -33,7 +33,7 @@ pub fn get_hooks_dir(
         .run_silent(
             repo,
             event_tx_id,
-            &["config", "core.hooksPath"],
+            &["config", "--type", "path", "core.hooksPath"],
             GitRunOpts {
                 treat_git_failure_as_error: false,
                 ..Default::default()


### PR DESCRIPTION
Using --type path will automatically take care of tilde and `%(prefix)` expansion. Fix #731.