### PR TITLE
fix(amend): don't amend children onto grandparent commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ version = "0.7.0-pre.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bstr",
  "bugreport",
  "color-eyre",
  "console",

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.7.0-pre.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bstr = "1.0.1"
 bugreport = "0.5.0"
 color-eyre = "0.6.2"
 console = "0.15.5"


### PR DESCRIPTION
Fixes #746.
