### PR TITLE
feat(revsets): add `merges()` and allow `branches()` to filter branch names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (#1129) Added a `--dry-run` option to `git submit` to report what would be submitted without actually doing so.
+- (#1130) Added `merges()` revset function.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING (#1128) Arguments/revsets passed to `git sync` are now resolved to their respective stacks.
   - This allows `git sync my-branch` to work as expected, instead of needing to use `git sync 'stack(my-branch)'`. The behavior of `git sync` when called without arguments is not affected by this change. If you rely on the previous behavior, please use `git move -x <commit(s)/revset> -d 'main()'` instead.
 - (#1169) `git record` now accepts multible `--message` arguments.
+- (#1130) `branches()` revset function now accepts an optional text pattern argument to limit which branches are matched.
 
 ### Fixed
 

--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -92,7 +92,7 @@ fn maybe_get_branch_name(
                 Ok(branch_name) => {
                     // To remove the `refs/heads/` prefix
                     let name = CategorizedReferenceName::new(branch_name);
-                    Ok(Some(name.remove_prefix()?))
+                    Ok(Some(name.render_suffix()))
                 }
                 Err(_) => Ok(current_target),
             },
@@ -124,7 +124,7 @@ pub fn check_out_commit(
         None => (None, None),
         Some(CheckoutTarget::Reference(reference_name)) => {
             let categorized_target = CategorizedReferenceName::new(&reference_name);
-            (Some(categorized_target.remove_prefix()?), None)
+            (Some(categorized_target.render_suffix()), None)
         }
         Some(CheckoutTarget::Oid(oid)) => (Some(oid.to_string()), Some(oid)),
         Some(CheckoutTarget::Unknown(target)) => (Some(target), None),

--- a/git-branchless-lib/src/core/repo_ext.rs
+++ b/git-branchless-lib/src/core/repo_ext.rs
@@ -130,7 +130,7 @@ https://github.com/arxanas/git-branchless/discussions/595 for more details.",
         match CategorizedReferenceName::new(&main_branch_name) {
             name @ CategorizedReferenceName::LocalBranch { .. } => {
                 if let Some(main_branch) =
-                    self.find_branch(&name.remove_prefix()?, BranchType::Local)?
+                    self.find_branch(&name.render_suffix(), BranchType::Local)?
                 {
                     if let Some(remote_name) = main_branch.get_push_remote_name()? {
                         return Ok(Some(remote_name));
@@ -139,7 +139,7 @@ https://github.com/arxanas/git-branchless/discussions/595 for more details.",
             }
 
             name @ CategorizedReferenceName::RemoteBranch { .. } => {
-                let name = name.remove_prefix()?;
+                let name = name.render_suffix();
                 if let Some((remote_name, _reference_name)) = name.split_once('/') {
                     return Ok(Some(remote_name.to_owned()));
                 }

--- a/git-branchless-lib/src/core/rewrite/execute.rs
+++ b/git-branchless-lib/src/core/rewrite/execute.rs
@@ -118,7 +118,7 @@ pub fn move_branches<'a>(
                                 warn!(?reference_name, "Not deleting non-local-branch reference");
                             }
                             CategorizedReferenceName::LocalBranch { .. } => {
-                                let branch_name = branch_name.remove_prefix()?;
+                                let branch_name = branch_name.render_suffix();
                                 match repo.find_branch(&branch_name, BranchType::Local) {
                                     Ok(Some(mut branch)) => {
                                         if let Err(err) = branch.delete() {

--- a/git-branchless-lib/src/git/reference.rs
+++ b/git-branchless-lib/src/git/reference.rs
@@ -183,18 +183,6 @@ impl<'a> CategorizedReferenceName<'a> {
         }
     }
 
-    /// Remove the prefix from the reference name. May raise an error if the
-    /// result couldn't be encoded as an `String` (shouldn't happen).
-    #[instrument]
-    pub fn remove_prefix(&self) -> Result<String> {
-        let (name, prefix): (_, &'static str) = match self {
-            Self::LocalBranch { name, prefix } => (name, prefix),
-            Self::RemoteBranch { name, prefix } => (name, prefix),
-            Self::OtherRef { name } => (name, ""),
-        };
-        Ok(name.strip_prefix(prefix).unwrap_or(name).to_owned())
-    }
-
     /// Render the full name of the reference, including its prefix, lossily as
     /// a `String`.
     pub fn render_full(&self) -> String {

--- a/git-branchless-query/tests/test_query.rs
+++ b/git-branchless-query/tests/test_query.rs
@@ -87,7 +87,7 @@ fn test_query_eval_error() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @r###"
-        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, current, descendants, difference, draft, exactly, heads, intersection, main, message, none, not, only, parents, parents.nth, paths.changed, public, range, roots, siblings, stack, tests.failed, tests.fixable, tests.passed, union
+        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, current, descendants, difference, draft, exactly, heads, intersection, main, merges, message, none, not, only, parents, parents.nth, paths.changed, public, range, roots, siblings, stack, tests.failed, tests.fixable, tests.passed, union
         "###);
         insta::assert_snapshot!(stdout, @"");
     }

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -188,8 +188,7 @@ fn record(
                     ],
                 )?),
                 [parent_commit] => {
-                    let branch_name =
-                        CategorizedReferenceName::new(reference_name).remove_prefix()?;
+                    let branch_name = CategorizedReferenceName::new(reference_name).render_suffix();
                     repo.detach_head(&head_info)?;
                     try_exit_code!(git_run_info.run(
                         effects,

--- a/git-branchless-revset/src/builtins.rs
+++ b/git-branchless-revset/src/builtins.rs
@@ -61,6 +61,7 @@ lazy_static! {
             ("committer.date", &fn_committer_date),
             ("exactly", &fn_exactly),
             ("current", &fn_current),
+            ("merges", &fn_merges),
             ("tests.passed", &fn_tests_passed),
             ("tests.failed", &fn_tests_failed),
             ("tests.fixable", &fn_tests_fixable),
@@ -511,6 +512,19 @@ fn fn_current(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
         }
     }
     Ok(result.into_iter().collect::<CommitSet>())
+}
+
+#[instrument]
+fn fn_merges(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
+    eval0(ctx, name, args)?;
+    // Use a "pattern matcher" that – instead of testing for a pattern –
+    // examines the parent count of each commit to find merges.
+    make_pattern_matcher(
+        ctx,
+        name,
+        args,
+        Box::new(move |_repo, commit| Ok(commit.get_parent_count() > 1)),
+    )
 }
 
 fn read_all_test_results(repo: &Repo, commit: &Commit) -> Option<Vec<SerializedTestResult>> {

--- a/git-branchless-submit/src/branch_forge.rs
+++ b/git-branchless-submit/src/branch_forge.rs
@@ -57,7 +57,7 @@ impl Forge for BranchForge<'_> {
             let mut branch_infos = HashMap::new();
             for branch_reference_name in branch_reference_names {
                 let branch_name = match CategorizedReferenceName::new(&branch_reference_name) {
-                    name @ CategorizedReferenceName::LocalBranch { .. } => name.remove_prefix()?,
+                    name @ CategorizedReferenceName::LocalBranch { .. } => name.render_suffix(),
                     CategorizedReferenceName::RemoteBranch { .. }
                     | CategorizedReferenceName::OtherRef { .. } => continue,
                 };

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -754,7 +754,7 @@ fn extract_checkout_target(
                         additional_args: match ref_name {
                             Some(ref_name) => {
                                 let branch_name = CategorizedReferenceName::new(ref_name);
-                                vec!["-B".into(), branch_name.remove_prefix()?.into()]
+                                vec!["-B".into(), branch_name.render_suffix().into()]
                             }
                             None => Default::default(),
                         },


### PR DESCRIPTION
- I have found `merges()` to be useful, in particular on public commits.
- for `branches(<pattern>)` see #1117
- ~~`branches(<pattern>)` needs more work; it's currently mush slower that I would expect, and it seems to not match some branchs (at least it didn't match all the branches I expected when I used it to push these recent PRs)~~ **Edit:** I believe that this is fixed.