### PR TITLE
Upgrade Eden DAG library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom 0.2.8",
  "once_cell",
  "version_check",
@@ -115,6 +115,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-trait"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,7 +150,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -209,6 +220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,12 +248,6 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -385,15 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +483,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -499,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -508,7 +513,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -522,7 +527,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -532,7 +537,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -544,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset 0.7.1",
  "scopeguard",
@@ -556,7 +561,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -566,7 +571,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -623,7 +628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5438eb16bdd8af51b31e74764fef5d0a9260227a5ec82ba75c9d11ce46595839"
 dependencies = [
  "ahash 0.8.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossterm 0.25.0",
  "cursive_core",
@@ -807,7 +812,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -925,23 +930,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "esl01-dag"
-version = "0.2.1"
+name = "esl01-atomicfile"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f284f338575e1b6c4f4ba306f2e36a9a31b53b071fc59c2f644769a4d948563d"
+checksum = "73020f11f072c66f335e7273c3509220c6c06db8e2f27e55f487d484c03c3ae2"
+dependencies = [
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "esl01-dag"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf33c6d93aebed1408b6e6379d3083ea0dc48b3256eba858e24ff1ad0910c5c"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags",
  "byteorder",
+ "esl01-dag-types",
  "esl01-drawdag",
  "esl01-indexedlog",
+ "esl01-mincode",
  "esl01-minibytes",
+ "esl01-nonblocking",
+ "esl01-renderdag",
  "esl01-vlqencoding",
+ "fail",
  "fs2",
+ "futures",
  "indexmap",
- "itertools 0.8.2",
- "once_cell",
- "parking_lot 0.10.2",
+ "rand 0.8.5",
  "serde",
  "tempfile",
  "thiserror",
@@ -949,18 +969,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "esl01-drawdag"
-version = "0.1.0"
+name = "esl01-dag-types"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f503f73744061222785c9fdedc5654830da64a09dee5f0bdcaf3ea67d7400422"
+checksum = "cd764f3e0441aa076242c5591e8c70e9250ece9a0298b9a118a636c97121608f"
+dependencies = [
+ "esl01-minibytes",
+ "serde",
+]
+
+[[package]]
+name = "esl01-drawdag"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58614a84fe70f0dcf8e4126950606bbe9339bf931002791e34bae0fab0a8c9a7"
 
 [[package]]
 name = "esl01-indexedlog"
-version = "0.1.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28043d7042ee6d9d9472f69acc8b9f1b2c2c5e5896489eb1298e147e18ed9147"
+checksum = "ca189b77364e351675e0ac8274a8df0be0c88d3e66103d81f9bd265371f49389"
 dependencies = [
  "byteorder",
+ "esl01-atomicfile",
  "esl01-minibytes",
  "esl01-vlqencoding",
  "fs2",
@@ -968,27 +999,55 @@ dependencies = [
  "libc",
  "memmap",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "tempfile",
  "tracing",
  "twox-hash",
 ]
 
 [[package]]
-name = "esl01-minibytes"
-version = "0.2.0"
+name = "esl01-mincode"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c26b8b6a743b61c33507a42ef590a314d3e5d6ffc10524e1270c0e809460fb1"
+checksum = "238b140f1ced88489a0b3770b3a7613237d73919d6e4c9b8d295c44142264482"
 dependencies = [
+ "byteorder",
+ "esl01-vlqencoding",
+ "serde",
+]
+
+[[package]]
+name = "esl01-minibytes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0068579525ef038377d270f31c6cf5062da1ac99f34c7bc83b31bc61aa701ad1"
+dependencies = [
+ "bytes",
  "memmap",
  "serde",
 ]
 
 [[package]]
-name = "esl01-vlqencoding"
-version = "0.1.0"
+name = "esl01-nonblocking"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9a5c382a325e954524d0b68f83ff6f51b2b68996d84aef0502b0350a7e16d3"
+checksum = "2a2c37087d9d14a9d6bdf80e61dc7757763839cb528f6b866256b1773dd378ba"
+
+[[package]]
+name = "esl01-renderdag"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1840969ab8be31e186bb6d2f672d586dcd203dd4019a80dc1277a14686eca9"
+dependencies = [
+ "bitflags",
+ "itertools",
+]
+
+[[package]]
+name = "esl01-vlqencoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad8aca6f16078736d5e7762a45125eaa685dfe47155f4a72ec301f13a5f0749"
 
 [[package]]
 name = "eyre"
@@ -998,6 +1057,17 @@ checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fail"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1080,6 +1150,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,7 +1253,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1105,7 +1264,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -1147,7 +1306,7 @@ dependencies = [
  "git-branchless-undo",
  "git-record",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "man",
  "num_cpus",
@@ -1174,7 +1333,7 @@ dependencies = [
  "git-branchless-invoke",
  "git-branchless-lib",
  "git-branchless-opts",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "regex",
  "tracing",
@@ -1190,7 +1349,7 @@ dependencies = [
  "git-branchless-invoke",
  "git-branchless-lib",
  "git-branchless-opts",
- "itertools 0.10.5",
+ "itertools",
  "path-slash",
  "tracing",
 ]
@@ -1218,6 +1377,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-trait",
  "bstr",
  "cc",
  "chashmap",
@@ -1229,11 +1389,12 @@ dependencies = [
  "cursive",
  "esl01-dag",
  "eyre",
+ "futures",
  "git-record",
  "git2",
  "indicatif",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "once_cell",
  "portable-pty",
@@ -1276,7 +1437,7 @@ dependencies = [
  "git-branchless-opts",
  "git-branchless-revset",
  "git-branchless-smartlog",
- "itertools 0.10.5",
+ "itertools",
  "skim",
  "tracing",
 ]
@@ -1288,7 +1449,7 @@ dependencies = [
  "clap 4.0.32",
  "clap_mangen",
  "git-branchless-lib",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1302,7 +1463,7 @@ dependencies = [
  "git-branchless-opts",
  "git-branchless-revset",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "tracing",
 ]
 
@@ -1319,7 +1480,7 @@ dependencies = [
  "git-branchless-opts",
  "git-record",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "rayon",
  "tracing",
 ]
@@ -1334,11 +1495,12 @@ dependencies = [
  "chronoutil",
  "esl01-dag",
  "eyre",
+ "futures",
  "git-branchless-lib",
  "git-branchless-opts",
  "glob",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
@@ -1393,7 +1555,7 @@ dependencies = [
  "git-branchless-opts",
  "git-branchless-revset",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
 ]
 
@@ -1415,7 +1577,7 @@ dependencies = [
  "git-branchless-revset",
  "indexmap",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "maplit",
  "num_cpus",
@@ -1645,7 +1807,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1677,15 +1839,6 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1738,7 +1891,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.10.5",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -1835,15 +1988,6 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
@@ -1858,7 +2002,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1959,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
 ]
 
@@ -1971,7 +2115,7 @@ checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -2129,21 +2273,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.9",
+ "lock_api",
  "parking_lot_core 0.9.5",
 ]
 
@@ -2161,27 +2295,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec 1.10.0",
- "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec 1.10.0",
  "windows-sys",
 ]
@@ -2312,7 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
- "itertools 0.10.5",
+ "itertools",
  "predicates-core",
 ]
 
@@ -2554,12 +2674,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
@@ -2574,7 +2688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.8",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -2695,7 +2809,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "maplit",
  "proptest",
  "thiserror",
@@ -2911,6 +3025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,9 +3112,9 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -3160,7 +3283,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3271,7 +3394,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -3443,7 +3566,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/git-branchless-invoke/src/lib.rs
+++ b/git-branchless-invoke/src/lib.rs
@@ -54,7 +54,11 @@ pub struct CommandContext {
 fn install_tracing(effects: Effects) -> eyre::Result<impl Drop> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::WARN.into())
-        .from_env_lossy();
+        .parse(std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_|
+                // Limit to first-party logs by default in case third-party
+                // packages log spuriously. See
+                // https://discord.com/channels/968932220549103686/968932220549103689/1077096194276339772
+                "git_branchless=warn".to_string()))?;
     let fmt_layer = tracing_fmt::layer().with_writer(move || effects.clone().get_error_stream());
 
     let (profile_layer, flush_guard): (_, Box<dyn Any>) = {

--- a/git-branchless-lib/Cargo.toml
+++ b/git-branchless-lib/Cargo.toml
@@ -50,7 +50,7 @@ color-eyre = "0.6.2"
 concolor = { version = "0.0.12", features = ["auto"] }
 console = "0.15.5"
 cursive = { version = "0.20.0", default-features = false }
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git2 = { version = "0.16.1", default-features = false }
 git-record = { version = "0.3", path = "../git-record" }
@@ -72,6 +72,8 @@ bstr = "1.3.0"
 serde = { version = "1.0.152", features = ["derive"] }
 portable-pty = "0.7.0"
 vt100 = "0.15.2"
+async-trait = "0.1.64"
+futures = "0.3.26"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -570,7 +570,9 @@ impl Repo {
     /// Get the directory where the DAG for the repository is stored.
     #[instrument]
     pub fn get_dag_dir(&self) -> PathBuf {
-        self.get_path().join("branchless").join("dag")
+        // Updated from `dag` to `dag2` for `esl01-dag==0.3.0`, since it may
+        // not be backwards-compatible.
+        self.get_path().join("branchless").join("dag2")
     }
 
     /// Get the directory to store man-pages. Note that this is the `man`

--- a/git-branchless-move/Cargo.toml
+++ b/git-branchless-move/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/arxanas/git-branchless"
 version = "0.7.0"
 
 [dependencies]
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-revset = { version = "0.7.0", path = "../git-branchless-revset" }
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }

--- a/git-branchless-navigation/Cargo.toml
+++ b/git-branchless-navigation/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.7.0"
 cursive = { version = "0.20.0", default-features = false, features = [
   "crossterm-backend",
 ] }
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }
 git-branchless-revset = { version = "0.7.0", path = "../git-branchless-revset" }

--- a/git-branchless-navigation/src/lib.rs
+++ b/git-branchless-navigation/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 
 use cursive::theme::BaseColor;
 use cursive::utils::markup::StyledString;
-use eden_dag::DagAlgorithm;
+
 use lib::core::check_out::{check_out_commit, CheckOutCommitOptions, CheckoutTarget};
 use lib::core::repo_ext::RepoExt;
 use lib::util::ExitCode;
@@ -108,7 +108,7 @@ fn advance(
         }
     };
 
-    let public_commits = dag.query().ancestors(dag.main_branch_commit.clone())?;
+    let public_commits = dag.query_ancestors(dag.main_branch_commit.clone())?;
 
     let glyphs = effects.get_glyphs();
     let mut current_oid = current_oid;
@@ -117,16 +117,16 @@ fn advance(
         let candidate_commits = match command {
             Command::Next => {
                 let child_commits = || -> eyre::Result<CommitSet> {
-                    let result = dag.query().children(CommitSet::from(current_oid))?;
+                    let result = dag.query_children(CommitSet::from(current_oid))?;
                     let result = dag.filter_visible_commits(result)?;
                     Ok(result)
                 };
 
                 let descendant_branches = || -> eyre::Result<CommitSet> {
-                    let descendant_commits = dag.query().descendants(child_commits()?)?;
+                    let descendant_commits = dag.query_descendants(child_commits()?)?;
                     let descendant_branches = dag.branch_commits.intersection(&descendant_commits);
-                    let descendants = dag.query().descendants(descendant_branches)?;
-                    let nearest_descendant_branches = dag.query().roots(descendants)?;
+                    let descendants = dag.query_descendants(descendant_branches)?;
+                    let nearest_descendant_branches = dag.query_roots(descendants)?;
                     Ok(nearest_descendant_branches)
                 };
 
@@ -153,14 +153,13 @@ fn advance(
 
             Command::Prev => {
                 let parent_commits = || -> eyre::Result<CommitSet> {
-                    let result = dag.query().parents(CommitSet::from(current_oid))?;
+                    let result = dag.query_parents(CommitSet::from(current_oid))?;
                     Ok(result)
                 };
                 let ancestor_branches = || -> eyre::Result<CommitSet> {
-                    let ancestor_commits = dag.query().ancestors(parent_commits()?)?;
+                    let ancestor_commits = dag.query_ancestors(parent_commits()?)?;
                     let ancestor_branches = dag.branch_commits.intersection(&ancestor_commits);
-                    let nearest_ancestor_branches =
-                        dag.query().heads_ancestors(ancestor_branches)?;
+                    let nearest_ancestor_branches = dag.query_heads_ancestors(ancestor_branches)?;
                     Ok(nearest_ancestor_branches)
                 };
 

--- a/git-branchless-query/Cargo.toml
+++ b/git-branchless-query/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.7.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-invoke = { version = "0.7.0", path = "../git-branchless-invoke" }
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }

--- a/git-branchless-query/src/lib.rs
+++ b/git-branchless-query/src/lib.rs
@@ -1,9 +1,8 @@
 use std::fmt::Write;
 
-use eden_dag::DagAlgorithm;
 use git_branchless_invoke::CommandContext;
 use itertools::Itertools;
-use lib::core::dag::{commit_set_to_vec, Dag};
+use lib::core::dag::Dag;
 use lib::core::effects::{Effects, OperationType};
 use lib::core::eventlog::{EventLogDb, EventReplayer};
 use lib::core::repo_ext::RepoExt;
@@ -75,8 +74,8 @@ fn query(
             let _effects = effects;
 
             let commit_set = commit_set.intersection(&dag.branch_commits);
-            let commit_set = dag.query().sort(&commit_set)?;
-            commit_set_to_vec(&commit_set)?
+            let commit_set = dag.sort(&commit_set)?;
+            dag.commit_set_to_vec(&commit_set)?
         };
         let ref_names = commit_oids
             .into_iter()
@@ -97,8 +96,8 @@ fn query(
             let (effects, _progress) = effects.start_operation(OperationType::SortCommits);
             let _effects = effects;
 
-            let commit_set = dag.query().sort(&commit_set)?;
-            commit_set_to_vec(&commit_set)?
+            let commit_set = dag.sort(&commit_set)?;
+            dag.commit_set_to_vec(&commit_set)?
         };
         for commit_oid in commit_oids.into_iter().rev() {
             if raw {

--- a/git-branchless-record/Cargo.toml
+++ b/git-branchless-record/Cargo.toml
@@ -11,7 +11,7 @@ cursive = { version = "0.20.0", default-features = false, features = [
   "crossterm-backend",
 ] }
 cursive_buffered_backend = "0.6.1"
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-invoke = { version = "0.7.0", path = "../git-branchless-invoke" }
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }

--- a/git-branchless-revset/Cargo.toml
+++ b/git-branchless-revset/Cargo.toml
@@ -11,8 +11,9 @@ bstr = "1.3.0"
 chrono = "0.4.22"
 chrono-english = "0.1.7"
 chronoutil = "0.2.3"
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
+futures = "0.3.26"
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }
 glob = "0.3.0"
 itertools = "0.10.5"

--- a/git-branchless-revset/src/eval.rs
+++ b/git-branchless-revset/src/eval.rs
@@ -350,7 +350,6 @@ pub(super) fn eval_number_rhs(
 mod tests {
     use std::borrow::Cow;
 
-    use lib::core::dag::commit_set_to_vec;
     use lib::core::effects::Effects;
     use lib::core::eventlog::{EventLogDb, EventReplayer};
     use lib::core::formatting::Glyphs;
@@ -368,7 +367,8 @@ mod tests {
         expr: &Expr,
     ) -> eyre::Result<Vec<Commit<'a>>> {
         let result = eval(effects, repo, dag, expr)?;
-        let mut commits: Vec<Commit> = commit_set_to_vec(&result)?
+        let mut commits: Vec<Commit> = dag
+            .commit_set_to_vec(&result)?
             .into_iter()
             .map(|oid| repo.find_commit_or_fail(oid))
             .try_collect()?;

--- a/git-branchless-reword/Cargo.toml
+++ b/git-branchless-reword/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.7.0"
 [dependencies]
 bstr = "1.3.0"
 chrono = "0.4.22"
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }
 git-branchless-revset = { version = "0.7.0", path = "../git-branchless-revset" }

--- a/git-branchless-smartlog/Cargo.toml
+++ b/git-branchless-smartlog/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.7.0"
 
 [dependencies]
 cursive_core = { version = "0.3.5", default-features = false }
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 git-branchless-invoke = { version = "0.7.0", path = "../git-branchless-invoke" }
 git-branchless-opts = { version = "0.7.0", path = "../git-branchless-opts" }

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -5,7 +5,7 @@ use cursive_core::theme::{BaseColor, Effect, Style};
 use git_branchless_invoke::CommandContext;
 use itertools::{Either, Itertools};
 use lazy_static::lazy_static;
-use lib::core::dag::{commit_set_to_vec, Dag};
+use lib::core::dag::Dag;
 use lib::core::effects::{Effects, OperationType};
 use lib::core::eventlog::{EventLogDb, EventReplayer};
 use lib::core::formatting::{Pluralize, StyledStringBuilder};
@@ -74,7 +74,8 @@ fn submit(
             }
         };
 
-    let branches: Vec<Branch> = commit_set_to_vec(&commit_set)?
+    let branches: Vec<Branch> = dag
+        .commit_set_to_vec(&commit_set)?
         .into_iter()
         .flat_map(|commit_oid| references_snapshot.branch_oid_to_names.get(&commit_oid))
         .flatten()

--- a/git-branchless-test/Cargo.toml
+++ b/git-branchless-test/Cargo.toml
@@ -13,7 +13,7 @@ crossbeam = "0.8.2"
 cursive = { version = "0.20.0", default-features = false, features = [
   "crossterm-backend",
 ] }
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 fslock = "0.2.1"
 git-branchless-invoke = { version = "0.7.0", path = "../git-branchless-invoke" }

--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -27,7 +27,7 @@ use clap::ValueEnum;
 use crossbeam::channel::{Receiver, RecvError};
 use cursive::theme::{BaseColor, Effect, Style};
 use cursive::utils::markup::StyledString;
-use eden_dag::DagAlgorithm;
+
 use eyre::WrapErr;
 use fslock::LockFile;
 use git_branchless_invoke::CommandContext;
@@ -39,7 +39,7 @@ use lib::core::config::{
     get_hint_enabled, get_hint_string, get_restack_preserve_timestamps,
     print_hint_suppression_notice, Hint,
 };
-use lib::core::dag::{commit_set_to_vec, sorted_commit_set, CommitSet, Dag};
+use lib::core::dag::{sorted_commit_set, CommitSet, Dag};
 use lib::core::effects::{icons, Effects, OperationIcon, OperationType};
 use lib::core::eventlog::{EventLogDb, EventReplayer, EventTransactionId};
 use lib::core::formatting::{Glyphs, Pluralize, StyledStringBuilder};
@@ -414,7 +414,7 @@ BUG: Expected resolved_interactive ({resolved_interactive:?}) to match interacti
                 match RebasePlanPermissions::verify_rewrite_set(dag, build_options, commits)? {
                     Ok(permissions) => permissions,
                     Err(err) => {
-                        err.describe(effects, repo)?;
+                        err.describe(effects, repo, dag)?;
                         return Ok(Err(ExitCode(1)));
                     }
                 };
@@ -1184,17 +1184,17 @@ impl<'a> search::SearchGraph for SearchGraph<'a> {
 
     #[instrument]
     fn ancestors(&self, node: Self::Node) -> Result<HashSet<Self::Node>, Self::Error> {
-        let ancestors = self.dag.query().ancestors(CommitSet::from(node))?;
+        let ancestors = self.dag.query_ancestors(CommitSet::from(node))?;
         let ancestors = ancestors.intersection(&self.commit_set);
-        let ancestors = commit_set_to_vec(&ancestors)?;
+        let ancestors = self.dag.commit_set_to_vec(&ancestors)?;
         Ok(ancestors.into_iter().collect())
     }
 
     #[instrument]
     fn descendants(&self, node: Self::Node) -> Result<HashSet<Self::Node>, Self::Error> {
-        let descendants = self.dag.query().descendants(CommitSet::from(node))?;
+        let descendants = self.dag.query_descendants(CommitSet::from(node))?;
         let descendants = descendants.intersection(&self.commit_set);
-        let descendants = commit_set_to_vec(&descendants)?;
+        let descendants = self.dag.commit_set_to_vec(&descendants)?;
         Ok(descendants.into_iter().collect())
     }
 }
@@ -1984,11 +1984,11 @@ fn apply_fixes(
             })
             .copied()
             .collect();
-        let descendant_oids = dag.query().descendants(original_oids.clone())?;
+        let descendant_oids = dag.query_descendants(original_oids.clone())?;
         let descendant_oids = dag
             .filter_visible_commits(descendant_oids)?
             .difference(&original_oids);
-        for descendant_oid in commit_set_to_vec(&descendant_oids)? {
+        for descendant_oid in dag.commit_set_to_vec(&descendant_oids)? {
             let descendant_commit = repo.find_commit_or_fail(descendant_oid)?;
             builder.replace_commit(descendant_oid, descendant_oid)?;
             builder.move_subtree(descendant_oid, descendant_commit.get_parent_oids())?;
@@ -2006,7 +2006,7 @@ fn apply_fixes(
             return Ok(ExitCode(0));
         }
         Err(err) => {
-            err.describe(effects, repo)?;
+            err.describe(effects, repo, dag)?;
             return Ok(ExitCode(1));
         }
     };

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -22,7 +22,7 @@ bugreport = "0.5.0"
 color-eyre = "0.6.2"
 console = "0.15.5"
 cursive_core = "0.3.7"
-eden_dag = { package = "esl01-dag", version = "0.2.1" }
+eden_dag = { package = "esl01-dag", version = "0.3.0" }
 eyre = "0.6.8"
 fslock = "0.2.1"
 git-branchless-hook = { version = "0.7.0", path = "../git-branchless-hook" }

--- a/git-branchless/src/commands/hide.rs
+++ b/git-branchless/src/commands/hide.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::time::SystemTime;
 
-use eden_dag::DagAlgorithm;
 use git_branchless_opts::{ResolveRevsetOptions, Revset};
 use lib::core::dag::{sorted_commit_set, union_all, Dag};
 use lib::core::effects::Effects;
@@ -57,11 +56,11 @@ pub fn hide(
 
     let commits = union_all(&commit_sets);
     let commits = if recursive {
-        dag.filter_visible_commits(dag.query().descendants(commits)?)?
+        dag.filter_visible_commits(dag.query_descendants(commits)?)?
     } else {
         commits
     };
-    let commits = dag.query().sort(&commits)?;
+    let commits = dag.sort(&commits)?;
     let commits = sorted_commit_set(&repo, &dag, &commits)?;
 
     let timestamp = now.duration_since(SystemTime::UNIX_EPOCH)?.as_secs_f64();
@@ -213,13 +212,12 @@ pub fn unhide(
 
     let commits = union_all(&commit_sets);
     let commits = if recursive {
-        dag.query()
-            .descendants(commits)?
+        dag.query_descendants(commits)?
             .intersection(&dag.query_obsolete_commits())
     } else {
         commits
     };
-    let commits = dag.query().sort(&commits)?;
+    let commits = dag.sort(&commits)?;
     let commits = sorted_commit_set(&repo, &dag, &commits)?;
 
     let timestamp = now.duration_since(SystemTime::UNIX_EPOCH)?.as_secs_f64();

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -217,7 +217,8 @@ fn test_init_basic() -> eyre::Result<()> {
     })?;
 
     {
-        let (stdout, _stderr) = git.branchless("init", &[])?;
+        let (stdout, stderr) = git.branchless("init", &[])?;
+        insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
         Created config file at <repo-path>/.git/branchless/config
         Auto-detected your main branch as: master


### PR DESCRIPTION
The updated version of the Eden (now Sapling) DAG library is MIT-licensed, as opposed to GPL-2.0-only
