### PR TITLE
`scm-diff-editor` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "diffy",
  "eyre",
  "insta",
+ "maplit",
  "num-traits",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +722,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cursive"
@@ -889,6 +917,25 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "diffy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs-next"
@@ -1401,6 +1448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2338,6 +2395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,6 +2519,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owning_ref"
@@ -3062,17 +3135,21 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "cassowary",
+ "clap 4.2.4",
  "criterion",
  "crossterm 0.26.1",
+ "diffy",
  "eyre",
  "insta",
  "num-traits",
  "serde",
  "serde_json",
+ "sha1",
  "thiserror",
  "tracing",
  "tui",
  "unicode-width",
+ "walkdir",
 ]
 
 [[package]]
@@ -3158,6 +3235,17 @@ checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 dependencies = [
  "libc",
  "serial-core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3655,6 +3743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,12 +3882,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/git-branchless-lib/bin/testing/regression_test_record.rs
+++ b/git-branchless-lib/bin/testing/regression_test_record.rs
@@ -58,6 +58,7 @@ fn entries_from_files(
 
 fn select_all(mut entries: Vec<File>) -> Vec<File> {
     for File {
+        old_path: _,
         path: _,
         file_mode: _,
         sections,

--- a/git-branchless-lib/src/git/diff.rs
+++ b/git-branchless-lib/src/git/diff.rs
@@ -119,6 +119,7 @@ pub fn process_diff_for_record(repo: &Repo, diff: &Diff) -> eyre::Result<Vec<Fil
 
         if new_oid.is_zero() {
             result.push(File {
+                old_path: None,
                 path: Cow::Owned(path),
                 file_mode: Some(old_file_mode),
                 sections: vec![Section::FileMode {
@@ -136,6 +137,7 @@ pub fn process_diff_for_record(repo: &Repo, diff: &Diff) -> eyre::Result<Vec<Fil
                 new_num_bytes,
             } => {
                 result.push(File {
+                    old_path: None,
                     path: Cow::Owned(path),
                     file_mode: Some(old_file_mode),
                     sections: vec![Section::Binary {
@@ -371,6 +373,7 @@ pub fn process_diff_for_record(repo: &Repo, diff: &Diff) -> eyre::Result<Vec<Fil
             vec![]
         };
         result.push(File {
+            old_path: None,
             path: Cow::Owned(path),
             file_mode: Some(old_file_mode),
             sections: [file_mode_section, file_sections].concat().to_vec(),

--- a/scm-record/Cargo.toml
+++ b/scm-record/Cargo.toml
@@ -36,6 +36,7 @@ assert_matches = "1.5.0"
 criterion = "0.4.0"
 eyre = "0.6.8"
 insta = "1.29.0"
+maplit = "1.0.2"
 
 [[bin]]
 name = "scm-diff-editor"

--- a/scm-record/Cargo.toml
+++ b/scm-record/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 [features]
 debug = ["serde"]
 default = ["debug"]
+scm-diff-editor = ["clap", "diffy", "sha1", "walkdir"]
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
@@ -25,11 +26,20 @@ tracing = "0.1.37"
 tui = "0.19.0"
 unicode-width = "0.1.10"
 
+clap = { version = "4.2.3", features = ["derive"], optional = true }
+diffy = {version = "0.3.0", optional = true}
+sha1 = { version = "0.10.5", optional = true}
+walkdir = { version = "2.3.3", optional = true }
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.4.0"
 eyre = "0.6.8"
 insta = "1.29.0"
+
+[[bin]]
+name = "scm-diff-editor"
+required-features = ["scm-diff-editor"]
 
 [[bench]]
 name = "benches"

--- a/scm-record/benches/benches.rs
+++ b/scm-record/benches/benches.rs
@@ -20,6 +20,7 @@ fn bench_record(c: &mut Criterion) {
         };
         let record_state = RecordState {
             files: vec![File {
+                old_path: None,
                 path: Cow::Borrowed(Path::new("foo")),
                 file_mode: None,
                 sections: vec![Section::Changed {

--- a/scm-record/examples/static_contents.rs
+++ b/scm-record/examples/static_contents.rs
@@ -12,6 +12,7 @@ use scm_record::{
 fn main() {
     let files = vec![
         File {
+            old_path: None,
             path: Cow::Borrowed(Path::new("foo/bar")),
             file_mode: None,
             sections: vec![
@@ -51,6 +52,7 @@ fn main() {
             ],
         },
         File {
+            old_path: None,
             path: Cow::Borrowed(Path::new("baz")),
             file_mode: None,
             sections: vec![

--- a/scm-record/src/bin/scm-diff-editor.rs
+++ b/scm-record/src/bin/scm-diff-editor.rs
@@ -298,7 +298,7 @@ mod render {
         change_type: ChangeType,
     ) -> Vec<SectionChangedLine<'static>> {
         contents
-            .lines()
+            .split_inclusive('\n')
             .map(|line| SectionChangedLine {
                 is_toggled: false,
                 change_type,
@@ -903,7 +903,7 @@ qux2
                             SectionChangedLine {
                                 is_toggled: false,
                                 change_type: Added,
-                                line: "right",
+                                line: "right\n",
                             },
                         ],
                     },
@@ -922,9 +922,9 @@ qux2
                         33188,
                     ),
                     contents: Text {
-                        contents: "right",
+                        contents: "right\n",
                         hash: "abc123",
-                        num_bytes: 5,
+                        num_bytes: 6,
                     },
                 },
             },
@@ -965,7 +965,7 @@ qux2
                             SectionChangedLine {
                                 is_toggled: false,
                                 change_type: Removed,
-                                line: "left",
+                                line: "left\n",
                             },
                         ],
                     },

--- a/scm-record/src/bin/scm-diff-editor.rs
+++ b/scm-record/src/bin/scm-diff-editor.rs
@@ -1,0 +1,598 @@
+//! An interactive difftool for use in VCS programs like
+//! [Jujutsu](https://github.com/martinvonz/jj) or Git.
+
+#![warn(missing_docs)]
+#![warn(
+    clippy::all,
+    clippy::as_conversions,
+    clippy::clone_on_ref_ptr,
+    clippy::dbg_macro
+)]
+#![allow(clippy::too_many_arguments, clippy::blocks_in_if_conditions)]
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::error;
+use std::fmt::Display;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf, StripPrefixError};
+
+use clap::Parser;
+use scm_record::RecordState;
+use scm_record::{
+    helpers::make_binary_description, ChangeType, File, FileMode, Section, SectionChangedLine,
+};
+use sha1::Digest;
+use walkdir::WalkDir;
+
+#[derive(Debug)]
+enum Error {
+    Cancelled,
+    DryRun,
+    WalkDir {
+        source: walkdir::Error,
+    },
+    StripPrefix {
+        root: PathBuf,
+        path: PathBuf,
+        source: StripPrefixError,
+    },
+    ReadFile {
+        path: PathBuf,
+        source: io::Error,
+    },
+    RemoveFile {
+        path: PathBuf,
+        source: io::Error,
+    },
+    CopyFile {
+        old_path: PathBuf,
+        new_path: PathBuf,
+        source: io::Error,
+    },
+    CreateDirAll {
+        parent_dir: PathBuf,
+        path: PathBuf,
+        source: io::Error,
+    },
+    WriteFile {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Record {
+        source: scm_record::RecordError,
+    },
+}
+
+impl error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Cancelled => {
+                write!(f, "aborted by user")
+            }
+            Error::DryRun => {
+                write!(f, "dry run, not writing any files")
+            }
+            Error::WalkDir { source } => {
+                write!(f, "walking directory: {source}")
+            }
+            Error::StripPrefix { root, path, source } => {
+                write!(
+                    f,
+                    "stripping directory prefix {} from {}: {source}",
+                    root.display(),
+                    path.display()
+                )
+            }
+            Error::ReadFile { path, source } => {
+                write!(f, "reading file {}: {source}", path.display())
+            }
+            Error::RemoveFile { path, source } => {
+                write!(f, "removing file {}: {source}", path.display())
+            }
+            Error::CopyFile {
+                old_path,
+                new_path,
+                source,
+            } => {
+                write!(
+                    f,
+                    "copying file {} to {}: {source}",
+                    old_path.display(),
+                    new_path.display()
+                )
+            }
+            Error::CreateDirAll {
+                parent_dir,
+                path,
+                source,
+            } => {
+                write!(
+                    f,
+                    "creating parent directory {} for path {}: {source}",
+                    parent_dir.display(),
+                    path.display(),
+                )
+            }
+            Error::WriteFile { path, source } => {
+                write!(f, "writing file {}: {source}", path.display())
+            }
+            Error::Record { source } => {
+                write!(f, "recording changes: {source}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[clap(short = 'd', long = "dir-diff")]
+    dir_diff: bool,
+    left: PathBuf,
+    right: PathBuf,
+    #[clap(short = 'N', long = "dry-run")]
+    dry_run: bool,
+}
+
+struct FileInfo {
+    file_mode: FileMode,
+    contents: FileContents,
+}
+
+#[derive(Debug)]
+enum FileContents {
+    Absent,
+    Text {
+        contents: String,
+        hash: String,
+        num_bytes: u64,
+    },
+    Binary {
+        hash: String,
+        num_bytes: u64,
+    },
+}
+
+fn make_section_changed_lines(
+    contents: &str,
+    change_type: ChangeType,
+) -> Vec<SectionChangedLine<'static>> {
+    contents
+        .lines()
+        .map(|line| SectionChangedLine {
+            is_toggled: false,
+            change_type,
+            line: Cow::Owned(line.to_owned()),
+        })
+        .collect()
+}
+
+fn read_file_info(path: PathBuf) -> Result<FileInfo, Error> {
+    let file_mode = match fs::metadata(&path) {
+        Ok(metadata) => {
+            // TODO: no support for gitlinks (submodules).
+            if metadata.is_symlink() {
+                FileMode(0o120000)
+            } else {
+                let permissions = metadata.permissions();
+                #[cfg(unix)]
+                let executable = {
+                    use std::os::unix::fs::PermissionsExt;
+                    permissions.mode() & 0o001 == 0o001
+                };
+                #[cfg(not(unix))]
+                let executable = false;
+                if executable {
+                    FileMode(0o100755)
+                } else {
+                    FileMode(0o100644)
+                }
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => FileMode::absent(),
+        Err(err) => return Err(Error::ReadFile { path, source: err }),
+    };
+    let contents = match fs::read(&path) {
+        Ok(contents) => {
+            let hash = {
+                let mut hasher = sha1::Sha1::new();
+                hasher.update(&contents);
+                format!("{:x}", hasher.finalize())
+            };
+            let num_bytes: u64 = contents.len().try_into().unwrap();
+            if contents.contains(&0) {
+                FileContents::Binary { hash, num_bytes }
+            } else {
+                match String::from_utf8(contents) {
+                    Ok(contents) => FileContents::Text {
+                        contents,
+                        hash,
+                        num_bytes,
+                    },
+                    Err(_) => FileContents::Binary { hash, num_bytes },
+                }
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => FileContents::Absent,
+        Err(err) => return Err(Error::ReadFile { path, source: err }),
+    };
+    Ok(FileInfo {
+        file_mode,
+        contents,
+    })
+}
+
+fn create_file(
+    left_path: PathBuf,
+    left_display_path: PathBuf,
+    right_path: PathBuf,
+    right_display_path: PathBuf,
+) -> Result<File<'static>, Error> {
+    let FileInfo {
+        file_mode: left_file_mode,
+        contents: left_contents,
+    } = read_file_info(left_path)?;
+    let FileInfo {
+        file_mode: right_file_mode,
+        contents: right_contents,
+    } = read_file_info(right_path)?;
+    let mut sections = Vec::new();
+
+    if left_file_mode != right_file_mode
+        && left_file_mode != FileMode::absent()
+        && right_file_mode != FileMode::absent()
+    {
+        sections.push(Section::FileMode {
+            is_toggled: false,
+            before: left_file_mode,
+            after: right_file_mode,
+        });
+    }
+
+    match (left_contents, right_contents) {
+        (FileContents::Absent, FileContents::Absent) => {}
+        (
+            FileContents::Absent,
+            FileContents::Text {
+                contents,
+                hash: _,
+                num_bytes: _,
+            },
+        ) => sections.push(Section::Changed {
+            lines: make_section_changed_lines(&contents, ChangeType::Added),
+        }),
+
+        (FileContents::Absent, FileContents::Binary { hash, num_bytes }) => {
+            sections.push(Section::Binary {
+                is_toggled: false,
+                old_description: None,
+                new_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
+            })
+        }
+
+        (
+            FileContents::Text {
+                contents,
+                hash: _,
+                num_bytes: _,
+            },
+            FileContents::Absent,
+        ) => sections.push(Section::Changed {
+            lines: make_section_changed_lines(&contents, ChangeType::Removed),
+        }),
+
+        (
+            FileContents::Text {
+                contents: old_contents,
+                hash: _,
+                num_bytes: _,
+            },
+            FileContents::Text {
+                contents: new_contents,
+                hash: _,
+                num_bytes: _,
+            },
+        ) => {
+            sections.extend(create_diff(&old_contents, &new_contents));
+        }
+
+        (
+            FileContents::Text {
+                contents: _,
+                hash: old_hash,
+                num_bytes: old_num_bytes,
+            }
+            | FileContents::Binary {
+                hash: old_hash,
+                num_bytes: old_num_bytes,
+            },
+            FileContents::Text {
+                contents: _,
+                hash: new_hash,
+                num_bytes: new_num_bytes,
+            }
+            | FileContents::Binary {
+                hash: new_hash,
+                num_bytes: new_num_bytes,
+            },
+        ) => sections.push(Section::Binary {
+            is_toggled: false,
+            old_description: Some(Cow::Owned(make_binary_description(
+                &old_hash,
+                old_num_bytes,
+            ))),
+            new_description: Some(Cow::Owned(make_binary_description(
+                &new_hash,
+                new_num_bytes,
+            ))),
+        }),
+
+        (FileContents::Binary { hash, num_bytes }, FileContents::Absent) => {
+            sections.push(Section::Binary {
+                is_toggled: false,
+                old_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
+                new_description: None,
+            })
+        }
+    }
+
+    Ok(File {
+        old_path: if left_display_path != right_display_path {
+            Some(Cow::Owned(left_display_path))
+        } else {
+            None
+        },
+        path: Cow::Owned(right_display_path),
+        file_mode: None, // TODO
+        sections,
+    })
+}
+
+fn create_diff(old_contents: &str, new_contents: &str) -> Vec<Section<'static>> {
+    let patch = {
+        // Set the context length to the maximum number of lines in either file,
+        // because we will handle abbreviating context ourselves.
+        let max_lines = old_contents
+            .lines()
+            .count()
+            .max(new_contents.lines().count());
+        let mut diff_options = diffy::DiffOptions::new();
+        diff_options.set_context_len(max_lines);
+        diff_options.create_patch(old_contents, new_contents)
+    };
+
+    let mut sections = Vec::new();
+    for hunk in patch.hunks() {
+        sections.extend(hunk.lines().iter().fold(Vec::new(), |mut acc, line| {
+            match line {
+                diffy::Line::Context(line) => match acc.last_mut() {
+                    Some(Section::Unchanged { lines }) => {
+                        lines.push(Cow::Owned((*line).to_owned()));
+                    }
+                    _ => {
+                        acc.push(Section::Unchanged {
+                            lines: vec![Cow::Owned((*line).to_owned())],
+                        });
+                    }
+                },
+                diffy::Line::Delete(line) => {
+                    let line = SectionChangedLine {
+                        is_toggled: false,
+                        change_type: ChangeType::Removed,
+                        line: Cow::Owned((*line).to_owned()),
+                    };
+                    match acc.last_mut() {
+                        Some(Section::Changed { lines }) => {
+                            lines.push(line);
+                        }
+                        _ => {
+                            acc.push(Section::Changed { lines: vec![line] });
+                        }
+                    }
+                }
+                diffy::Line::Insert(line) => {
+                    let line = SectionChangedLine {
+                        is_toggled: false,
+                        change_type: ChangeType::Added,
+                        line: Cow::Owned((*line).to_owned()),
+                    };
+                    match acc.last_mut() {
+                        Some(Section::Changed { lines }) => {
+                            lines.push(line);
+                        }
+                        _ => {
+                            acc.push(Section::Changed { lines: vec![line] });
+                        }
+                    }
+                }
+            }
+            acc
+        }));
+    }
+    sections
+}
+
+fn print_dry_run(write_root: &Path, state: RecordState) {
+    let scm_record::RecordState { files } = state;
+    for file in files {
+        let file_path = write_root.join(file.path.clone());
+        let (selected_contents, _unselected_contents) = file.get_selected_contents();
+        match selected_contents {
+            scm_record::SelectedContents::Absent => {
+                println!("Would delete file: {}", file_path.display())
+            }
+            scm_record::SelectedContents::Unchanged => {
+                println!("Would leave file unchanged: {}", file_path.display())
+            }
+            scm_record::SelectedContents::Binary {
+                old_description,
+                new_description,
+            } => {
+                println!("Would update binary file: {}", file_path.display());
+                println!("  Old: {:?}", old_description);
+                println!("  New: {:?}", new_description);
+            }
+            scm_record::SelectedContents::Present { contents } => {
+                println!("Would update text file: {}", file_path.display());
+                for line in contents.lines() {
+                    println!("  {line}");
+                }
+            }
+        }
+    }
+}
+
+fn apply_changes(write_root: &Path, state: RecordState) -> Result<(), Error> {
+    let scm_record::RecordState { files } = state;
+    for file in files {
+        let file_path = write_root.join(file.path.clone());
+        let (selected_contents, _unselected_contents) = file.get_selected_contents();
+        match selected_contents {
+            scm_record::SelectedContents::Absent => match fs::remove_file(&file_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(Error::RemoveFile {
+                        path: file_path,
+                        source: err,
+                    });
+                }
+            },
+            scm_record::SelectedContents::Unchanged => {
+                // Do nothing.
+            }
+            scm_record::SelectedContents::Binary {
+                old_description: _,
+                new_description: _,
+            } => {
+                let new_path = file_path;
+                let old_path = match &file.old_path {
+                    Some(old_path) => old_path.clone(),
+                    None => Cow::Borrowed(new_path.as_path()),
+                };
+                match fs::copy(&old_path, &new_path) {
+                    Ok(_bytes_written) => {}
+                    Err(err) => {
+                        return Err(Error::CopyFile {
+                            source: err,
+                            old_path: old_path.clone().into_owned(),
+                            new_path,
+                        });
+                    }
+                };
+            }
+            scm_record::SelectedContents::Present { contents } => {
+                if let Some(parent_dir) = file_path.parent() {
+                    fs::create_dir_all(parent_dir).map_err(|err| Error::CreateDirAll {
+                        parent_dir: parent_dir.to_owned(),
+                        path: file_path.clone(),
+                        source: err,
+                    })?;
+                }
+                match fs::write(&file_path, contents) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        return Err(Error::WriteFile {
+                            path: file_path,
+                            source: err,
+                        })
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn main_inner() -> Result<(), Error> {
+    let opts = Opts::parse();
+    let (files, write_root) = match opts {
+        Opts {
+            dir_diff: false,
+            left,
+            right,
+            dry_run: _,
+        } => {
+            let write_root = right
+                .parent()
+                .map(|path| path.to_owned())
+                .unwrap_or_default();
+            let files = vec![create_file(left.clone(), left, right.clone(), right)?];
+            (files, write_root)
+        }
+        Opts {
+            dir_diff: true,
+            left,
+            right,
+            dry_run: _,
+        } => {
+            fn walk_dir(dir: &Path) -> Result<BTreeMap<PathBuf, PathBuf>, Error> {
+                let mut files = BTreeMap::new();
+                for entry in WalkDir::new(dir) {
+                    let entry = entry.map_err(|err| Error::WalkDir { source: err })?;
+                    if entry.file_type().is_file() || entry.file_type().is_symlink() {
+                        let display_path = match entry.path().strip_prefix(dir) {
+                            Ok(path) => path.to_owned(),
+                            Err(err) => {
+                                return Err(Error::StripPrefix {
+                                    root: dir.to_owned(),
+                                    path: entry.path().to_owned(),
+                                    source: err,
+                                })
+                            }
+                        };
+                        files.insert(display_path, entry.path().to_owned());
+                    }
+                }
+                Ok(files)
+            }
+            let left_files = walk_dir(&left)?;
+            let right_files = walk_dir(&right)?;
+            let display_paths = left_files
+                .keys()
+                .chain(right_files.keys())
+                .collect::<BTreeSet<_>>();
+            let mut files = Vec::new();
+            for display_path in display_paths {
+                files.push(create_file(
+                    left.join(display_path),
+                    display_path.clone(),
+                    right.join(display_path),
+                    display_path.clone(),
+                )?);
+            }
+            (files, right)
+        }
+    };
+
+    let state = scm_record::RecordState { files };
+    let event_source = scm_record::EventSource::Crossterm;
+    let recorder = scm_record::Recorder::new(state, event_source);
+    match recorder.run() {
+        Ok(state) => {
+            if opts.dry_run {
+                print_dry_run(&write_root, state);
+                Err(Error::DryRun)
+            } else {
+                apply_changes(&write_root, state)?;
+                Ok(())
+            }
+        }
+        Err(scm_record::RecordError::Cancelled) => Err(Error::Cancelled),
+        Err(err) => Err(Error::Record { source: err }),
+    }
+}
+
+fn main() {
+    match main_inner() {
+        Ok(()) => {}
+        Err(err) => {
+            eprintln!("error: {err}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/scm-record/src/bin/scm-diff-editor.rs
+++ b/scm-record/src/bin/scm-diff-editor.rs
@@ -20,15 +20,13 @@ use std::io;
 use std::path::{Path, PathBuf, StripPrefixError};
 
 use clap::Parser;
-use scm_record::RecordState;
-use scm_record::{
-    helpers::make_binary_description, ChangeType, File, FileMode, Section, SectionChangedLine,
-};
+use scm_record::{File, FileMode, RecordState};
 use sha1::Digest;
 use walkdir::WalkDir;
 
+#[allow(missing_docs)]
 #[derive(Debug)]
-enum Error {
+pub enum Error {
     Cancelled,
     DryRun,
     WalkDir {
@@ -53,7 +51,6 @@ enum Error {
         source: io::Error,
     },
     CreateDirAll {
-        parent_dir: PathBuf,
         path: PathBuf,
         source: io::Error,
     },
@@ -106,17 +103,8 @@ impl Display for Error {
                     new_path.display()
                 )
             }
-            Error::CreateDirAll {
-                parent_dir,
-                path,
-                source,
-            } => {
-                write!(
-                    f,
-                    "creating parent directory {} for path {}: {source}",
-                    parent_dir.display(),
-                    path.display(),
-                )
+            Error::CreateDirAll { path, source } => {
+                write!(f, "creating directory {}: {source}", path.display())
             }
             Error::WriteFile { path, source } => {
                 write!(f, "writing file {}: {source}", path.display())
@@ -128,22 +116,15 @@ impl Display for Error {
     }
 }
 
-#[derive(Debug, Parser)]
-struct Opts {
-    #[clap(short = 'd', long = "dir-diff")]
-    dir_diff: bool,
-    left: PathBuf,
-    right: PathBuf,
-    #[clap(short = 'N', long = "dry-run")]
-    dry_run: bool,
-}
+type Result<T> = std::result::Result<T, Error>;
 
-struct FileInfo {
+#[derive(Clone, Debug)]
+pub struct FileInfo {
     file_mode: FileMode,
     contents: FileContents,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum FileContents {
     Absent,
     Text {
@@ -157,263 +138,365 @@ enum FileContents {
     },
 }
 
-fn make_section_changed_lines(
-    contents: &str,
-    change_type: ChangeType,
-) -> Vec<SectionChangedLine<'static>> {
-    contents
-        .lines()
-        .map(|line| SectionChangedLine {
-            is_toggled: false,
-            change_type,
-            line: Cow::Owned(line.to_owned()),
-        })
-        .collect()
+#[allow(missing_docs)]
+pub trait Filesystem {
+    /// Find the set of files that appear in either `left` or `right`.
+    fn read_dir_diff_paths(&self, left: &Path, right: &Path) -> Result<BTreeSet<PathBuf>>;
+
+    fn read_file_info(&self, path: &Path) -> Result<FileInfo>;
+    fn write_file(&mut self, path: &Path, contents: &str) -> Result<()>;
+    fn copy_file(&mut self, old_path: &Path, new_path: &Path) -> Result<()>;
+    fn remove_file(&mut self, path: &Path) -> Result<()>;
+    fn create_dir_all(&mut self, path: &Path) -> Result<()>;
 }
 
-fn read_file_info(path: PathBuf) -> Result<FileInfo, Error> {
-    let file_mode = match fs::metadata(&path) {
-        Ok(metadata) => {
-            // TODO: no support for gitlinks (submodules).
-            if metadata.is_symlink() {
-                FileMode(0o120000)
-            } else {
-                let permissions = metadata.permissions();
-                #[cfg(unix)]
-                let executable = {
-                    use std::os::unix::fs::PermissionsExt;
-                    permissions.mode() & 0o001 == 0o001
-                };
-                #[cfg(not(unix))]
-                let executable = false;
-                if executable {
-                    FileMode(0o100755)
+struct RealFilesystem;
+
+impl Filesystem for RealFilesystem {
+    fn read_dir_diff_paths(&self, left: &Path, right: &Path) -> Result<BTreeSet<PathBuf>> {
+        fn walk_dir(dir: &Path) -> Result<BTreeSet<PathBuf>> {
+            let mut files = BTreeSet::new();
+            for entry in WalkDir::new(dir) {
+                let entry = entry.map_err(|err| Error::WalkDir { source: err })?;
+                if entry.file_type().is_file() || entry.file_type().is_symlink() {
+                    let relative_path = match entry.path().strip_prefix(dir) {
+                        Ok(path) => path.to_owned(),
+                        Err(err) => {
+                            return Err(Error::StripPrefix {
+                                root: dir.to_owned(),
+                                path: entry.path().to_owned(),
+                                source: err,
+                            })
+                        }
+                    };
+                    files.insert(relative_path);
+                }
+            }
+            Ok(files)
+        }
+        let left_files = walk_dir(left)?;
+        let right_files = walk_dir(right)?;
+        let paths = left_files
+            .into_iter()
+            .chain(right_files.into_iter())
+            .collect::<BTreeSet<_>>();
+        Ok(paths)
+    }
+
+    fn read_file_info(&self, path: &Path) -> Result<FileInfo> {
+        let file_mode = match fs::metadata(path) {
+            Ok(metadata) => {
+                // TODO: no support for gitlinks (submodules).
+                if metadata.is_symlink() {
+                    FileMode(0o120000)
                 } else {
-                    FileMode(0o100644)
+                    let permissions = metadata.permissions();
+                    #[cfg(unix)]
+                    let executable = {
+                        use std::os::unix::fs::PermissionsExt;
+                        permissions.mode() & 0o001 == 0o001
+                    };
+                    #[cfg(not(unix))]
+                    let executable = false;
+                    if executable {
+                        FileMode(0o100755)
+                    } else {
+                        FileMode(0o100644)
+                    }
                 }
             }
-        }
-        Err(err) if err.kind() == io::ErrorKind::NotFound => FileMode::absent(),
-        Err(err) => return Err(Error::ReadFile { path, source: err }),
-    };
-    let contents = match fs::read(&path) {
-        Ok(contents) => {
-            let hash = {
-                let mut hasher = sha1::Sha1::new();
-                hasher.update(&contents);
-                format!("{:x}", hasher.finalize())
-            };
-            let num_bytes: u64 = contents.len().try_into().unwrap();
-            if contents.contains(&0) {
-                FileContents::Binary { hash, num_bytes }
-            } else {
-                match String::from_utf8(contents) {
-                    Ok(contents) => FileContents::Text {
-                        contents,
-                        hash,
-                        num_bytes,
-                    },
-                    Err(_) => FileContents::Binary { hash, num_bytes },
+            Err(err) if err.kind() == io::ErrorKind::NotFound => FileMode::absent(),
+            Err(err) => {
+                return Err(Error::ReadFile {
+                    path: path.to_owned(),
+                    source: err,
+                })
+            }
+        };
+        let contents = match fs::read(path) {
+            Ok(contents) => {
+                let hash = {
+                    let mut hasher = sha1::Sha1::new();
+                    hasher.update(&contents);
+                    format!("{:x}", hasher.finalize())
+                };
+                let num_bytes: u64 = contents.len().try_into().unwrap();
+                if contents.contains(&0) {
+                    FileContents::Binary { hash, num_bytes }
+                } else {
+                    match String::from_utf8(contents) {
+                        Ok(contents) => FileContents::Text {
+                            contents,
+                            hash,
+                            num_bytes,
+                        },
+                        Err(_) => FileContents::Binary { hash, num_bytes },
+                    }
                 }
             }
-        }
-        Err(err) if err.kind() == io::ErrorKind::NotFound => FileContents::Absent,
-        Err(err) => return Err(Error::ReadFile { path, source: err }),
-    };
-    Ok(FileInfo {
-        file_mode,
-        contents,
-    })
-}
-
-fn create_file(
-    left_path: PathBuf,
-    left_display_path: PathBuf,
-    right_path: PathBuf,
-    right_display_path: PathBuf,
-) -> Result<File<'static>, Error> {
-    let FileInfo {
-        file_mode: left_file_mode,
-        contents: left_contents,
-    } = read_file_info(left_path)?;
-    let FileInfo {
-        file_mode: right_file_mode,
-        contents: right_contents,
-    } = read_file_info(right_path)?;
-    let mut sections = Vec::new();
-
-    if left_file_mode != right_file_mode
-        && left_file_mode != FileMode::absent()
-        && right_file_mode != FileMode::absent()
-    {
-        sections.push(Section::FileMode {
-            is_toggled: false,
-            before: left_file_mode,
-            after: right_file_mode,
-        });
+            Err(err) if err.kind() == io::ErrorKind::NotFound => FileContents::Absent,
+            Err(err) => {
+                return Err(Error::ReadFile {
+                    path: path.to_owned(),
+                    source: err,
+                })
+            }
+        };
+        Ok(FileInfo {
+            file_mode,
+            contents,
+        })
     }
 
-    match (left_contents, right_contents) {
-        (FileContents::Absent, FileContents::Absent) => {}
-        (
-            FileContents::Absent,
-            FileContents::Text {
-                contents,
-                hash: _,
-                num_bytes: _,
-            },
-        ) => sections.push(Section::Changed {
-            lines: make_section_changed_lines(&contents, ChangeType::Added),
-        }),
+    fn write_file(&mut self, path: &Path, contents: &str) -> Result<()> {
+        fs::write(path, contents).map_err(|err| Error::WriteFile {
+            path: path.to_owned(),
+            source: err,
+        })
+    }
 
-        (FileContents::Absent, FileContents::Binary { hash, num_bytes }) => {
-            sections.push(Section::Binary {
-                is_toggled: false,
-                old_description: None,
-                new_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
-            })
-        }
+    fn copy_file(&mut self, old_path: &Path, new_path: &Path) -> Result<()> {
+        fs::copy(old_path, new_path).map_err(|err| Error::CopyFile {
+            old_path: old_path.to_owned(),
+            new_path: new_path.to_owned(),
+            source: err,
+        })?;
+        Ok(())
+    }
 
-        (
-            FileContents::Text {
-                contents,
-                hash: _,
-                num_bytes: _,
-            },
-            FileContents::Absent,
-        ) => sections.push(Section::Changed {
-            lines: make_section_changed_lines(&contents, ChangeType::Removed),
-        }),
-
-        (
-            FileContents::Text {
-                contents: old_contents,
-                hash: _,
-                num_bytes: _,
-            },
-            FileContents::Text {
-                contents: new_contents,
-                hash: _,
-                num_bytes: _,
-            },
-        ) => {
-            sections.extend(create_diff(&old_contents, &new_contents));
-        }
-
-        (
-            FileContents::Text {
-                contents: _,
-                hash: old_hash,
-                num_bytes: old_num_bytes,
-            }
-            | FileContents::Binary {
-                hash: old_hash,
-                num_bytes: old_num_bytes,
-            },
-            FileContents::Text {
-                contents: _,
-                hash: new_hash,
-                num_bytes: new_num_bytes,
-            }
-            | FileContents::Binary {
-                hash: new_hash,
-                num_bytes: new_num_bytes,
-            },
-        ) => sections.push(Section::Binary {
-            is_toggled: false,
-            old_description: Some(Cow::Owned(make_binary_description(
-                &old_hash,
-                old_num_bytes,
-            ))),
-            new_description: Some(Cow::Owned(make_binary_description(
-                &new_hash,
-                new_num_bytes,
-            ))),
-        }),
-
-        (FileContents::Binary { hash, num_bytes }, FileContents::Absent) => {
-            sections.push(Section::Binary {
-                is_toggled: false,
-                old_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
-                new_description: None,
-            })
+    fn remove_file(&mut self, path: &Path) -> Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(Error::RemoveFile {
+                path: path.to_owned(),
+                source: err,
+            }),
         }
     }
 
-    Ok(File {
-        old_path: if left_display_path != right_display_path {
-            Some(Cow::Owned(left_display_path))
-        } else {
-            None
-        },
-        path: Cow::Owned(right_display_path),
-        file_mode: None, // TODO
-        sections,
-    })
+    fn create_dir_all(&mut self, path: &Path) -> Result<()> {
+        fs::create_dir_all(path).map_err(|err| Error::CreateDirAll {
+            path: path.to_owned(),
+            source: err,
+        })?;
+        Ok(())
+    }
 }
 
-fn create_diff(old_contents: &str, new_contents: &str) -> Vec<Section<'static>> {
-    let patch = {
-        // Set the context length to the maximum number of lines in either file,
-        // because we will handle abbreviating context ourselves.
-        let max_lines = old_contents
+mod render {
+    use std::borrow::Cow;
+    use std::path::PathBuf;
+
+    use scm_record::helpers::make_binary_description;
+    use scm_record::{ChangeType, File, FileMode, Section, SectionChangedLine};
+
+    use crate::{Error, FileContents, FileInfo, Filesystem};
+
+    fn make_section_changed_lines(
+        contents: &str,
+        change_type: ChangeType,
+    ) -> Vec<SectionChangedLine<'static>> {
+        contents
             .lines()
-            .count()
-            .max(new_contents.lines().count());
-        let mut diff_options = diffy::DiffOptions::new();
-        diff_options.set_context_len(max_lines);
-        diff_options.create_patch(old_contents, new_contents)
-    };
-
-    let mut sections = Vec::new();
-    for hunk in patch.hunks() {
-        sections.extend(hunk.lines().iter().fold(Vec::new(), |mut acc, line| {
-            match line {
-                diffy::Line::Context(line) => match acc.last_mut() {
-                    Some(Section::Unchanged { lines }) => {
-                        lines.push(Cow::Owned((*line).to_owned()));
-                    }
-                    _ => {
-                        acc.push(Section::Unchanged {
-                            lines: vec![Cow::Owned((*line).to_owned())],
-                        });
-                    }
-                },
-                diffy::Line::Delete(line) => {
-                    let line = SectionChangedLine {
-                        is_toggled: false,
-                        change_type: ChangeType::Removed,
-                        line: Cow::Owned((*line).to_owned()),
-                    };
-                    match acc.last_mut() {
-                        Some(Section::Changed { lines }) => {
-                            lines.push(line);
-                        }
-                        _ => {
-                            acc.push(Section::Changed { lines: vec![line] });
-                        }
-                    }
-                }
-                diffy::Line::Insert(line) => {
-                    let line = SectionChangedLine {
-                        is_toggled: false,
-                        change_type: ChangeType::Added,
-                        line: Cow::Owned((*line).to_owned()),
-                    };
-                    match acc.last_mut() {
-                        Some(Section::Changed { lines }) => {
-                            lines.push(line);
-                        }
-                        _ => {
-                            acc.push(Section::Changed { lines: vec![line] });
-                        }
-                    }
-                }
-            }
-            acc
-        }));
+            .map(|line| SectionChangedLine {
+                is_toggled: false,
+                change_type,
+                line: Cow::Owned(line.to_owned()),
+            })
+            .collect()
     }
-    sections
+
+    pub fn create_file(
+        filesystem: &dyn Filesystem,
+        left_path: PathBuf,
+        left_display_path: PathBuf,
+        right_path: PathBuf,
+        right_display_path: PathBuf,
+    ) -> Result<File<'static>, Error> {
+        let FileInfo {
+            file_mode: left_file_mode,
+            contents: left_contents,
+        } = filesystem.read_file_info(&left_path)?;
+        let FileInfo {
+            file_mode: right_file_mode,
+            contents: right_contents,
+        } = filesystem.read_file_info(&right_path)?;
+        let mut sections = Vec::new();
+
+        if left_file_mode != right_file_mode
+            && left_file_mode != FileMode::absent()
+            && right_file_mode != FileMode::absent()
+        {
+            sections.push(Section::FileMode {
+                is_toggled: false,
+                before: left_file_mode,
+                after: right_file_mode,
+            });
+        }
+
+        match (left_contents, right_contents) {
+            (FileContents::Absent, FileContents::Absent) => {}
+            (
+                FileContents::Absent,
+                FileContents::Text {
+                    contents,
+                    hash: _,
+                    num_bytes: _,
+                },
+            ) => sections.push(Section::Changed {
+                lines: make_section_changed_lines(&contents, ChangeType::Added),
+            }),
+
+            (FileContents::Absent, FileContents::Binary { hash, num_bytes }) => {
+                sections.push(Section::Binary {
+                    is_toggled: false,
+                    old_description: None,
+                    new_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
+                })
+            }
+
+            (
+                FileContents::Text {
+                    contents,
+                    hash: _,
+                    num_bytes: _,
+                },
+                FileContents::Absent,
+            ) => sections.push(Section::Changed {
+                lines: make_section_changed_lines(&contents, ChangeType::Removed),
+            }),
+
+            (
+                FileContents::Text {
+                    contents: old_contents,
+                    hash: _,
+                    num_bytes: _,
+                },
+                FileContents::Text {
+                    contents: new_contents,
+                    hash: _,
+                    num_bytes: _,
+                },
+            ) => {
+                sections.extend(create_diff(&old_contents, &new_contents));
+            }
+
+            (
+                FileContents::Text {
+                    contents: _,
+                    hash: old_hash,
+                    num_bytes: old_num_bytes,
+                }
+                | FileContents::Binary {
+                    hash: old_hash,
+                    num_bytes: old_num_bytes,
+                },
+                FileContents::Text {
+                    contents: _,
+                    hash: new_hash,
+                    num_bytes: new_num_bytes,
+                }
+                | FileContents::Binary {
+                    hash: new_hash,
+                    num_bytes: new_num_bytes,
+                },
+            ) => sections.push(Section::Binary {
+                is_toggled: false,
+                old_description: Some(Cow::Owned(make_binary_description(
+                    &old_hash,
+                    old_num_bytes,
+                ))),
+                new_description: Some(Cow::Owned(make_binary_description(
+                    &new_hash,
+                    new_num_bytes,
+                ))),
+            }),
+
+            (FileContents::Binary { hash, num_bytes }, FileContents::Absent) => {
+                sections.push(Section::Binary {
+                    is_toggled: false,
+                    old_description: Some(Cow::Owned(make_binary_description(&hash, num_bytes))),
+                    new_description: None,
+                })
+            }
+        }
+
+        Ok(File {
+            old_path: if left_display_path != right_display_path {
+                Some(Cow::Owned(left_display_path))
+            } else {
+                None
+            },
+            path: Cow::Owned(right_display_path),
+            file_mode: None, // TODO
+            sections,
+        })
+    }
+
+    fn create_diff(old_contents: &str, new_contents: &str) -> Vec<Section<'static>> {
+        let patch = {
+            // Set the context length to the maximum number of lines in either file,
+            // because we will handle abbreviating context ourselves.
+            let max_lines = old_contents
+                .lines()
+                .count()
+                .max(new_contents.lines().count());
+            let mut diff_options = diffy::DiffOptions::new();
+            diff_options.set_context_len(max_lines);
+            diff_options.create_patch(old_contents, new_contents)
+        };
+
+        let mut sections = Vec::new();
+        for hunk in patch.hunks() {
+            sections.extend(hunk.lines().iter().fold(Vec::new(), |mut acc, line| {
+                match line {
+                    diffy::Line::Context(line) => match acc.last_mut() {
+                        Some(Section::Unchanged { lines }) => {
+                            lines.push(Cow::Owned((*line).to_owned()));
+                        }
+                        _ => {
+                            acc.push(Section::Unchanged {
+                                lines: vec![Cow::Owned((*line).to_owned())],
+                            });
+                        }
+                    },
+                    diffy::Line::Delete(line) => {
+                        let line = SectionChangedLine {
+                            is_toggled: false,
+                            change_type: ChangeType::Removed,
+                            line: Cow::Owned((*line).to_owned()),
+                        };
+                        match acc.last_mut() {
+                            Some(Section::Changed { lines }) => {
+                                lines.push(line);
+                            }
+                            _ => {
+                                acc.push(Section::Changed { lines: vec![line] });
+                            }
+                        }
+                    }
+                    diffy::Line::Insert(line) => {
+                        let line = SectionChangedLine {
+                            is_toggled: false,
+                            change_type: ChangeType::Added,
+                            line: Cow::Owned((*line).to_owned()),
+                        };
+                        match acc.last_mut() {
+                            Some(Section::Changed { lines }) => {
+                                lines.push(line);
+                            }
+                            _ => {
+                                acc.push(Section::Changed { lines: vec![line] });
+                            }
+                        }
+                    }
+                }
+                acc
+            }));
+        }
+        sections
+    }
 }
 
 fn print_dry_run(write_root: &Path, state: RecordState) {
@@ -446,22 +529,19 @@ fn print_dry_run(write_root: &Path, state: RecordState) {
     }
 }
 
-fn apply_changes(write_root: &Path, state: RecordState) -> Result<(), Error> {
+fn apply_changes(
+    filesystem: &mut dyn Filesystem,
+    write_root: &Path,
+    state: RecordState,
+) -> Result<()> {
     let scm_record::RecordState { files } = state;
     for file in files {
         let file_path = write_root.join(file.path.clone());
         let (selected_contents, _unselected_contents) = file.get_selected_contents();
         match selected_contents {
-            scm_record::SelectedContents::Absent => match fs::remove_file(&file_path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-                Err(err) => {
-                    return Err(Error::RemoveFile {
-                        path: file_path,
-                        source: err,
-                    });
-                }
-            },
+            scm_record::SelectedContents::Absent => {
+                filesystem.remove_file(&file_path)?;
+            }
             scm_record::SelectedContents::Unchanged => {
                 // Do nothing.
             }
@@ -474,43 +554,31 @@ fn apply_changes(write_root: &Path, state: RecordState) -> Result<(), Error> {
                     Some(old_path) => old_path.clone(),
                     None => Cow::Borrowed(new_path.as_path()),
                 };
-                match fs::copy(&old_path, &new_path) {
-                    Ok(_bytes_written) => {}
-                    Err(err) => {
-                        return Err(Error::CopyFile {
-                            source: err,
-                            old_path: old_path.clone().into_owned(),
-                            new_path,
-                        });
-                    }
-                };
+                filesystem.copy_file(&old_path, &new_path)?;
             }
             scm_record::SelectedContents::Present { contents } => {
                 if let Some(parent_dir) = file_path.parent() {
-                    fs::create_dir_all(parent_dir).map_err(|err| Error::CreateDirAll {
-                        parent_dir: parent_dir.to_owned(),
-                        path: file_path.clone(),
-                        source: err,
-                    })?;
+                    filesystem.create_dir_all(parent_dir)?;
                 }
-                match fs::write(&file_path, contents) {
-                    Ok(()) => {}
-                    Err(err) => {
-                        return Err(Error::WriteFile {
-                            path: file_path,
-                            source: err,
-                        })
-                    }
-                }
+                filesystem.write_file(&file_path, &contents)?;
             }
         }
     }
     Ok(())
 }
 
-fn main_inner() -> Result<(), Error> {
-    let opts = Opts::parse();
-    let (files, write_root) = match opts {
+#[derive(Debug, Parser)]
+struct Opts {
+    #[clap(short = 'd', long = "dir-diff")]
+    dir_diff: bool,
+    left: PathBuf,
+    right: PathBuf,
+    #[clap(short = 'N', long = "dry-run")]
+    dry_run: bool,
+}
+
+fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<(Vec<File<'static>>, PathBuf)> {
+    let result = match opts {
         Opts {
             dir_diff: false,
             left,
@@ -521,7 +589,13 @@ fn main_inner() -> Result<(), Error> {
                 .parent()
                 .map(|path| path.to_owned())
                 .unwrap_or_default();
-            let files = vec![create_file(left.clone(), left, right.clone(), right)?];
+            let files = vec![render::create_file(
+                filesystem,
+                left.clone(),
+                left.clone(),
+                right.clone(),
+                right.clone(),
+            )?];
             (files, write_root)
         }
         Opts {
@@ -530,45 +604,27 @@ fn main_inner() -> Result<(), Error> {
             right,
             dry_run: _,
         } => {
-            fn walk_dir(dir: &Path) -> Result<BTreeMap<PathBuf, PathBuf>, Error> {
-                let mut files = BTreeMap::new();
-                for entry in WalkDir::new(dir) {
-                    let entry = entry.map_err(|err| Error::WalkDir { source: err })?;
-                    if entry.file_type().is_file() || entry.file_type().is_symlink() {
-                        let display_path = match entry.path().strip_prefix(dir) {
-                            Ok(path) => path.to_owned(),
-                            Err(err) => {
-                                return Err(Error::StripPrefix {
-                                    root: dir.to_owned(),
-                                    path: entry.path().to_owned(),
-                                    source: err,
-                                })
-                            }
-                        };
-                        files.insert(display_path, entry.path().to_owned());
-                    }
-                }
-                Ok(files)
-            }
-            let left_files = walk_dir(&left)?;
-            let right_files = walk_dir(&right)?;
-            let display_paths = left_files
-                .keys()
-                .chain(right_files.keys())
-                .collect::<BTreeSet<_>>();
+            let display_paths = filesystem.read_dir_diff_paths(left, right)?;
             let mut files = Vec::new();
             for display_path in display_paths {
-                files.push(create_file(
-                    left.join(display_path),
+                files.push(render::create_file(
+                    filesystem,
+                    left.join(&display_path),
                     display_path.clone(),
-                    right.join(display_path),
+                    right.join(&display_path),
                     display_path.clone(),
                 )?);
             }
-            (files, right)
+            (files, right.clone())
         }
     };
+    Ok(result)
+}
 
+fn main_inner() -> Result<()> {
+    let opts = Opts::parse();
+    let filesystem = RealFilesystem;
+    let (files, write_root) = process_opts(&filesystem, &opts)?;
     let state = scm_record::RecordState { files };
     let event_source = scm_record::EventSource::Crossterm;
     let recorder = scm_record::Recorder::new(state, event_source);
@@ -578,7 +634,8 @@ fn main_inner() -> Result<(), Error> {
                 print_dry_run(&write_root, state);
                 Err(Error::DryRun)
             } else {
-                apply_changes(&write_root, state)?;
+                let mut filesystem = filesystem;
+                apply_changes(&mut filesystem, &write_root, state)?;
                 Ok(())
             }
         }
@@ -594,5 +651,351 @@ fn main() {
             eprintln!("error: {err}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+    use maplit::btreemap;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestFilesystem {
+        files: BTreeMap<PathBuf, FileInfo>,
+        dirs: BTreeSet<PathBuf>,
+    }
+
+    impl TestFilesystem {
+        pub fn new(files: BTreeMap<PathBuf, FileInfo>) -> Self {
+            let dirs = files
+                .keys()
+                .flat_map(|path| path.ancestors().skip(1))
+                .map(|path| path.to_owned())
+                .collect();
+            Self { files, dirs }
+        }
+
+        fn assert_parent_dir_exists(&self, path: &Path) {
+            if let Some(parent_dir) = path.parent() {
+                assert!(
+                    self.dirs.contains(parent_dir),
+                    "parent dir for {path:?} does not exist"
+                );
+            }
+        }
+    }
+
+    impl Filesystem for TestFilesystem {
+        fn read_dir_diff_paths(&self, left: &Path, right: &Path) -> Result<BTreeSet<PathBuf>> {
+            Ok(self
+                .files
+                .keys()
+                .filter(|path| path.starts_with(left) || path.starts_with(right))
+                .cloned()
+                .collect())
+        }
+
+        fn read_file_info(&self, path: &Path) -> Result<FileInfo> {
+            match self.files.get(path) {
+                Some(file_info) => Ok(file_info.clone()),
+                None => Ok(FileInfo {
+                    file_mode: FileMode::absent(),
+                    contents: FileContents::Absent,
+                }),
+            }
+        }
+
+        fn write_file(&mut self, path: &Path, contents: &str) -> Result<()> {
+            self.assert_parent_dir_exists(path);
+            self.files.insert(path.to_owned(), file_info(contents));
+            Ok(())
+        }
+
+        fn copy_file(&mut self, old_path: &Path, new_path: &Path) -> Result<()> {
+            self.assert_parent_dir_exists(new_path);
+            let file_info = self.read_file_info(old_path)?;
+            self.files.insert(new_path.to_owned(), file_info);
+            Ok(())
+        }
+
+        fn remove_file(&mut self, path: &Path) -> Result<()> {
+            match self.files.remove(path) {
+                Some(_) => Ok(()),
+                None => {
+                    panic!("tried to remove non-existent file: {path:?}");
+                }
+            }
+        }
+
+        fn create_dir_all(&mut self, path: &Path) -> Result<()> {
+            self.dirs.insert(path.to_owned());
+            Ok(())
+        }
+    }
+
+    fn file_info(contents: impl Into<String>) -> FileInfo {
+        let contents = contents.into();
+        let num_bytes = contents.len().try_into().unwrap();
+        FileInfo {
+            file_mode: FileMode(0o100644),
+            contents: FileContents::Text {
+                contents,
+                hash: "abc123".to_string(),
+                num_bytes,
+            },
+        }
+    }
+
+    fn toggle_all(files: &mut [File]) {
+        for file in files {
+            for section in &mut file.sections {
+                match section {
+                    scm_record::Section::Unchanged { .. } => {}
+                    scm_record::Section::Changed { lines } => {
+                        for line in lines {
+                            line.is_toggled = true;
+                        }
+                    }
+                    scm_record::Section::FileMode { is_toggled, .. }
+                    | scm_record::Section::Binary { is_toggled, .. } => {
+                        *is_toggled = true;
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_diff() -> Result<()> {
+        let mut filesystem = TestFilesystem::new(btreemap! {
+            PathBuf::from("left") => file_info("\
+foo
+common1
+common2
+bar
+"),
+            PathBuf::from("right") => file_info("\
+qux1
+common1
+common2
+qux2
+"),
+        });
+        let (mut files, write_root) = process_opts(
+            &filesystem,
+            &Opts {
+                dir_diff: false,
+                left: PathBuf::from("left"),
+                right: PathBuf::from("right"),
+                dry_run: false,
+            },
+        )?;
+        assert_debug_snapshot!(files, @r###"
+        [
+            File {
+                old_path: Some(
+                    "left",
+                ),
+                path: "right",
+                file_mode: None,
+                sections: [
+                    Changed {
+                        lines: [
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Removed,
+                                line: "foo\n",
+                            },
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Added,
+                                line: "qux1\n",
+                            },
+                        ],
+                    },
+                    Unchanged {
+                        lines: [
+                            "common1\n",
+                            "common2\n",
+                        ],
+                    },
+                    Changed {
+                        lines: [
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Removed,
+                                line: "bar\n",
+                            },
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Added,
+                                line: "qux2\n",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        "###);
+
+        toggle_all(&mut files);
+        apply_changes(&mut filesystem, &write_root, RecordState { files })?;
+        insta::assert_debug_snapshot!(filesystem, @r###"
+        TestFilesystem {
+            files: {
+                "left": FileInfo {
+                    file_mode: FileMode(
+                        33188,
+                    ),
+                    contents: Text {
+                        contents: "foo\ncommon1\ncommon2\nbar\n",
+                        hash: "abc123",
+                        num_bytes: 24,
+                    },
+                },
+                "right": FileInfo {
+                    file_mode: FileMode(
+                        33188,
+                    ),
+                    contents: Text {
+                        contents: "qux1\ncommon1\ncommon2\nqux2\n",
+                        hash: "abc123",
+                        num_bytes: 26,
+                    },
+                },
+            },
+            dirs: {
+                "",
+            },
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_absent_left() -> Result<()> {
+        let mut filesystem = TestFilesystem::new(btreemap! {
+            PathBuf::from("right") => file_info("right\n"),
+        });
+        let (mut files, write_root) = process_opts(
+            &filesystem,
+            &Opts {
+                dir_diff: false,
+                left: PathBuf::from("left"),
+                right: PathBuf::from("right"),
+                dry_run: false,
+            },
+        )?;
+        assert_debug_snapshot!(files, @r###"
+        [
+            File {
+                old_path: Some(
+                    "left",
+                ),
+                path: "right",
+                file_mode: None,
+                sections: [
+                    Changed {
+                        lines: [
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Added,
+                                line: "right",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        "###);
+
+        toggle_all(&mut files);
+        apply_changes(&mut filesystem, &write_root, RecordState { files })?;
+        insta::assert_debug_snapshot!(filesystem, @r###"
+        TestFilesystem {
+            files: {
+                "right": FileInfo {
+                    file_mode: FileMode(
+                        33188,
+                    ),
+                    contents: Text {
+                        contents: "right",
+                        hash: "abc123",
+                        num_bytes: 5,
+                    },
+                },
+            },
+            dirs: {
+                "",
+            },
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_absent_right() -> Result<()> {
+        let mut filesystem = TestFilesystem::new(btreemap! {
+            PathBuf::from("left") => file_info("left\n"),
+        });
+        let (mut files, write_root) = process_opts(
+            &filesystem,
+            &Opts {
+                dir_diff: false,
+                left: PathBuf::from("left"),
+                right: PathBuf::from("right"),
+                dry_run: false,
+            },
+        )?;
+        assert_debug_snapshot!(files, @r###"
+        [
+            File {
+                old_path: Some(
+                    "left",
+                ),
+                path: "right",
+                file_mode: None,
+                sections: [
+                    Changed {
+                        lines: [
+                            SectionChangedLine {
+                                is_toggled: false,
+                                change_type: Removed,
+                                line: "left",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        "###);
+
+        toggle_all(&mut files);
+        apply_changes(&mut filesystem, &write_root, RecordState { files })?;
+        insta::assert_debug_snapshot!(filesystem, @r###"
+        TestFilesystem {
+            files: {
+                "left": FileInfo {
+                    file_mode: FileMode(
+                        33188,
+                    ),
+                    contents: Text {
+                        contents: "left\n",
+                        hash: "abc123",
+                        num_bytes: 5,
+                    },
+                },
+            },
+            dirs: {
+                "",
+            },
+        }
+        "###);
+
+        Ok(())
     }
 }

--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -120,7 +120,11 @@ impl TryFrom<FileMode> for i32 {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct File<'a> {
-    /// The path to the file.
+    /// The path to the previous version of the file, for display purposes. This
+    /// should be set if the file was renamed or copied from another file.
+    pub old_path: Option<Cow<'a, Path>>,
+
+    /// The path to the current version of the file, for display purposes.
     pub path: Cow<'a, Path>,
 
     /// The Unix file mode of the file (before any changes), if available. This
@@ -187,6 +191,7 @@ impl File<'_> {
     /// the `file_mode` value that this [`FileState`] was constructed with.
     pub fn get_file_mode(&self) -> Option<FileMode> {
         let Self {
+            old_path: _,
             path: _,
             file_mode,
             sections,
@@ -219,6 +224,7 @@ impl File<'_> {
         let mut acc_selected = SelectedContents::Unchanged;
         let mut acc_unselected = SelectedContents::Unchanged;
         let Self {
+            old_path: _,
             path: _,
             file_mode: _,
             sections,

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -584,6 +584,7 @@ impl<'a> Recorder<'a> {
                         is_focused,
                     },
                     is_header_selected: is_focused,
+                    old_path: file.old_path.as_deref(),
                     path: &file.path,
                     section_views: {
                         let mut section_views = Vec::new();
@@ -1452,6 +1453,7 @@ struct FileView<'a> {
     file_key: FileKey,
     tristate_box: TristateBox<ComponentId>,
     is_header_selected: bool,
+    old_path: Option<&'a Path>,
     path: &'a Path,
     section_views: Vec<SectionView<'a>>,
 }
@@ -1478,6 +1480,7 @@ impl Component for FileView<'_> {
             debug,
             file_key: _,
             tristate_box,
+            old_path,
             path,
             section_views,
             is_header_selected,
@@ -1489,7 +1492,14 @@ impl Component for FileView<'_> {
             x + tristate_box_rect.width.unwrap_isize() + 1,
             y,
             &Span::styled(
-                path.to_string_lossy(),
+                format!(
+                    "{}{}",
+                    match old_path {
+                        Some(old_path) => format!("{} => ", old_path.to_string_lossy()),
+                        None => String::new(),
+                    },
+                    path.to_string_lossy(),
+                ),
                 if *is_header_selected {
                     Style::default().fg(Color::Blue)
                 } else {
@@ -2065,6 +2075,7 @@ mod tests {
 
         let state = RecordState {
             files: vec![File {
+                old_path: None,
                 path: Cow::Borrowed(Path::new("foo/bar")),
                 file_mode: None,
                 sections: Default::default(),


### PR DESCRIPTION
This PR creates the `scm-diff-editor` binary, a TUI application for selecting subsets of changes in a diff. It can be used with `jj` as the `diff-editor` to facilitate commands like `jj move` and `jj split`.

To install the `scm-diff-editor` binary:

```sh
$ cargo install --git https://github.com/arxanas/git-branchless --branch scm-diff-editor scm-record --features scm-diff-editor
```

Then set the following in your `jjconfig.toml`:

```toml
[ui]
diff-editor = ["scm-diff-editor", "--dir-diff", "$left", "$right"]
```