### PR TITLE
Create `scm-record` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "scm-record"
+version = "0.1.0"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2683,12 @@ dependencies = [
 [[package]]
 name = "scm-record"
 version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "thiserror",
+ "tracing",
+ "tui",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3197,6 +3209,19 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tui"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "git-branchless",
     "git-record",
     "scm-bisect",
+    "scm-record",
 ]
 
 [workspace.metadata.release]

--- a/scm-record/Cargo.toml
+++ b/scm-record/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crossterm = "0.25.0"
+thiserror = "1.0.38"
+tracing = "0.1.37"
+tui = "0.19.0"

--- a/scm-record/Cargo.toml
+++ b/scm-record/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scm-record"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/scm-record/examples/static_contents.rs
+++ b/scm-record/examples/static_contents.rs
@@ -1,0 +1,107 @@
+#![warn(clippy::all, clippy::as_conversions)]
+#![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
+
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use scm_record::{FileState, RecordError, RecordState, Recorder, Section, SectionChangedLine};
+
+fn main() {
+    let file_states = vec![
+        (
+            PathBuf::from("foo/bar"),
+            FileState {
+                file_mode: None,
+                sections: vec![
+                    Section::Unchanged {
+                        contents: std::iter::repeat(Cow::Borrowed("this is some text"))
+                            .take(20)
+                            .collect(),
+                    },
+                    Section::Changed {
+                        before: vec![
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("before text 1"),
+                            },
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("before text 2"),
+                            },
+                        ],
+                        after: vec![
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("after text 1"),
+                            },
+                            SectionChangedLine {
+                                is_selected: false,
+                                line: Cow::Borrowed("after text 2"),
+                            },
+                        ],
+                    },
+                    Section::Unchanged {
+                        contents: vec![Cow::Borrowed("this is some trailing text")],
+                    },
+                ],
+            },
+        ),
+        (
+            PathBuf::from("baz"),
+            FileState {
+                file_mode: None,
+                sections: vec![
+                    Section::Unchanged {
+                        contents: vec![
+                            Cow::Borrowed("Some leading text 1"),
+                            Cow::Borrowed("Some leading text 2"),
+                        ],
+                    },
+                    Section::Changed {
+                        before: vec![
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("before text 1"),
+                            },
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("before text 2"),
+                            },
+                        ],
+                        after: vec![
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("after text 1"),
+                            },
+                            SectionChangedLine {
+                                is_selected: true,
+                                line: Cow::Borrowed("after text 2"),
+                            },
+                        ],
+                    },
+                    Section::Unchanged {
+                        contents: vec![Cow::Borrowed("this is some trailing text")],
+                    },
+                ],
+            },
+        ),
+    ];
+    let record_state = RecordState { file_states };
+
+    let recorder = Recorder::new(record_state);
+    let result = recorder.run();
+    match result {
+        Ok(result) => {
+            let RecordState { file_states } = result;
+            for (path, file_state) in file_states {
+                println!("--- Path {path:?} final contents: ---");
+                let (selected, _unselected) = file_state.get_selected_contents();
+                print!("{selected}");
+            }
+        }
+        Err(RecordError::Cancelled) => println!("Cancelled!"),
+        Err(err) => {
+            println!("Error: {err}");
+        }
+    }
+}

--- a/scm-record/examples/static_contents.rs
+++ b/scm-record/examples/static_contents.rs
@@ -22,23 +22,23 @@ fn main() {
                 Section::Changed {
                     lines: vec![
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Removed,
                             line: Cow::Borrowed("before text 1"),
                         },
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Removed,
                             line: Cow::Borrowed("before text 2"),
                         },
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Added,
 
                             line: Cow::Borrowed("after text 1"),
                         },
                         SectionChangedLine {
-                            is_selected: false,
+                            is_toggled: false,
                             change_type: ChangeType::Added,
                             line: Cow::Borrowed("after text 2"),
                         },
@@ -62,22 +62,22 @@ fn main() {
                 Section::Changed {
                     lines: vec![
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Removed,
                             line: Cow::Borrowed("before text 1"),
                         },
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Removed,
                             line: Cow::Borrowed("before text 2"),
                         },
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Added,
                             line: Cow::Borrowed("after text 1"),
                         },
                         SectionChangedLine {
-                            is_selected: true,
+                            is_toggled: true,
                             change_type: ChangeType::Added,
                             line: Cow::Borrowed("after text 2"),
                         },

--- a/scm-record/examples/static_contents.rs
+++ b/scm-record/examples/static_contents.rs
@@ -2,100 +2,102 @@
 #![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
 
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::Path;
 
-use scm_record::{FileState, RecordError, RecordState, Recorder, Section, SectionChangedLine};
+use scm_record::{
+    ChangeType, File, RecordError, RecordState, Recorder, Section, SectionChangedLine,
+};
 
 fn main() {
-    let file_states = vec![
-        (
-            PathBuf::from("foo/bar"),
-            FileState {
-                file_mode: None,
-                sections: vec![
-                    Section::Unchanged {
-                        contents: std::iter::repeat(Cow::Borrowed("this is some text"))
-                            .take(20)
-                            .collect(),
-                    },
-                    Section::Changed {
-                        before: vec![
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("before text 1"),
-                            },
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("before text 2"),
-                            },
-                        ],
-                        after: vec![
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("after text 1"),
-                            },
-                            SectionChangedLine {
-                                is_selected: false,
-                                line: Cow::Borrowed("after text 2"),
-                            },
-                        ],
-                    },
-                    Section::Unchanged {
-                        contents: vec![Cow::Borrowed("this is some trailing text")],
-                    },
-                ],
-            },
-        ),
-        (
-            PathBuf::from("baz"),
-            FileState {
-                file_mode: None,
-                sections: vec![
-                    Section::Unchanged {
-                        contents: vec![
-                            Cow::Borrowed("Some leading text 1"),
-                            Cow::Borrowed("Some leading text 2"),
-                        ],
-                    },
-                    Section::Changed {
-                        before: vec![
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("before text 1"),
-                            },
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("before text 2"),
-                            },
-                        ],
-                        after: vec![
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("after text 1"),
-                            },
-                            SectionChangedLine {
-                                is_selected: true,
-                                line: Cow::Borrowed("after text 2"),
-                            },
-                        ],
-                    },
-                    Section::Unchanged {
-                        contents: vec![Cow::Borrowed("this is some trailing text")],
-                    },
-                ],
-            },
-        ),
-    ];
-    let record_state = RecordState { file_states };
+    let files = vec![
+        File {
+            path: Cow::Borrowed(Path::new("foo/bar")),
+            file_mode: None,
+            sections: vec![
+                Section::Unchanged {
+                    lines: std::iter::repeat(Cow::Borrowed("this is some text"))
+                        .take(20)
+                        .collect(),
+                },
+                Section::Changed {
+                    lines: vec![
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Removed,
+                            line: Cow::Borrowed("before text 1"),
+                        },
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Removed,
+                            line: Cow::Borrowed("before text 2"),
+                        },
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Added,
 
-    let recorder = Recorder::new(record_state);
-    let result = recorder.run();
+                            line: Cow::Borrowed("after text 1"),
+                        },
+                        SectionChangedLine {
+                            is_selected: false,
+                            change_type: ChangeType::Added,
+                            line: Cow::Borrowed("after text 2"),
+                        },
+                    ],
+                },
+                Section::Unchanged {
+                    lines: vec![Cow::Borrowed("this is some trailing text")],
+                },
+            ],
+        },
+        File {
+            path: Cow::Borrowed(Path::new("baz")),
+            file_mode: None,
+            sections: vec![
+                Section::Unchanged {
+                    lines: vec![
+                        Cow::Borrowed("Some leading text 1"),
+                        Cow::Borrowed("Some leading text 2"),
+                    ],
+                },
+                Section::Changed {
+                    lines: vec![
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Removed,
+                            line: Cow::Borrowed("before text 1"),
+                        },
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Removed,
+                            line: Cow::Borrowed("before text 2"),
+                        },
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Added,
+                            line: Cow::Borrowed("after text 1"),
+                        },
+                        SectionChangedLine {
+                            is_selected: true,
+                            change_type: ChangeType::Added,
+                            line: Cow::Borrowed("after text 2"),
+                        },
+                    ],
+                },
+                Section::Unchanged {
+                    lines: vec![Cow::Borrowed("this is some trailing text")],
+                },
+            ],
+        },
+    ];
+    let record_state = RecordState { files };
+
+    let result = Recorder::run(record_state);
     match result {
         Ok(result) => {
-            let RecordState { file_states } = result;
-            for (path, file_state) in file_states {
-                println!("--- Path {path:?} final contents: ---");
-                let (selected, _unselected) = file_state.get_selected_contents();
+            let RecordState { files } = result;
+            for file in files {
+                println!("--- Path {:?} final lines: ---", file.path);
+                let (selected, _unselected) = file.get_selected_contents();
                 print!("{selected}");
             }
         }

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -1,0 +1,10 @@
+//! Reusable change selector UI for source control systems.
+
+#![warn(missing_docs)]
+#![warn(
+    clippy::all,
+    clippy::as_conversions,
+    clippy::clone_on_ref_ptr,
+    clippy::dbg_macro
+)]
+#![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -9,5 +9,8 @@
 )]
 #![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
 
