### PR TITLE
[1/1] cleanup: fix `cargo clippy`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,4 +47,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features --all-targets -- -D warnings
+          # Allow `--allow renamed_and_removed_lints` because the new lint name
+          # may not be available in our oldest-supported Rust version.
+          args: --workspace --all-features --all-targets -- --deny warnings --allow renamed_and_removed_lints

--- a/git-branchless-lib/src/core/effects.rs
+++ b/git-branchless-lib/src/core/effects.rs
@@ -762,7 +762,7 @@ trait WriteProgress {
         // `ProgressBar` is included in a `MultiProgress`, it doesn't matter
         // which of them we call `println` on. The output will be printed above
         // the `MultiProgress` regardless.
-        let operation = root_operation.children.get(0);
+        let operation = root_operation.children.first();
         match operation {
             None => {
                 // There's no progress meters, so we can write directly to

--- a/git-branchless-lib/src/git/index.rs
+++ b/git-branchless-lib/src/git/index.rs
@@ -84,7 +84,7 @@ impl Index {
                     // `libgit2` uses u32 for file modes in index entries, but
                     // i32 for file modes in tree entries for some reason.
                     let mode = i32::try_from(entry.mode).unwrap();
-                    FileMode::try_from(mode).unwrap()
+                    FileMode::from(mode)
                 },
             })
     }

--- a/git-branchless-lib/tests/test_eventlog.rs
+++ b/git-branchless-lib/tests/test_eventlog.rs
@@ -92,7 +92,7 @@ fn test_different_event_transaction_ids() -> eyre::Result<()> {
 fn test_advance_cursor_by_transaction() -> eyre::Result<()> {
     let mut event_replayer = new_event_replayer("refs/heads/master".into());
     for (timestamp, event_tx_id) in (0..).zip(&[1, 1, 2, 2, 3, 4]) {
-        let timestamp: f64 = timestamp.try_into()?;
+        let timestamp = f64::from(timestamp);
         event_replayer.process_event(&Event::UnobsoleteEvent {
             timestamp,
             event_tx_id: new_event_transaction_id(*event_tx_id),

--- a/scm-record/src/util.rs
+++ b/scm-record/src/util.rs
@@ -9,7 +9,7 @@ impl UsizeExt for usize {
     }
 
     fn clamp_into_u16(self) -> u16 {
-        if self > u16::MAX.try_into().unwrap() {
+        if self > usize::from(u16::MAX) {
             u16::MAX
         } else {
             self.try_into().unwrap()


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1170


---

cleanup: fix `cargo clippy`

