### PR TITLE
[2/15] refactor(bisect): pass `Bounds` to `Strategy::midpoint`

### DIFF
--- a/scm-bisect/examples/guessing_game.rs
+++ b/scm-bisect/examples/guessing_game.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::io;
 use std::ops::RangeInclusive;
@@ -38,10 +37,13 @@ impl search::Strategy<Graph> for Strategy {
     fn midpoint(
         &self,
         _graph: &Graph,
-        success_bounds: &HashSet<Node>,
-        failure_bounds: &HashSet<Node>,
+        bounds: &search::Bounds<Node>,
         _statuses: &IndexMap<Node, search::Status>,
     ) -> Result<Option<Node>, Self::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let lower_bound = success_bounds
             .iter()
             .max()

--- a/scm-bisect/src/basic.rs
+++ b/scm-bisect/src/basic.rs
@@ -198,10 +198,13 @@ impl<G: BasicSourceControlGraph> search::Strategy<G> for BasicStrategy {
     fn midpoint(
         &self,
         graph: &G,
-        success_bounds: &HashSet<G::Node>,
-        failure_bounds: &HashSet<G::Node>,
+        bounds: &search::Bounds<G::Node>,
         statuses: &IndexMap<G::Node, search::Status>,
     ) -> Result<Option<G::Node>, G::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let mut nodes_to_search = {
             let implied_success_nodes = graph.ancestors_all(success_bounds.clone())?;
             let implied_failure_nodes = graph.descendants_all(failure_bounds.clone())?;


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1220
* https://github.com/arxanas/git-branchless/pull/1221
* https://github.com/arxanas/git-branchless/pull/1222
* https://github.com/arxanas/git-branchless/pull/1223
* https://github.com/arxanas/git-branchless/pull/1224
* https://github.com/arxanas/git-branchless/pull/1225
* https://github.com/arxanas/git-branchless/pull/1226
* https://github.com/arxanas/git-branchless/pull/1227
* https://github.com/arxanas/git-branchless/pull/1228
* https://github.com/arxanas/git-branchless/pull/1229
* https://github.com/arxanas/git-branchless/pull/1184
* https://github.com/arxanas/git-branchless/pull/1230
* https://github.com/arxanas/git-branchless/pull/1231
* https://github.com/arxanas/git-branchless/pull/1232
* https://github.com/arxanas/git-branchless/pull/1233


---

refactor(bisect): pass `Bounds` to `Strategy::midpoint`

I forgot that we have a container type for the success+failure bounds, so use that here.