-pub mod types;
-pub mod ui;
+mod types;
+mod ui;
+
+pub use types::{FileMode, FileState, RecordError, RecordState, Section, SectionChangedLine};
+pub use ui::Recorder;

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -9,8 +9,12 @@
 )]
 #![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
 
+mod render;
 mod types;
 mod ui;
+mod util;
 
-pub use types::{FileMode, FileState, RecordError, RecordState, Section, SectionChangedLine};
+pub use types::{
+    ChangeType, File, FileMode, RecordError, RecordState, Section, SectionChangedLine,
+};
 pub use ui::Recorder;

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -10,3 +10,4 @@
 #![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
 
 pub mod types;
+pub mod ui;

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -8,3 +8,5 @@
     clippy::dbg_macro
 )]
 #![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
+
+pub mod types;

--- a/scm-record/src/render.rs
+++ b/scm-record/src/render.rs
@@ -1,0 +1,154 @@
+use std::borrow::Cow;
+use std::cmp::min;
+
+use tui::buffer::Buffer;
+use tui::text::Span;
+use tui::widgets::Widget;
+
+use crate::util::UsizeExt;
+
+/// Like `tui::layout::Rect`, but supports addressing negative coordinates. (These
+/// coordinates shouldn't be rendered.)
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub(crate) struct Rect {
+    pub x: isize,
+    pub y: isize,
+    pub width: usize,
+    pub height: usize,
+}
+
+impl From<tui::layout::Rect> for Rect {
+    fn from(value: tui::layout::Rect) -> Self {
+        let tui::layout::Rect {
+            x,
+            y,
+            width,
+            height,
+        } = value;
+        Self {
+            x: x.try_into().unwrap(),
+            y: y.try_into().unwrap(),
+            width: width.into(),
+            height: height.into(),
+        }
+    }
+}
+
+impl Rect {
+    pub fn intersects(self, other: Self) -> bool {
+        let Self {
+            x,
+            y,
+            width,
+            height,
+        } = self;
+        let width = width.unwrap_isize();
+        let height = height.unwrap_isize();
+        let Self {
+            x: other_x,
+            y: other_y,
+            width: other_width,
+            height: other_height,
+        } = other;
+        let other_width = other_width.unwrap_isize();
+        let other_height = other_height.unwrap_isize();
+        x < other_x + other_width
+            && x + width > other_x
+            && y < other_y + other_height
+            && y + height > other_y
+    }
+}
+
+pub(crate) struct Viewport<'a> {
+    pub(crate) buf: &'a mut Buffer,
+    x: isize,
+    y: isize,
+}
+
+impl Viewport<'_> {
+    pub fn size(&self) -> Rect {
+        Rect {
+            x: self.x,
+            y: self.y,
+            width: self.buf.area().width.into(),
+            height: self.buf.area().height.into(),
+        }
+    }
+
+    pub fn area(&self) -> Rect {
+        Rect {
+            x: self.x,
+            y: self.y,
+            width: self.buf.area().width.into(),
+            height: self.buf.area().height.into(),
+        }
+    }
+
+    pub fn contains(&self, area: Rect) -> bool {
+        self.area().intersects(area)
+    }
+
+    pub fn draw_span(&mut self, x: isize, y: isize, span: &Span) {
+        let x = x - self.x;
+        let y = y - self.y;
+
+        if x >= self.size().width.unwrap_isize() || y >= self.size().height.unwrap_isize() {
+            return;
+        }
+
+        let y = match u16::try_from(y) {
+            Ok(y) => y,
+            Err(_) => return,
+        };
+
+        let Span { content, style } = span;
+        // FIXME: probably not Unicode-correct
+        let (x, content) = match u16::try_from(x) {
+            Ok(x) => (x, Cow::Borrowed(content.as_ref())),
+            Err(_) => {
+                if x < 0 {
+                    let difference = usize::try_from(-x).unwrap();
+                    let index = match content.char_indices().nth(difference) {
+                        None => return,
+                        Some((index, _)) => index,
+                    };
+                    let content = Cow::Borrowed(&content[index..]);
+                    (0, content)
+                } else {
+                    // Value too large for a u16, so we can't render it anyways.
+                    return;
+                }
+            }
+        };
+        let width = content.chars().count();
+        let width = u16::try_from(min(width, u16::MAX.into()))
+            .expect("the width should already have been constrained to the valid range of a u16");
+        let span = Span {
+            content,
+            style: *style,
+        };
+        self.buf.set_span(x, y, &span, width);
+    }
+}
+
+pub(crate) trait Component {
+    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize);
+}
+
+pub(crate) struct TopLevelComponentWidget<C: Component> {
+    pub(crate) app: C,
+    pub(crate) viewport_x: isize,
+    pub(crate) viewport_y: isize,
+}
+
+impl<C: Component> Widget for TopLevelComponentWidget<C> {
+    fn render(self, area: tui::layout::Rect, buf: &mut Buffer) {
+        let mut viewport = Viewport {
+            buf,
+            x: self.viewport_x,
+            y: self.viewport_y,
+        };
+        let area = Rect::from(area);
+        self.app.draw(&mut viewport, area.x, area.y);
+    }
+}

--- a/scm-record/src/render.rs
+++ b/scm-record/src/render.rs
@@ -391,9 +391,9 @@ pub(crate) trait Component: Sized {
     /// was drawn.
     type Id: Clone + Debug + Eq + Hash;
 
-    /// Get the ID for this compoent.
+    /// Get the ID for this component.
     fn id(&self) -> Self::Id;
 
     /// Draw this component and any child components.
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize);
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize);
 }

