### PR TITLE
scm-record: fix build without `serde` feature

### DIFF
--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -42,6 +42,7 @@ pub enum RecordError {
     #[error("failed to read user input: {0}")]
     ReadInput(#[source] crossterm::ErrorKind),
 
+    #[cfg(feature = "serde")]
     #[error("failed to serialize JSON: {0}")]
     SerializeJson(#[source] serde_json::Error),
 


### PR DESCRIPTION
Closes #1053.