### PR TITLE
Fix release for new license files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           outdir="./target/${{ matrix.target }}/release"
           staging="git-branchless-${{ github.event.release.tag_name }}-${{ matrix.target }}"
           mkdir -p "$staging"
-          cp {README.md,LICENSE} "$staging/"
+          cp README.md LICENSE-{APACHE,MIT} "$staging/"
           if [ "${{ matrix.os }}" = "windows-2022" ]; then
             cp "target/${{ matrix.target }}/release/git-branchless.exe" "$staging/"
             cd "$staging"


### PR DESCRIPTION
The release script was trying to copy LICENSE, which no longer exists. Instead copy the new LICENSE-APACHE and LICENSE-MIT. I'm hopeful this will fix the issue mentioned in the v0.8.0 [release discussion](https://github.com/arxanas/git-branchless/discussions/1052#discussioncomment-6913309), shown [here in the GitHub Actions log](https://github.com/arxanas/git-branchless/actions/runs/6040012495/job/16389940594#step:6:19):
<img width="484" alt="image" src="https://github.com/arxanas/git-branchless/assets/614934/103c0825-012f-4926-b669-7489e6f6e88d">