--- a/scm-record/src/render.rs
+++ b/scm-record/src/render.rs
@@ -1,15 +1,44 @@
-use std::borrow::Cow;
-use std::cmp::min;
+use std::cmp::{max, min};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::{borrow::Cow, collections::HashMap};
 
+use tui::backend::Backend;
 use tui::buffer::Buffer;
+use tui::style::{Color, Modifier, Style};
 use tui::text::Span;
-use tui::widgets::Widget;
+use tui::widgets::StatefulWidget;
+use tui::Frame;
 
-use crate::util::UsizeExt;
+use crate::util::{IsizeExt, UsizeExt};
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct RectSize {
+    pub width: usize,
+    pub height: usize,
+}
+
+impl From<tui::layout::Rect> for RectSize {
+    fn from(rect: tui::layout::Rect) -> Self {
+        Rect::from(rect).into()
+    }
+}
+
+impl From<Rect> for RectSize {
+    fn from(rect: Rect) -> Self {
+        let Rect {
+            x: _,
+            y: _,
+            width,
+            height,
+        } = rect;
+        Self { width, height }
+    }
+}
 
 /// Like `tui::layout::Rect`, but supports addressing negative coordinates. (These
 /// coordinates shouldn't be rendered.)
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Rect {
     pub x: isize,
     pub y: isize,
@@ -35,120 +64,333 @@ impl From<tui::layout::Rect> for Rect {
 }
 
 impl Rect {
-    pub fn intersects(self, other: Self) -> bool {
-        let Self {
-            x,
-            y,
-            width,
-            height,
-        } = self;
-        let width = width.unwrap_isize();
-        let height = height.unwrap_isize();
-        let Self {
-            x: other_x,
-            y: other_y,
-            width: other_width,
-            height: other_height,
-        } = other;
-        let other_width = other_width.unwrap_isize();
-        let other_height = other_height.unwrap_isize();
-        x < other_x + other_width
-            && x + width > other_x
-            && y < other_y + other_height
-            && y + height > other_y
+    /// The (x, y) coordinate of the top-left corner of this `Rect`.
+    fn top_left(self) -> (isize, isize) {
+        (self.x, self.y)
+    }
+
+    /// The (x, y) coordinate of the bottom-right corner of this `Rect`.
+    fn bottom_right(self) -> (isize, isize) {
+        (
+            self.x + self.width.unwrap_isize(),
+            self.y + self.height.unwrap_isize(),
+        )
+    }
+
+    /// Whether this `Rect` has zero area.
+    pub fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+
+    /// The largest `Rect` which is contained completely within both `self` and
+    /// `other`.
+    pub fn intersect(self, other: Self) -> Self {
+        let (self_x1, self_y1) = self.top_left();
+        let (self_x2, self_y2) = self.bottom_right();
+        let (other_x1, other_y1) = other.top_left();
+        let (other_x2, other_y2) = other.bottom_right();
+        let x1 = max(self_x1, other_x1);
+        let y1 = max(self_y1, other_y1);
+        let x2 = min(self_x2, other_x2);
+        let y2 = min(self_y2, other_y2);
+        let width = max(0, x2 - x1);
+        let height = max(0, y2 - y1);
+        Self {
+            x: x1,
+            y: y1,
+            width: width.unwrap_usize(),
+            height: height.unwrap_usize(),
+        }
+    }
+
+    /// The smallest `Rect` which contains both `self` and `other`. Note that if
+    /// one of `self` or `other` is empty, the other is returned, i.e. we don't
+    /// try to calculate the bounding box which includes a zero-area point.
+    pub fn union_bounding(self, other: Rect) -> Rect {
+        if self.is_empty() {
+            other
+        } else if other.is_empty() {
+            self
+        } else {
+            let (self_x1, self_y1) = self.top_left();
+            let (self_x2, self_y2) = self.bottom_right();
+            let (other_x1, other_y1) = other.top_left();
+            let (other_x2, other_y2) = other.bottom_right();
+            let x1 = min(self_x1, other_x1);
+            let y1 = min(self_y1, other_y1);
+            let x2 = max(self_x2, other_x2);
+            let y2 = max(self_y2, other_y2);
+            let width = max(0, x2 - x1);
+            let height = max(0, y2 - y1);
+            Self {
+                x: x1,
+                y: y1,
+                width: width.unwrap_usize(),
+                height: height.unwrap_usize(),
+            }
+        }
     }
 }
 
-pub(crate) struct Viewport<'a> {
-    pub(crate) buf: &'a mut Buffer,
+/// Recording of where the component with a certain ID drew on the virtual
+/// canvas.
+#[derive(Debug)]
+struct DrawTrace<ComponentId> {
+    /// The bounding box of all cells where the component drew.
+    ///
+    /// This `Rect` is at least as big as the bounding box containing all child
+    /// component `Rect`s, and could be bigger if the component drew somewhere
+    /// to the screen where no child component drew.
+    rect: Rect,
+
+    /// The bounding boxes of where each child component drew.
+    components: HashMap<ComponentId, Rect>,
+}
+
+impl<ComponentId: Clone + Debug + Eq + Hash> DrawTrace<ComponentId> {
+    /// Update the bounding box of this trace to include `other_rect`.
+    pub fn merge_rect(&mut self, other_rect: Rect) {
+        let Self {
+            rect,
+            components: _,
+        } = self;
+        *rect = rect.union_bounding(other_rect)
+    }
+
+    /// Update the bounding box of this trace to include `other.rect` and copy
+    /// all child component `Rect`s.
+    pub fn merge(&mut self, other: Self) {
+        let Self { rect, components } = self;
+        let Self {
+            rect: other_rect,
+            components: other_components,
+        } = other;
+        *rect = rect.union_bounding(other_rect);
+        for (id, rect) in other_components {
+            components.insert(id.clone(), rect);
+        }
+    }
+}
+
+impl<ComponentId> Default for DrawTrace<ComponentId> {
+    fn default() -> Self {
+        Self {
+            rect: Default::default(),
+            components: Default::default(),
+        }
+    }
+}
+
+/// Accessor to draw on the virtual canvas. The caller can draw anywhere on the
+/// canvas, but the actual renering will be restricted to this viewport. All
+/// draw calls are also tracked so that we know where each component was drawn
+/// after the fact (see `DrawTrace`).
+#[derive(Debug)]
+pub(crate) struct Viewport<'a, ComponentId> {
+    buf: &'a mut Buffer,
+    rect: Rect,
+    trace: Vec<DrawTrace<ComponentId>>,
+    debug_messages: Vec<String>,
+}
+
+impl<'a, ComponentId: Clone + Debug + Eq + Hash> Viewport<'a, ComponentId> {
+    /// The size of the viewport.
+    pub fn size(&self) -> RectSize {
+        RectSize {
+            width: self.buf.area().width.into(),
+            height: self.buf.area().height.into(),
+        }
+    }
+
+    /// Render the provided component using the given `Frame`. Returns a mapping
+    /// indicating where each component was drawn on the screen.
+    pub fn render_top_level<C: Component>(
+        frame: &mut Frame<impl Backend>,
+        x: isize,
+        y: isize,
+        component: &C,
+    ) -> HashMap<C::Id, Rect> {
+        let widget = TopLevelWidget { component, x, y };
+        let term_area = frame.size();
+        let mut drawn_rects = Default::default();
+        frame.render_stateful_widget(widget, term_area, &mut drawn_rects);
+        drawn_rects
+    }
+
+    fn current_trace_mut(&mut self) -> &mut DrawTrace<ComponentId> {
+        self.trace.last_mut()
+        .expect("draw trace stack is empty, so can't update trace for current component; did you call `Viewport::render_top_level` to render the top-level component?")
+    }
+
+    /// Set the terminal styling for a certain area. This can also be
+    /// accomplished using `draw_span` with a styled `Span`, but in some cases,
+    /// it may be more appropriate to set the style of certain cells directly.
+    pub fn set_style(&mut self, rect: Rect, style: Style) {
+        // TODO: track call.
+        self.buf.set_style(self.translate_rect(rect), style);
+        self.current_trace_mut().merge_rect(rect);
+    }
+
+    /// Render a debug message to the screen (at an unspecified location).
+    pub fn debug(&mut self, message: impl Into<String>) {
+        self.debug_messages.push(message.into())
+    }
+
+    /// Draw the provided child component to the screen at the given `(x, y)`
+    /// location.
+    pub fn draw_component<C: Component<Id = ComponentId>>(
+        &mut self,
+        x: isize,
+        y: isize,
+        component: &C,
+    ) -> Rect {
+        self.trace.push(Default::default());
+        component.draw(self, x, y);
+        let mut trace = self.trace.pop().unwrap();
+        let component_rect = trace.rect;
+        // TODO: do we need to get the bound with each child component too?
+        trace.components.insert(component.id(), component_rect);
+
+        self.current_trace_mut().merge(trace);
+        component_rect
+    }
+
+    /// Draw a `Span` directly to the screen at the given `(x, y)` location.
+    pub fn draw_span(&mut self, x: isize, y: isize, span: &Span) -> Rect {
+        let Span { content, style } = span;
+        let span_rect = Rect {
+            x,
+            y,
+            // FIXME: probably not Unicode-safe
+            width: content.chars().count(),
+            height: 1,
+        };
+        self.current_trace_mut().merge_rect(span_rect);
+
+        let draw_rect = self.rect.intersect(span_rect);
+        if !draw_rect.is_empty() {
+            let span_start_idx = (draw_rect.x - span_rect.x).unwrap_usize();
+            let span_start_byte_idx = content
+                .char_indices()
+                .nth(span_start_idx)
+                .map(|(i, _c)| i)
+                .unwrap_or(0);
+            let span_end_byte_idx = match content
+                .char_indices()
+                .nth(span_start_idx + draw_rect.width)
+                .map(|(i, _c)| i)
+            {
+                Some(span_end_byte_index) => span_end_byte_index,
+                None => content.len(),
+            };
+            let draw_span = Span {
+                content: Cow::Borrowed(&content.as_ref()[span_start_byte_idx..span_end_byte_idx]),
+                style: *style,
+            };
+
+            let buf_rect = self.translate_rect(draw_rect);
+            self.buf
+                .set_span(buf_rect.x, buf_rect.y, &draw_span, buf_rect.width);
+        }
+
+        span_rect
+    }
+
+    /// Convert the virtual `Rect` being displayed on the viewport, potentially
+    /// including an area off-screen, into a real terminal `tui::layout::Rect`
+    /// indicating the actual positions of the characters to be printed
+    /// on-screen.
+    fn translate_rect(&self, rect: Rect) -> tui::layout::Rect {
+        let draw_rect = self.rect.intersect(rect);
+        let x = draw_rect.x - self.rect.x;
+        let y = draw_rect.y - self.rect.y;
+        let width = draw_rect.width;
+        let height = draw_rect.height;
+        tui::layout::Rect {
+            x: x.try_into().unwrap(),
+            y: y.try_into().unwrap(),
+            width: width.try_into().unwrap(),
+            height: height.try_into().unwrap(),
+        }
+    }
+}
+
+/// Wrapper to render via `tui::Frame`.
+struct TopLevelWidget<'a, C> {
+    component: &'a C,
     x: isize,
     y: isize,
 }
 
