### PR TITLE
[3/3] feat(bisect): lift the binary search's speculation to `Search`

### DIFF
--- a/scm-bisect/proptest-regressions/basic.txt
+++ b/scm-bisect/proptest-regressions/basic.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5a4ffdf1267e9ca2dc25020bfaf35f8de38978291725aa4c7451dcde0868e8b8 # shrinks to strategy = Linear, (graph, failure_nodes) = (TestGraph { nodes: {'a': {}} }, [])


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1176
* https://github.com/arxanas/git-branchless/pull/1177
* https://github.com/arxanas/git-branchless/pull/1162


---

feat(bisect): lift the binary search's speculation to `Search`

Previously, `midpoint` returned an iterator of next nodes to search, which is meant to support speculative searching. This was implemented only for the basic binary search. It could be tedious and error-prone to implement speculation by one's self, so it would be preferable if the library could do it instead. This commit lifts the speculation out of the binary search and into `Search`.

Now, `midpoint` returns a single next node to search, which is substantially easier for implementors (for example, the implementation of binary search is now simply picking and returning the midpoint node).

This commit fixes an arguable bug in the binary search implementation, where it didn't *quite* go in breadth-first order, and also incidentally implements breadth-first ordering for the linear search (assuming that the input nodes are originally given in topological order).

