### PR TITLE
feat(submit): add --dry-run flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- (#1129) Added a `--dry-run` option to `git submit` to report what would be submitted without actually doing so.
+
 ## [v0.8.0] - 2023-08-27
 
 ### Added

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -396,6 +396,11 @@ pub struct SubmitArgs {
     /// An optional message to include with the create or update operation.
     #[clap(short = 'm', long = "message")]
     pub message: Option<String>,
+
+    /// Don't push or create anything. Instead, report what would be pushed or
+    /// created. (Still triggers a fetch.)
+    #[clap(short = 'n', long = "dry-run")]
+    pub dry_run: bool,
 }
 
 /// Run a command on each commit in a given set and aggregate the results.

--- a/git-branchless-submit/tests/test_submit.rs
+++ b/git-branchless-submit/tests/test_submit.rs
@@ -65,6 +65,24 @@ fn test_submit() -> eyre::Result<()> {
     }
 
     {
+        let (stdout, stderr) = cloned_repo.run(&["submit", "--dry-run"])?;
+        insta::assert_snapshot!(stderr, @"");
+        insta::assert_snapshot!(stdout, @r###"
+        Would skip 2 branches (not yet on remote): bar, qux
+        These branches would be skipped because they are not already associated with a remote repository. To
+        create and push them, retry this operation with the --create option.
+        "###);
+    }
+
+    {
+        let (stdout, stderr) = cloned_repo.run(&["submit", "--create", "--dry-run"])?;
+        insta::assert_snapshot!(stderr, @"");
+        insta::assert_snapshot!(stdout, @r###"
+        Would create 2 branches: bar, qux
+        "###);
+    }
+
+    {
         let (stdout, stderr) = cloned_repo.run(&["submit", "--create"])?;
         let stderr = redact_remotes(stderr);
         insta::assert_snapshot!(stderr, @r###"


### PR DESCRIPTION
`submit` is inherently side effecting in non-obvious-to-undo ways. This is a rudimentary attempt to add a `--dry-run` flag to see what `submit` would be trying to do.