-impl Viewport<'_> {
-    pub fn size(&self) -> Rect {
-        Rect {
-            x: self.x,
-            y: self.y,
-            width: self.buf.area().width.into(),
-            height: self.buf.area().height.into(),
-        }
-    }
+impl<C: Component> StatefulWidget for TopLevelWidget<'_, C> {
+    type State = HashMap<C::Id, Rect>;
 
-    pub fn area(&self) -> Rect {
-        Rect {
-            x: self.x,
-            y: self.y,
-            width: self.buf.area().width.into(),
-            height: self.buf.area().height.into(),
-        }
-    }
-
-    pub fn contains(&self, area: Rect) -> bool {
-        self.area().intersects(area)
-    }
-
-    pub fn draw_span(&mut self, x: isize, y: isize, span: &Span) {
-        let x = x - self.x;
-        let y = y - self.y;
-
-        if x >= self.size().width.unwrap_isize() || y >= self.size().height.unwrap_isize() {
-            return;
-        }
-
-        let y = match u16::try_from(y) {
-            Ok(y) => y,
-            Err(_) => return,
+    fn render(self, area: tui::layout::Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let Self { component, x, y } = self;
+        let trace = vec![Default::default()];
+        let mut viewport = Viewport::<C::Id> {
+            buf,
+            rect: Rect {
+                x,
+                y,
+                width: area.width.into(),
+                height: area.height.into(),
+            },
+            trace,
+            debug_messages: Default::default(),
         };
+        viewport.draw_component(0, 0, component);
+        *state = viewport.trace.pop().unwrap().components;
+        debug_assert!(viewport.trace.is_empty());
 
-        let Span { content, style } = span;
-        // FIXME: probably not Unicode-correct
-        let (x, content) = match u16::try_from(x) {
-            Ok(x) => (x, Cow::Borrowed(content.as_ref())),
-            Err(_) => {
-                if x < 0 {
-                    let difference = usize::try_from(-x).unwrap();
-                    let index = match content.char_indices().nth(difference) {
-                        None => return,
-                        Some((index, _)) => index,
-                    };
-                    let content = Cow::Borrowed(&content[index..]);
-                    (0, content)
-                } else {
-                    // Value too large for a u16, so we can't render it anyways.
-                    return;
+        // Render debug messages.
+        {
+            let x = 50_u16;
+            let debug_messages: Vec<String> = viewport
+                .debug_messages
+                .into_iter()
+                .flat_map(|message| -> Vec<String> {
+                    message.split('\n').map(|s| s.to_string()).collect()
+                })
+                .collect();
+            let max_line_len = min(
+                debug_messages.iter().map(|s| s.len()).max().unwrap_or(0),
+                viewport.buf.area.width.into(),
+            );
+            for (y, message) in debug_messages.into_iter().enumerate() {
+                let spaces = " ".repeat(max_line_len - message.len());
+                let span = Span::styled(
+                    message + &spaces,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::REVERSED),
+                );
+                if y < viewport.buf.area.height.into() {
+                    viewport.buf.set_span(
+                        x,
+                        y.clamp_into_u16(),
+                        &span,
+                        max_line_len.clamp_into_u16(),
+                    );
                 }
             }
-        };
-        let width = content.chars().count();
-        let width = u16::try_from(min(width, u16::MAX.into()))
-            .expect("the width should already have been constrained to the valid range of a u16");
-        let span = Span {
-            content,
-            style: *style,
-        };
-        self.buf.set_span(x, y, &span, width);
+        }
     }
 }
 
-pub(crate) trait Component {
-    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize);
-}
+/// A component which can be rendered on the virtual canvas. All calls to draw
+/// components are traced so that it can be determined later where a given
+/// component was drawn.
+pub(crate) trait Component: Sized {
+    /// A unique identifier which identifies this component or one of its child
+    /// components. This can be used with the return value of
+    /// `Viewport::render_top_level` to find where the component with a given ID
+    /// was drawn.
+    type Id: Clone + Debug + Eq + Hash;
 
-pub(crate) struct TopLevelComponentWidget<C: Component> {
-    pub(crate) app: C,
-    pub(crate) viewport_x: isize,
-    pub(crate) viewport_y: isize,
-}
+    /// Get the ID for this compoent.
+    fn id(&self) -> Self::Id;
 
-impl<C: Component> Widget for TopLevelComponentWidget<C> {
-    fn render(self, area: tui::layout::Rect, buf: &mut Buffer) {
-        let mut viewport = Viewport {
-            buf,
-            x: self.viewport_x,
-            y: self.viewport_y,
-        };
-        let area = Rect::from(area);
-        self.app.draw(&mut viewport, area.x, area.y);
-    }
+    /// Draw this component and any child components.
+    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize);
 }

--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -1,3 +1,5 @@
+//! Data types for the change selector interface.
+
 use std::borrow::Cow;
 use std::path::PathBuf;
 
@@ -17,6 +19,7 @@ pub enum RecordError {
     Cancelled,
 }
 
+/// The Unix file mode.
 pub type FileMode = usize;
 
 /// The state of a file to be recorded.

--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -102,13 +102,13 @@ impl File<'_> {
                 Section::Unchanged { .. }
                 | Section::Changed { .. }
                 | Section::FileMode {
-                    is_selected: false,
+                    is_toggled: false,
                     before: _,
                     after: _,
                 } => None,
 
                 Section::FileMode {
-                    is_selected: true,
+                    is_toggled: true,
                     before: _,
                     after,
                 } => Some(*after),
@@ -140,7 +140,7 @@ impl File<'_> {
                 Section::Changed { lines } => {
                     for line in lines {
                         let SectionChangedLine {
-                            is_selected,
+                            is_toggled: is_selected,
                             change_type,
                             line,
                         } = line;
@@ -157,7 +157,7 @@ impl File<'_> {
                     }
                 }
                 Section::FileMode {
-                    is_selected: _,
+                    is_toggled: _,
                     before: _,
                     after: _,
                 } => {
@@ -196,7 +196,7 @@ pub enum Section<'a> {
     /// "contents" of the file per se, but it's rendered inline as if it were.
     FileMode {
         /// Whether or not the file mode change was accepted.
-        is_selected: bool,
+        is_toggled: bool,
 
         /// The old file mode.
         before: FileMode,
@@ -204,6 +204,17 @@ pub enum Section<'a> {
         /// The new file mode.
         after: FileMode,
     },
+}
+
+impl Section<'_> {
+    /// Whether or not this section contains user-editable content (as opposed
+    /// to simply contextual content).
+    pub fn is_editable(&self) -> bool {
+        match self {
+            Section::Unchanged { .. } => false,
+            Section::Changed { .. } | Section::FileMode { .. } => true,
+        }
+    }
 }
 
 /// The type of change in the patch/diff.
