### PR TITLE
feat(smartlog): add --reverse option

### DIFF
--- a/git-branchless-lib/src/core/effects.rs
+++ b/git-branchless-lib/src/core/effects.rs
@@ -567,6 +567,15 @@ impl Effects {
         }
     }
 
+    /// Apply transformations to the returned `Effects` to support emitting
+    /// graphical output in the opposite of its usual order.
+    pub fn reverse_order(&self, reverse: bool) -> Self {
+        Self {
+            glyphs: self.glyphs.clone().reverse_order(reverse),
+            ..self.clone()
+        }
+    }
+
     /// Start reporting progress for the specified operation type.
     ///
     /// A progress spinner is shown until the returned `ProgressHandle` is

--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -218,6 +218,15 @@ impl Glyphs {
         }
     }
 
+    /// Return a `Glyphs` object suitable for rendering graphs in the reverse of
+    /// their usual order.
+    pub fn reverse_order(mut self, reverse: bool) -> Self {
+        if reverse {
+            std::mem::swap(&mut self.split, &mut self.merge);
+        }
+        self
+    }
+
     /// Write the provided string to `out`, using ANSI escape codes as necessary to
     /// style it.
     ///

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -279,6 +279,11 @@ pub struct SmartlogArgs {
     #[clap(value_parser)]
     pub revset: Option<Revset>,
 
+    /// Print the smartlog in the opposite of the usual order, with the latest
+    /// commits first.
+    #[clap(long)]
+    pub reverse: bool,
+
     /// Options for resolving revset expressions.
     #[clap(flatten)]
     pub resolve_revset_options: ResolveRevsetOptions,

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -316,9 +316,9 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::core::eventlog::from_event_log_db with effects=<Output fancy=false> repo=<Git repository at: "<repo-path>/.git/"> event_log_db=<EventLogDb>
           at some/file/path.rs:123
-       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: Revset("((draft() | branches() | @) % main()) | branches() | @"), resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: Revset("((draft() | branches() | @) % main()) | branches() | @"), resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false }
           at some/file/path.rs:123
-       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
           at some/file/path.rs:123
 
     Suggestion:


### PR DESCRIPTION
This pull request adds a flag for reverse-chronological smartlog output. 😈 As far as I can tell, all that's needed is to swap the `split` and `merge` glyphs and then to reverse the order when outputting the smartlog line by line.

I've continued to emit hints at the end of the output, mostly just because that was the path of least resistance. I'm agnostic on whether it would make sense to move them to the top.