### PR TITLE
[1/5] refactor(bisect): rename `search::SearchGraph` -> `search::Graph`

### DIFF
--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -1164,7 +1164,7 @@ struct SearchGraph<'a> {
     commit_set: CommitSet,
 }
 
-impl<'a> search::SearchGraph for SearchGraph<'a> {
+impl<'a> search::Graph for SearchGraph<'a> {
     type Node = NonZeroOid;
     type Error = SearchGraphError;
 

--- a/scm-bisect/src/search.rs
+++ b/scm-bisect/src/search.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tracing::instrument;
 
 /// The set of nodes compromising a directed acyclic graph to be searched.
-pub trait SearchGraph: Debug {
+pub trait Graph: Debug {
     /// The type of nodes in the graph. This should be cheap to clone.
     type Node: Clone + Debug + Hash + Eq;
 
@@ -272,16 +272,16 @@ pub enum Error2<Node, Error> {
 }
 
 /// The error type for the search.
-pub type Error<G> = Error2<<G as SearchGraph>::Node, <G as SearchGraph>::Error>;
+pub type Error<G> = Error2<<G as Graph>::Node, <G as Graph>::Error>;
 
 /// The search algorithm.
 #[derive(Clone, Debug)]
-pub struct Search<G: SearchGraph> {
+pub struct Search<G: Graph> {
     graph: G,
     nodes: IndexMap<G::Node, Status>,
 }
 
-impl<G: SearchGraph> Search<G> {
+impl<G: Graph> Search<G> {
     /// Construct a new search.
     pub fn new(graph: G, nodes: impl IntoIterator<Item = G::Node>) -> Self {
         let nodes = nodes
@@ -451,7 +451,7 @@ mod tests {
         max: usize,
     }
 
-    impl SearchGraph for UsizeGraph {
+    impl Graph for UsizeGraph {
         type Node = usize;
         type Error = Infallible;
 
@@ -602,7 +602,7 @@ mod tests {
         nodes: HashMap<char, HashSet<char>>,
     }
 
-    impl SearchGraph for TestGraph {
+    impl Graph for TestGraph {
         type Node = char;
         type Error = Infallible;
 


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1174
* https://github.com/arxanas/git-branchless/pull/1175
* https://github.com/arxanas/git-branchless/pull/1176
* https://github.com/arxanas/git-branchless/pull/1177
* https://github.com/arxanas/git-branchless/pull/1162


---

refactor(bisect): rename `search::SearchGraph` -> `search::Graph`

For uniformity with the other symbols in this module (`Strategy` etc.).