@@ -220,7 +231,7 @@ pub enum ChangeType {
 #[derive(Clone, Debug)]
 pub struct SectionChangedLine<'a> {
     /// Whether or not this line was selected to be recorded.
-    pub is_selected: bool,
+    pub is_toggled: bool,
 
     /// The type of change this line was.
     pub change_type: ChangeType,

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -1,9 +1,12 @@
 //! UI implementation.
 
-use std::io;
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+use std::{io, panic};
 
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+    MouseEvent, MouseEventKind,
 };
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, EnterAlternateScreen,
@@ -11,27 +14,56 @@ use crossterm::terminal::{
 };
 use tracing::warn;
 use tui::layout::{Constraint, Direction, Layout};
-use tui::widgets::Paragraph;
+use tui::style::{Color, Modifier, Style};
+use tui::text::Span;
 use tui::{backend::CrosstermBackend, Terminal};
 
-use crate::types::{RecordError, RecordState};
+use crate::render::{Component, Rect, TopLevelComponentWidget, Viewport};
+use crate::types::{ChangeType, RecordError, RecordState};
+use crate::util::UsizeExt;
+use crate::{File, Section, SectionChangedLine};
 
-type CrosstermTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+type Backend = CrosstermBackend<io::Stdout>;
+type CrosstermTerminal = Terminal<Backend>;
+
+#[derive(Clone, Copy, Debug)]
+struct FileKey {
+    file_idx: usize,
+}
+
+#[allow(dead_code)] // TODO: remove
+#[derive(Clone, Copy, Debug)]
+struct SectionKey {
+    file_idx: usize,
+    section_idx: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LineKey {
+    file_idx: usize,
+    section_idx: usize,
+    line_idx: usize,
+}
+
+#[allow(dead_code)] // TODO: remove
+#[derive(Clone, Copy, Debug)]
+enum Key {
+    File(FileKey),
+    Section(SectionKey),
+    Line(LineKey),
+}
 
 /// UI component to record the user's changes.
 pub struct Recorder<'a> {
     state: RecordState<'a>,
+    use_unicode: bool,
+    key: Key,
 }
 
 impl<'a> Recorder<'a> {
-    /// Constructor.
-    pub fn new(state: RecordState<'a>) -> Self {
-        Self { state }
-    }
-
     /// Run the terminal user interface and have the user interactively select
     /// changes.
-    pub fn run(self) -> Result<RecordState<'a>, RecordError> {
+    pub fn run(state: RecordState<'a>) -> Result<RecordState<'a>, RecordError> {
         let mut stdout = io::stdout();
         if !is_raw_mode_enabled().map_err(RecordError::SetUpTerminal)? {
             enable_raw_mode().map_err(RecordError::SetUpTerminal)?;
@@ -41,40 +73,48 @@ impl<'a> Recorder<'a> {
         let backend = CrosstermBackend::new(stdout);
         let mut term = Terminal::new(backend).map_err(RecordError::SetUpTerminal)?;
 
-        let state = self.run_inner(&mut term)?;
-
-        if let Err(err) = Self::clean_up(&mut term) {
-            warn!(?err, "Failed to clean up terminal");
-        }
-        Ok(state)
-    }
-
-    fn run_inner(self, term: &mut CrosstermTerminal) -> Result<RecordState<'a>, RecordError> {
-        loop {
-            let layout = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(1)]);
-
-            term.draw(|frame| {
-                let chunks = layout.split(frame.size());
-
-                frame.render_widget(Paragraph::new("Hello, world!"), chunks[0]);
-            })
-            .map_err(RecordError::RenderFrame)?;
-
-            match crossterm::event::read().map_err(RecordError::ReadInput)? {
-                Event::Key(KeyEvent {
-                    code: KeyCode::Char('q'),
-                    modifiers: KeyModifiers::NONE,
-                    kind: KeyEventKind::Press,
-                    state: _,
-                }) => break,
-
-                _event => {}
+        let dump_panics = std::env::var_os("SCM_RECORD_DUMP_PANICS").is_some();
+        let recorder = Self {
+            state,
+            use_unicode: true,
+            // FIXME: handle out of bounds indexing.
+            key: Key::File(FileKey { file_idx: 0 }),
+        };
+        let state = if dump_panics {
+            recorder.run_inner(&mut term)
+        } else {
+            // Catch any panics and restore terminal state, since otherwise the
+            // terminal will be mostly unusable.
+            let state = panic::catch_unwind(
+                // HACK: I don't actually know if the terminal is unwind-safe 🙃.
+                AssertUnwindSafe(|| recorder.run_inner(&mut term)),
+            );
+            if let Err(err) = Self::clean_up(&mut term) {
+                warn!(?err, "Failed to clean up terminal");
             }
-        }
-
-        Ok(self.state)
+            match state {
+                Ok(state) => state,
+                Err(panic) => {
+                    // HACK: it should be possible to just call
+                    //
+                    //     panic::resume_unwind(panic)
+                    //
+                    // but, for some reason, when I do that, the panic information
+                    // is not printed. Then it generally looks like the program
+                    // exited successfully but did nothing. This at least ensures
+                    // that *something* is printed to indicate that there was a
+                    // panic, even if it doesn't include all of the panic details.
+                    if let Some(payload) = panic.downcast_ref::<String>() {
+                        panic!("panic occurred: {payload}");
+                    } else if let Some(payload) = panic.downcast_ref::<&str>() {
+                        panic!("panic occurred: {payload}");
+                    } else {
+                        panic!("panic occurred (message not available)");
+                    }
+                }
+            }
+        };
+        state
     }
 
     fn clean_up(term: &mut CrosstermTerminal) -> io::Result<()> {
@@ -88,5 +128,468 @@ impl<'a> Recorder<'a> {
             )?;
         }
         Ok(())
+    }
+
+    fn run_inner(mut self, term: &mut CrosstermTerminal) -> Result<RecordState<'a>, RecordError> {
+        let mut scroll_offset_y = 0;
+        loop {
+            let layout = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(100)]);
+
+            let file_views: Vec<FileView> = self
+                .state
+                .files
+                .iter()
+                .enumerate()
+                .map(|(file_idx, file)| {
+                    let file_key = FileKey { file_idx };
+                    let file_tristate = self.file_tristate(file_key).unwrap();
+                    FileView {
+                        tristate_box: TristateBox {
+                            use_unicode: self.use_unicode,
+                            tristate: file_tristate,
+                        },
+                        path: &file.path,
+                        section_views: file
+                            .sections
+                            .iter()
+                            .map(|section| SectionView {
+                                use_unicode: self.use_unicode,
+                                section,
+                            })
+                            .collect(),
+                    }
+                })
+                .collect();
+            let app = App { file_views };
+
+            // Ensure that at least one line is always visible.
+            let term_height = usize::from(term.get_frame().size().height);
+            let max_scroll_offset_y = app.height().saturating_sub(1);
+
+            scroll_offset_y = scroll_offset_y.clamp(0, max_scroll_offset_y);
+
+            term.draw(|frame| {
+                let chunks = layout.split(frame.size());
+                let widget = TopLevelComponentWidget {
+                    app,
+                    viewport_x: 0,
+                    viewport_y: scroll_offset_y.unwrap_isize(),
+                };
+                frame.render_widget(widget, chunks[0]);
+            })
+            .map_err(RecordError::RenderFrame)?;
+
+            match crossterm::event::read().map_err(RecordError::ReadInput)? {
+                Event::Key(
+                    KeyEvent {
+                        code: KeyCode::Char('q'),
+                        modifiers: KeyModifiers::NONE,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    }
+                    | KeyEvent {
+                        code: KeyCode::Char('c'),
+                        modifiers: KeyModifiers::CONTROL,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    },
+                ) => break,
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Up,
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                })
+                | Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollUp,
+                    column: _,
+                    row: _,
+                    modifiers: _,
+                }) => {
+                    scroll_offset_y = scroll_offset_y.saturating_sub(1);
+                }
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down,
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                })
+                | Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollDown,
+                    column: _,
+                    row: _,
+                    modifiers: _,
+                }) => {
+                    scroll_offset_y = scroll_offset_y.saturating_add(1);
+                }
+
+                Event::Key(
+                    KeyEvent {
+                        code: KeyCode::PageUp,
+                        modifiers: KeyModifiers::NONE,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    }
+                    | KeyEvent {
+                        code: KeyCode::Char('u'),
+                        modifiers: KeyModifiers::CONTROL,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    },
+                ) => {
+                    scroll_offset_y = scroll_offset_y.saturating_sub(term_height);
+                }
+                Event::Key(
+                    KeyEvent {
+                        code: KeyCode::PageDown,
+                        modifiers: KeyModifiers::NONE,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    }
+                    | KeyEvent {
+                        code: KeyCode::Char('d'),
+                        modifiers: KeyModifiers::CONTROL,
+                        kind: KeyEventKind::Press,
+                        state: _,
+                    },
+                ) => {
+                    scroll_offset_y = scroll_offset_y.saturating_add(term_height);
+                }
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char(' '),
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                }) => {
+                    self.toggle_current_item()?;
+                }
+
+                _event => {}
+            }
+        }
+
+        Ok(self.state)
+    }
+
+    fn toggle_current_item(&mut self) -> Result<(), RecordError> {
+        match self.key {
+            Key::File(file_key) => {
+                let tristate = self.file_tristate(file_key)?;
+                let is_selected_new = match tristate {
+                    Tristate::Unchecked => true,
+                    Tristate::Partial | Tristate::Checked => false,
+                };
+                self.visit_file(file_key, |file| {
+                    for section in file.sections.iter_mut() {
+                        match section {
+                            Section::Unchanged { .. } => {}
+                            Section::Changed { lines } => {
+                                for line in lines {
+                                    line.is_selected = is_selected_new;
+                                }
+                            }
+                            Section::FileMode {
+                                is_selected,
+                                before: _,
+                                after: _,
+                            } => {
+                                *is_selected = is_selected_new;
+                            }
+                        }
+                    }
+                })?;
+            }
+            Key::Section(_) => todo!(),
+            Key::Line(line_key) => {
+                // TODO: propagate upward checkboxes
+                self.visit_line(line_key, |line| {
+                    line.is_selected = !line.is_selected;
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn file(&self, file_key: FileKey) -> Result<&File, RecordError> {
+        let FileKey { file_idx } = file_key;
+        match self.state.files.get(file_idx) {
+            Some(file) => Ok(file),
+            None => Err(RecordError::Bug(format!(
+                "Out-of-bounds file key: {file_key:?}"
+            ))),
+        }
+    }
+
+    fn visit_file<T>(
+        &mut self,
+        file_key: FileKey,
+        f: impl Fn(&mut File) -> T,
+    ) -> Result<T, RecordError> {
+        let FileKey { file_idx } = file_key;
+        match self.state.files.get_mut(file_idx) {
+            Some(file) => Ok(f(file)),
+            None => Err(RecordError::Bug(format!(
+                "Out-of-bounds file key: {file_key:?}"
+            ))),
+        }
+    }
+
+    fn file_tristate(&self, file_key: FileKey) -> Result<Tristate, RecordError> {
+        let mut seen_value = None;
+        for section in &self.file(file_key)?.sections {
+            match section {
+                Section::Unchanged { .. } => {}
+                Section::Changed { lines } => {
+                    for line in lines {
+                        seen_value = match (seen_value, line.is_selected) {
+                            (None, is_selected) => Some(is_selected),
+                            (Some(true), true) => Some(true),
+                            (Some(false), false) => Some(false),
+                            (Some(true), false) | (Some(false), true) => {
+                                return Ok(Tristate::Partial)
+                            }
+                        };
+                    }
+                }
+                Section::FileMode {
+                    is_selected,
+                    before: _,
+                    after: _,
+                } => {
+                    seen_value = match (seen_value, is_selected) {
+                        (None, is_selected) => Some(*is_selected),
+                        (Some(true), true) => Some(true),
+                        (Some(false), false) => Some(false),
+                        (Some(true), false) | (Some(false), true) => return Ok(Tristate::Partial),
+                    }
+                }
+            }
+        }
+        let result = match seen_value {
+            Some(true) => Tristate::Checked,
+            None | Some(false) => Tristate::Unchecked,
+        };
+        Ok(result)
+    }
+
+    fn visit_line<T>(
+        &mut self,
+        line_key: LineKey,
+        f: impl FnOnce(&mut SectionChangedLine) -> T,
+    ) -> Result<T, RecordError> {
+        let LineKey {
+            file_idx,
+            section_idx,
+            line_idx,
+        } = line_key;
+        let section = &mut self.state.files[file_idx].sections[section_idx];
+        match section {
+            Section::Changed { lines } => {
+                let line = &mut lines[line_idx];
+                Ok(f(line))
+            }
+            section @ (Section::Unchanged { lines: _ }
+            | Section::FileMode {
+                is_selected: _,
+                before: _,
+                after: _,
+            }) => Err(RecordError::Bug(format!(
+                "Bad line key {line_key:?}, tried to index section {section:?}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Tristate {
+    Unchecked,
+    Partial,
+    Checked,
+}
+
+impl From<bool> for Tristate {
+    fn from(value: bool) -> Self {
+        if value {
+            Tristate::Checked
+        } else {
+            Tristate::Unchecked
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TristateBox {
+    pub(crate) use_unicode: bool,
+    pub(crate) tristate: Tristate,
+}
+
+impl TristateBox {
+    fn text(&self) -> &'static str {
+        let Self {
+            use_unicode,
+            tristate,
+        } = self;
+        match tristate {
+            Tristate::Unchecked => "[ ] ",
+            Tristate::Partial => "[~] ",
+            Tristate::Checked => {
+                if *use_unicode {
+                    "[✕] "
+                } else {
+                    "[x] "
+                }
+            }
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.text().chars().count()
+    }
+}
+
+impl Component for TristateBox {
+    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize) {
+        let span = Span::styled(self.text(), Style::default().add_modifier(Modifier::BOLD));
+        viewport.draw_span(x, y, &span);
+    }
+}
+
+#[derive(Debug)]
+struct App<'a> {
+    file_views: Vec<FileView<'a>>,
+}
+
+impl App<'_> {
+    fn height(&self) -> usize {
+        let Self { file_views } = self;
+        file_views.iter().map(|file_view| file_view.height()).sum()
+    }
+}
+
+impl Component for App<'_> {
+    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize) {
+        let Self { file_views } = self;
+
+        let mut y = y;
+        for file_view in file_views {
+            file_view.draw(viewport, x, y);
+            y += file_view.height().unwrap_isize();
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FileView<'a> {
+    pub(crate) tristate_box: TristateBox,
+    pub(crate) path: &'a Path,
+    pub(crate) section_views: Vec<SectionView<'a>>,
+}
+
+impl FileView<'_> {
+    pub fn height(&self) -> usize {
+        1 + self
+            .section_views
+            .iter()
+            .map(|section_view| section_view.height())
+            .sum::<usize>()
+    }
+}
+
+impl Component for FileView<'_> {
+    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize) {
+        let Self {
+            tristate_box,
+            path,
+            section_views: sections,
+        } = self;
+
+        tristate_box.draw(viewport, x, y);
+        viewport.draw_span(
+            x + tristate_box.width().unwrap_isize(),
+            y,
+            &Span::styled(path.to_string_lossy(), Style::default()),
+        );
+
+        let x = x + 2;
+        let mut y = y + 1;
+        for section_view in sections {
+            let section_area = Rect {
+                x,
+                y,
+                width: viewport.size().width,
+                height: section_view.height(),
+            };
+            if viewport.contains(section_area) {
+                section_view.draw(viewport, section_area.x, section_area.y);
+            }
+            y += section_area.height.unwrap_isize();
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SectionView<'a> {
+    use_unicode: bool,
+    section: &'a Section<'a>,
+}
+
+impl SectionView<'_> {
+    pub fn height(&self) -> usize {
+        match self.section {
+            Section::Unchanged { lines } => lines.len(),
+            Section::Changed { lines } => lines.len(),
+            Section::FileMode { .. } => 1,
+        }
+    }
+}
+
+impl Component for SectionView<'_> {
+    fn draw(&self, viewport: &mut Viewport, x: isize, y: isize) {
+        let Self {
+            use_unicode,
+            section,
+        } = self;
+
+        match section {
+            Section::Unchanged { lines } => {
+                // TODO: only display a certain number of contextual lines
+                for (dy, line) in lines.iter().enumerate() {
+                    let span = Span::styled(line.as_ref(), Style::default());
+                    viewport.draw_span(x, y + dy.unwrap_isize(), &span);
+                }
+            }
+
+            Section::Changed { lines } => {
+                for (dy, line) in lines.iter().enumerate() {
+                    let y = y + dy.unwrap_isize();
+                    let SectionChangedLine {
+                        is_selected,
+                        change_type,
+                        line,
+                    } = line;
+
+                    let tristate_box = TristateBox {
+                        use_unicode: *use_unicode,
+                        tristate: Tristate::from(*is_selected),
+                    };
+                    tristate_box.draw(viewport, x, y);
+                    let x = x + tristate_box.width().unwrap_isize();
+
+                    let (change_type_text, style) = match change_type {
+                        ChangeType::Added => ("+ ", Style::default().fg(Color::Green)),
+                        ChangeType::Removed => ("- ", Style::default().fg(Color::Red)),
+                    };
+                    viewport.draw_span(x, y, &Span::styled(change_type_text, style));
+                    let x = x + change_type_text.chars().count().unwrap_isize();
+                    viewport.draw_span(x, y, &Span::styled(line.as_ref(), style));
+                }
+            }
+
+            Section::FileMode { .. } => unimplemented!("rendering file mode section"),
+        }
     }
 }

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -1,0 +1,21 @@
+//! UI implementation.
+
+use crate::types::{RecordError, RecordState};
+
+/// UI component to record the user's changes.
+pub struct Recorder<'a> {
+    _state: RecordState<'a>,
+}
+
+impl<'a> Recorder<'a> {
+    /// Constructor.
+    pub fn new(state: RecordState<'a>) -> Self {
+        Self { _state: state }
+    }
+
+    /// Run the terminal user interface and have the user interactively select
+    /// changes.
+    pub fn run(self) -> Result<RecordState<'a>, RecordError> {
+        todo!()
+    }
+}

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -1,21 +1,92 @@
 //! UI implementation.
 
+use std::io;
+
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, EnterAlternateScreen,
+    LeaveAlternateScreen,
+};
+use tracing::warn;
+use tui::layout::{Constraint, Direction, Layout};
+use tui::widgets::Paragraph;
+use tui::{backend::CrosstermBackend, Terminal};
+
 use crate::types::{RecordError, RecordState};
+
+type CrosstermTerminal = Terminal<CrosstermBackend<io::Stdout>>;
 
 /// UI component to record the user's changes.
 pub struct Recorder<'a> {
-    _state: RecordState<'a>,
+    state: RecordState<'a>,
 }
 
 impl<'a> Recorder<'a> {
     /// Constructor.
     pub fn new(state: RecordState<'a>) -> Self {
-        Self { _state: state }
+        Self { state }
     }
 
     /// Run the terminal user interface and have the user interactively select
     /// changes.
     pub fn run(self) -> Result<RecordState<'a>, RecordError> {
-        todo!()
+        let mut stdout = io::stdout();
+        if !is_raw_mode_enabled().map_err(RecordError::SetUpTerminal)? {
+            enable_raw_mode().map_err(RecordError::SetUpTerminal)?;
+            crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+                .map_err(RecordError::SetUpTerminal)?;
+        }
+        let backend = CrosstermBackend::new(stdout);
+        let mut term = Terminal::new(backend).map_err(RecordError::SetUpTerminal)?;
+
+        let state = self.run_inner(&mut term)?;
+
+        if let Err(err) = Self::clean_up(&mut term) {
+            warn!(?err, "Failed to clean up terminal");
+        }
+        Ok(state)
+    }
+
+    fn run_inner(self, term: &mut CrosstermTerminal) -> Result<RecordState<'a>, RecordError> {
+        loop {
+            let layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1)]);
+
+            term.draw(|frame| {
+                let chunks = layout.split(frame.size());
+
+                frame.render_widget(Paragraph::new("Hello, world!"), chunks[0]);
+            })
+            .map_err(RecordError::RenderFrame)?;
+
+            match crossterm::event::read().map_err(RecordError::ReadInput)? {
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('q'),
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                }) => break,
+
+                _event => {}
+            }
+        }
+
+        Ok(self.state)
+    }
+
+    fn clean_up(term: &mut CrosstermTerminal) -> io::Result<()> {
+        term.show_cursor()?;
+        if is_raw_mode_enabled()? {
+            disable_raw_mode()?;
+            crossterm::execute!(
+                term.backend_mut(),
+                LeaveAlternateScreen,
+                DisableMouseCapture
+            )?;
+        }
+        Ok(())
     }
 }

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -931,7 +931,7 @@ impl<Id: Clone + Debug + Eq + Hash> Component for TristateBox<Id> {
         self.id.clone()
     }
 
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize) {
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize) {
         let span = Span::styled(self.text(), Style::default().add_modifier(Modifier::BOLD));
         viewport.draw_span(x, y, &span);
     }
