### PR TITLE
tests: set an explicit value for core.abbrev config

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -369,6 +369,7 @@ then you can only run tests in the main `git-branchless` and \
         self.run(&["init"])?;
         self.run(&["config", "user.name", DUMMY_NAME])?;
         self.run(&["config", "user.email", DUMMY_EMAIL])?;
+        self.run(&["config", "core.abbrev", "7"])?;
 
         if options.make_initial_commit {
             self.commit_file("initial", 0)?;


### PR DESCRIPTION
Users can have a value for core.abbrev different than the default one in their ~/.gitconfig, this makes some tests fail because when comparing the output, they expect hashes to be 7 chars long. Fix by setting an explicit value of 7 when initializing a repo inside a test.