### PR TITLE
feat(record): allow multiple --message args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING (#1128) Arguments/revsets passed to `git sync` are now resolved to their respective stacks.
   - This allows `git sync my-branch` to work as expected, instead of needing to use `git sync 'stack(my-branch)'`. The behavior of `git sync` when called without arguments is not affected by this change. If you rely on the previous behavior, please use `git move -x <commit(s)/revset> -d 'main()'` instead.
+- (#1169) `git record` now accepts multible `--message` arguments.
 
 ### Fixed
 

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -129,6 +129,25 @@ impl Git {
             })
             .into_owned();
 
+        lazy_static! {
+            // Convert non-empty, blank lines to empty, blank lines to make the
+            // command output easier to use in snapshot assertions.
+            //
+            // Some git output includes lines made up of only whitespace, which
+            // is hard to work with as inline snapshots because editors often
+            // trim such trailing whitespace automatically. In particular,
+            // `git show` prints 4 spaces instead of just an empty line for the
+            // lines between commit message paragraphs. (ie "    \n" instead of
+            // just "\n".)
+            //
+            // This regex targets the output of `git show`, but it could be
+            // generalized in the future if other cases come up.
+            static ref WHITESPACE_ONLY_LINE_RE: Regex = Regex::new(r"(?m)^ {4}$").unwrap();
+        }
+        let output = WHITESPACE_ONLY_LINE_RE
+            .replace_all(&output, "")
+            .into_owned();
+
         Ok(output)
     }
 

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -300,7 +300,7 @@ pub struct RecordArgs {
     /// The commit message to use. If not provided, will be prompted to provide a commit message
     /// interactively.
     #[clap(value_parser, short = 'm', long = "message")]
-    pub message: Option<String>,
+    pub messages: Vec<String>,
 
     /// Select changes to include interactively, rather than using the
     /// current staged/unstaged changes.

--- a/git-branchless-record/tests/test_record.rs
+++ b/git-branchless-record/tests/test_record.rs
@@ -13,9 +13,9 @@ fn test_record_unstaged_changes() -> eyre::Result<()> {
     git.commit_file("test1", 1)?;
     git.write_file_txt("test1", "contents1\n")?;
     {
-        let (stdout, _stderr) = git.branchless("record", &["-m", "foo"])?;
+        let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "-m", "bar"])?;
         insta::assert_snapshot!(stdout, @r###"
-        [master 914812a] foo
+        [master 872eae1] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
         "###);
     }
@@ -23,11 +23,13 @@ fn test_record_unstaged_changes() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["show"])?;
         insta::assert_snapshot!(stdout, @r###"
-        commit 914812ae3220add483f11d851dc59f0b5dbdeaa0
+        commit 872eae10daf1e94d0c346540f6d655027c60e7ae
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
 
             foo
+
+            bar
 
         diff --git a/test1.txt b/test1.txt
         index 7432a8f..a024003 100644


### PR DESCRIPTION
This is a minor QOL improvement, and should bring `record` in line with how `commit` and `reword` accept multiple `-m/--message` args, turning them into multiple paragraphs in the commit message.