### PR TITLE
feat(hooks): Suppress warning for peeled refs while parsing packed-refs

### DIFF
--- a/git-branchless-hook/src/lib.rs
+++ b/git-branchless-hook/src/lib.rs
@@ -206,8 +206,12 @@ mod reference_transaction {
             // The leading `# pack-refs with:` pragma.
             return None;
         }
+        if line.starts_with('^') {
+            // A peeled ref
+            // FIXME actually support peeled refs in packed-refs
+            return None;
+        }
         if !line.starts_with(|c: char| c.is_ascii_hexdigit()) {
-            // The leading `# pack-refs with:` pragma.
             warn!(?line, "Unrecognized pack-refs line starting character");
             return None;
         }


### PR DESCRIPTION
As discussed on [discord](https://discord.com/channels/915309546984050709/915309546984050712/1108952258877599855), this suppresses the warnings generated when `branchless` encounters a peeled ref while parsing the `packed-refs` file. This does make any attempt to process these refs correctly, which -- as I understand it -- would be to associate there OIDs with the preceding "normal" ref. 