### PR TITLE
Limit fetch in submit to relevant branches

### DIFF
--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -159,12 +159,13 @@ These remotes are available: {}",
     };
 
     // TODO: explain why fetching here.
-    let remote_names = remotes_to_branches.keys().sorted().collect_vec();
-    if !remote_names.is_empty() {
+    for (remote_name, branches) in remotes_to_branches.iter() {
         let remote_args = {
-            let mut result = vec!["fetch"];
-            for remote_name in &remote_names {
-                result.push(remote_name.as_str());
+            let mut result = vec!["fetch".to_owned()];
+            result.push((*remote_name).clone());
+            for branch in branches {
+                let branch_ref = branch.get_reference_name()?;
+                result.push(branch_ref.as_str().to_owned());
             }
             result
         };
@@ -172,8 +173,8 @@ These remotes are available: {}",
         if !exit_code.is_success() {
             writeln!(
                 effects.get_output_stream(),
-                "Failed to fetch from remotes: {}",
-                remote_names.into_iter().join(", ")
+                "Failed to fetch from remote: {}",
+                remote_name
             )?;
             return Ok(exit_code);
         }


### PR DESCRIPTION
This is a follow up from my question in https://github.com/arxanas/git-branchless/discussions/671. I have made the changes to only fetch branches that are being pushed. I am testing it locally now and so far it seems to behave as expected but I am not sure if there are other edge cases to consider. I will continue to use this build for a few days and see if I encounter any other issues, but I figured it would be good to just open the MR for feedback first.

Thank you.

EDIT: not sure why the tests are failing for windows. They are passing on my machine.
EDIT2: I was not running tests for the entire workspace. Fixed.