### PR TITLE
(#1088) post-rewrite hook does not track intermediate commits from an interactive rebase

### DIFF
--- a/git-branchless-hook/tests/test_hook.rs
+++ b/git-branchless-hook/tests/test_hook.rs
@@ -105,7 +105,6 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
             insta::assert_snapshot!(stdout, @"");
         }
 
-        git.commit_file("test4", 4)?;
         {
             let (stdout, stderr) = git.run(&["rebase", "--continue"])?;
             insta::assert_snapshot!(stderr, @r###"
@@ -133,8 +132,6 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
             O f777ecc (master) create initial.txt
             |\
             | o 047b7ad create test1.txt
-            | |
-            | o ecab41f create test4.txt
             |
             x 62fc20d (rewritten as 047b7ad7) create test1.txt
             |

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -498,14 +498,15 @@ then you can only run tests in the main `git-branchless` and \
     /// used to set the commit timestamp, which is factored into the commit
     /// hash. The filename is always appended to the message prefix.
     #[instrument]
-    pub fn commit_file_with_contents_and_message(
+    pub fn commit_file_with_contents_and_message_and_file_name(
         &self,
         name: &str,
         time: isize,
         contents: &str,
         message_prefix: &str,
+        file_name: &str,
     ) -> eyre::Result<NonZeroOid> {
-        let message = format!("{message_prefix} {name}.txt");
+        let message = format!("{message_prefix} {file_name}");
         self.write_file_txt(name, contents)?;
         self.run(&["add", "."])?;
         self.run_with_options(
@@ -522,6 +523,26 @@ then you can only run tests in the main `git-branchless` and \
             .oid
             .expect("Could not find OID for just-created commit");
         Ok(oid)
+    }
+
+    /// Commit a file with given contents and message. The `time` argument is
+    /// used to set the commit timestamp, which is factored into the commit
+    /// hash. The filename is always appended to the message prefix.
+    #[instrument]
+    pub fn commit_file_with_contents_and_message(
+        &self,
+        name: &str,
+        time: isize,
+        contents: &str,
+        message_prefix: &str,
+    ) -> eyre::Result<NonZeroOid> {
+        self.commit_file_with_contents_and_message_and_file_name(
+            name,
+            time,
+            contents,
+            message_prefix,
+            format!("{name}.txt").as_str(),
+        )
     }
 
     /// Commit a file with given contents and a default message. The `time`
@@ -878,6 +899,18 @@ pub mod pty {
         args: &[&str],
         inputs: &[PtyAction],
     ) -> eyre::Result<ExitStatus> {
+        // add "branchless" to subcommand list
+        run_in_pty_with_command(git, &["branchless", branchless_subcommand], args, inputs)
+    }
+
+    /// Run the provided script in the context of a virtual terminal.
+    #[track_caller]
+    pub fn run_in_pty_with_command(
+        git: &Git,
+        command: &[&str],
+        args: &[&str],
+        inputs: &[PtyAction],
+    ) -> eyre::Result<ExitStatus> {
         // Use the native pty implementation for the system
         let pty_system = native_pty_system();
         let pty_size = PtySize::default();
@@ -896,8 +929,7 @@ pub mod pty {
             cmd.env(k, v);
         }
         cmd.env("TERM", "xterm");
-        cmd.arg("branchless");
-        cmd.arg(branchless_subcommand);
+        cmd.args(command);
         cmd.args(args);
         cmd.cwd(&git.repo_path);
 

--- a/git-branchless/tests/test_hooks.rs
+++ b/git-branchless/tests/test_hooks.rs
@@ -5,8 +5,11 @@ use lib::core::eventlog::{Event, EventLogDb, EventReplayer};
 use lib::core::formatting::Glyphs;
 use lib::git::GitVersion;
 use lib::testing::make_git;
+use lib::testing::pty::{run_in_pty_with_command, PtyAction};
 use lib::util::get_sh;
 use std::process::Command;
+
+const CARRIAGE_RETURN: &str = "\r";
 
 #[test]
 fn test_abandoned_commit_message() -> eyre::Result<()> {
@@ -380,6 +383,57 @@ fn test_git_am_recorded() -> eyre::Result<()> {
         | o 047b7ad create test1.txt
         |
         o 62fc20d create test1.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_git_rebase_multiple_fixup_does_not_strand_commits() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+
+    git.detach_head()?;
+    git.commit_file_with_contents_and_message_and_file_name(
+        "test1",
+        1,
+        "bleh",
+        "create",
+        "test1.txt",
+    )?;
+    git.commit_file_with_contents_and_message_and_file_name(
+        "test2",
+        2,
+        "bleh",
+        "fixup! create",
+        "test1.txt",
+    )?;
+    git.commit_file_with_contents_and_message_and_file_name(
+        "test3",
+        3,
+        "bleh",
+        "fixup! create",
+        "test1.txt",
+    )?;
+
+    run_in_pty_with_command(
+        &git,
+        &["rebase"],
+        &["-i", "--autosquash", "master"],
+        &[
+            PtyAction::WaitUntilContains(" "),
+            PtyAction::Write(CARRIAGE_RETURN),
+        ],
+    )?;
+
+    {
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 916a41f create test1.txt
         "###);
     }
 


### PR DESCRIPTION
Fixes #1088 

I was able to repro the issue from #1088. It seems that we are tracking the intermediate commits created by a rebase and adding them to the events db during the post rewrite hook. I noticed that this code was added to prevent aborted rebases from adding intermediate commits, but the test written for that still passes. Looking for feedback on the approach from @arxanas regarding omitting deferred commits from the event log during the post-rewrite hook.