### PR TITLE
feat(reword): Use distinctive name for tempfile

### DIFF
--- a/git-branchless-reword/src/dialoguer_edit.rs
+++ b/git-branchless-reword/src/dialoguer_edit.rs
@@ -119,7 +119,7 @@ impl Editor {
     /// entered text.
     pub fn edit(&self, s: &str) -> io::Result<Option<String>> {
         let mut f = tempfile::Builder::new()
-            .prefix("edit-")
+            .prefix("COMMIT_EDITMSG-")
             .suffix(&self.extension)
             .rand_bytes(12)
             .tempfile()?;


### PR DESCRIPTION
Name the tempfile used by `git reword` `COMMIT_EDITMSG-*.txt`, aligning with the naming of `.git/COMMIT_EDITMSG`. This makes it easier to configure editors to apply syntax highlighting without false positives.