### PR TITLE
style: diff.deltas() is already an iterator

### DIFF
--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -819,7 +819,6 @@ impl Repo {
             })?;
         let paths = diff
             .deltas()
-            .into_iter()
             .flat_map(|delta| vec![delta.old_file().path(), delta.new_file().path()])
             .flat_map(|p| p.map(PathBuf::from))
             .collect();


### PR DESCRIPTION
Calling .into_iter() in this context is a no-op and is flagged by clippy.
