### PR TITLE
[1/16] feat(record): use commit message template in inline message editor

### DIFF
--- a/git-branchless-reword/src/lib.rs
+++ b/git-branchless-reword/src/lib.rs
@@ -66,6 +66,10 @@ pub fn edit_message(git_run_info: &GitRunInfo, repo: &Repo, message: &str) -> ey
         Some(editor_program) => (editor.executable(&editor_program), editor_program),
         None => (&mut editor, "<default>".into()),
     };
+    if editor_program == ":" {
+        // Special case in Git: treat `:` as a no-op editor.
+        return Ok(message.to_string());
+    }
     let result = editor
         .require_save(false)
         .edit(message)


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1167
* https://github.com/arxanas/git-branchless/pull/1171
* https://github.com/arxanas/git-branchless/pull/1173
* https://github.com/arxanas/git-branchless/pull/1172
* [5/16] refactor(dag): extract `query_stack_commits` to `Dag`
* [6/16] feat(git): export `GitErrorCode` from `repo`
* [7/16] feat(submit): create `SubmitStatus::Local`
* [8/16] feat(submit): make forges branch-agnostic
* [9/16] feat(git): add `Branch::rename` method
* [10/16] testing: configure repos cloned with `Git::clone_repo_into`
* [11/16] wip: some `GithubForge` implementation
* [12/16] wip: more Github forge
* [13/16] wip: update `commit_summary_slug`
* [14/16] feat(submit:github): auto-select Github forge when `gh repo set-default` has been used
* [15/16] wip: fix select Github forge
* [16/16] wip: more Github forge test


---

feat(record): use commit message template in inline message editor

Note that after this commit, the commit message template is only rendered if the user opens the message editor at least once. Otherwise the message is implicitly kept empty and it's up to the subsequent `git commit` to prompt for a message (whose behavior might change, as we probably don't want to use `git commit` in the long-term?).

