### PR TITLE
feat(record:scm-diff-editor): add key "a" for toggling all selections

### DIFF
--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -348,6 +348,24 @@ impl Section<'_> {
             Section::Changed { .. } | Section::FileMode { .. } | Section::Binary { .. } => true,
         }
     }
+
+    /// Toggle the selection of this section.
+    pub fn toggle_all(&mut self) {
+        match self {
+            Section::Unchanged { .. } => {}
+            Section::Changed { lines } => {
+                for line in lines {
+                    line.is_toggled = !line.is_toggled;
+                }
+            }
+            Section::FileMode { is_toggled, .. } => {
+                *is_toggled = !*is_toggled;
+            }
+            Section::Binary { is_toggled, .. } => {
+                *is_toggled = !*is_toggled;
+            }
+        }
+    }
 }
 
 /// The type of change in the patch/diff.

--- a/scm-record/tests/test_scm_record.rs
+++ b/scm-record/tests/test_scm_record.rs
@@ -66,6 +66,71 @@ fn test_select_scroll_into_view() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_toggle_all() -> eyre::Result<()> {
+    let before = TestingScreenshot::default();
+    let after = TestingScreenshot::default();
+    let event_source = EventSource::testing(
+        80,
+        20,
+        [
+            before.event(),
+            Event::ToggleAll,
+            after.event(),
+            Event::QuitAccept,
+        ],
+    );
+    let state = example_contents();
+    let recorder = Recorder::new(state, event_source);
+    recorder.run()?;
+
+    insta::assert_display_snapshot!(before, @r###"
+    "(~) foo/bar                                                                     "
+    "        ⋮                                                                       "
+    "       18 this is some text                                                     "
+    "       19 this is some text                                                     "
+    "       20 this is some text                                                     "
+    "  [~] Section 1/1                                                               "
+    "    [×] - before text 1                                                         "
+    "    [×] - before text 2                                                         "
+    "    [×] + after text 1                                                          "
+    "    [ ] + after text 2                                                          "
+    "       23 this is some trailing text                                            "
+    "[×] baz                                                                         "
+    "        1 Some leading text 1                                                   "
+    "        2 Some leading text 2                                                   "
+    "  [×] Section 1/1                                                               "
+    "    [×] - before text 1                                                         "
+    "    [×] - before text 2                                                         "
+    "    [×] + after text 1                                                          "
+    "    [×] + after text 2                                                          "
+    "        5 this is some trailing text                                            "
+    "###);
+    insta::assert_display_snapshot!(after, @r###"
+    "(~) foo/bar                                                                     "
+    "        ⋮                                                                       "
+    "       18 this is some text                                                     "
+    "       19 this is some text                                                     "
+    "       20 this is some text                                                     "
+    "  [~] Section 1/1                                                               "
+    "    [ ] - before text 1                                                         "
+    "    [ ] - before text 2                                                         "
+    "    [ ] + after text 1                                                          "
+    "    [×] + after text 2                                                          "
+    "       23 this is some trailing text                                            "
+    "[ ] baz                                                                         "
+    "        1 Some leading text 1                                                   "
+    "        2 Some leading text 2                                                   "
+    "  [ ] Section 1/1                                                               "
+    "    [ ] - before text 1                                                         "
+    "    [ ] - before text 2                                                         "
+    "    [ ] + after text 1                                                          "
+    "    [ ] + after text 2                                                          "
+    "        5 this is some trailing text                                            "
+    "###);
+    Ok(())
+}
+
+#[test]
 fn test_quit_dialog_size() -> eyre::Result<()> {
     let expect_quit_dialog_to_be_centered = TestingScreenshot::default();
     let event_source = EventSource::testing(


### PR DESCRIPTION
This copies a feature from hg's record interface. It's most often useful before you do anything, to select all lines.