### PR TITLE
docs: Suggest checking package repositories before cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ When you use `git rebase --interactive` with `git-branchless`, you will be promp
 
 See https://github.com/arxanas/git-branchless/wiki/Installation.
 
-Short version: run `cargo install --locked git-branchless`, then run `git branchless init` in your repository.
+Short version: check for packages in the repositories appropriate for your system or run `cargo install --locked git-branchless`. Once installed, run `git branchless init` in your repository.
 
 ## Status
 


### PR DESCRIPTION
With v0.7.1 I am migrating `git-branchless` [to the official repositories for Arch Linux](https://archlinux.org/packages/community/x86_64/git-branchless/). That makes quite a few platforms with prebuilt packages now. I would suggest that *if* the user is on a system with system packages available that is almost certainly a better path for them than directly compiling and installing via `cargo` (completions, access from other users, automatic upgrades, etc.). As such I suggest suggesting it in the "short version" of how to install.