@@ -971,7 +971,7 @@ impl Component for App<'_> {
         ComponentId::App
     }
 
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize) {
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize) {
         let Self {
             debug_info,
             file_views,
@@ -1023,7 +1023,7 @@ impl Component for FileView<'_> {
         ComponentId::SelectableItem(SelectionKey::File(self.file_key))
     }
 
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize) {
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize) {
         let Self {
             debug,
             file_key: _,
@@ -1099,7 +1099,7 @@ impl Component for SectionView<'_> {
         ComponentId::SelectableItem(SelectionKey::Section(self.section_key))
     }
 
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize) {
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize) {
         let Self {
             use_unicode,
             section_key,
@@ -1232,7 +1232,7 @@ impl Component for SectionLineView<'_> {
         ComponentId::SelectableItem(SelectionKey::Line(self.line_key))
     }
 
-    fn draw<'a, 'b: 'a>(&'b self, viewport: &'a mut Viewport<Self::Id>, x: isize, y: isize) {
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, x: isize, y: isize) {
         let Self { line_key: _, inner } = self;
         match inner {
             SectionLineViewInner::Unchanged { line } => {

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -223,8 +223,8 @@ impl<'a> Recorder<'a> {
                 ) => break,
 
                 Event::Key(KeyEvent {
-                    code: KeyCode::Up,
-                    modifiers: KeyModifiers::NONE,
+                    code: KeyCode::Char('y'),
+                    modifiers: KeyModifiers::CONTROL,
                     kind: KeyEventKind::Press,
                     state: _,
                 })
@@ -237,8 +237,8 @@ impl<'a> Recorder<'a> {
                     scroll_offset_y = scroll_offset_y.saturating_sub(1);
                 }
                 Event::Key(KeyEvent {
-                    code: KeyCode::Down,
-                    modifiers: KeyModifiers::NONE,
+                    code: KeyCode::Char('e'),
+                    modifiers: KeyModifiers::CONTROL,
                     kind: KeyEventKind::Press,
                     state: _,
                 })
@@ -251,6 +251,23 @@ impl<'a> Recorder<'a> {
                     scroll_offset_y = scroll_offset_y.saturating_add(1);
                 }
 
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('u'),
+                    modifiers: KeyModifiers::CONTROL,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                }) => {
+                    scroll_offset_y = scroll_offset_y.saturating_sub(term_height / 2);
+                }
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('d'),
+                    modifiers: KeyModifiers::CONTROL,
+                    kind: KeyEventKind::Press,
+                    state: _,
+                }) => {
+                    scroll_offset_y = scroll_offset_y.saturating_add(term_height / 2);
+                }
+
                 Event::Key(
                     KeyEvent {
                         code: KeyCode::PageUp,
@@ -259,7 +276,7 @@ impl<'a> Recorder<'a> {
                         state: _,
                     }
                     | KeyEvent {
-                        code: KeyCode::Char('u'),
+                        code: KeyCode::Char('b'),
                         modifiers: KeyModifiers::CONTROL,
                         kind: KeyEventKind::Press,
                         state: _,
@@ -275,7 +292,7 @@ impl<'a> Recorder<'a> {
                         state: _,
                     }
                     | KeyEvent {
-                        code: KeyCode::Char('d'),
+                        code: KeyCode::Char('f'),
                         modifiers: KeyModifiers::CONTROL,
                         kind: KeyEventKind::Press,
                         state: _,

--- a/scm-record/src/util.rs
+++ b/scm-record/src/util.rs
@@ -1,0 +1,9 @@
+pub(crate) trait UsizeExt {
+    fn unwrap_isize(self) -> isize;
+}
+
+impl UsizeExt for usize {
+    fn unwrap_isize(self) -> isize {
+        isize::try_from(self).unwrap()
+    }
+}

--- a/scm-record/src/util.rs
+++ b/scm-record/src/util.rs
@@ -1,9 +1,39 @@
 pub(crate) trait UsizeExt {
     fn unwrap_isize(self) -> isize;
+    fn clamp_into_u16(self) -> u16;
 }
 
 impl UsizeExt for usize {
     fn unwrap_isize(self) -> isize {
         isize::try_from(self).unwrap()
+    }
+
+    fn clamp_into_u16(self) -> u16 {
+        if self > u16::MAX.try_into().unwrap() {
+            u16::MAX
+        } else {
+            self.try_into().unwrap()
+        }
+    }
+}
+
+pub(crate) trait IsizeExt {
+    fn unwrap_usize(self) -> usize;
+    fn clamp_into_u16(self) -> u16;
+}
+
+impl IsizeExt for isize {
+    fn unwrap_usize(self) -> usize {
+        usize::try_from(self).unwrap()
+    }
+
+    fn clamp_into_u16(self) -> u16 {
+        if self < 0 {
+            0
+        } else if self > u16::MAX.try_into().unwrap() {
+            u16::MAX
+        } else {
+            self.try_into().unwrap()
+        }
     }
 }


### PR DESCRIPTION
This is a replacement for the existing `git-record` library, which doesn't perform well. The approach is to use `tui` instead of `cursive`, which requires that we implement a lot more by hand, but also should be more performant.