### PR TITLE
[4/15] feat(git): export `GitErrorCode` from `repo`

### DIFF
--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -23,8 +23,8 @@ pub use reference::{
 };
 pub use repo::{
     message_prettify, AmendFastOptions, CherryPickFastOptions, CreateCommitFastError,
-    Error as RepoError, GitVersion, PatchId, Repo, ResolvedReferenceInfo, Result as RepoResult,
-    Time,
+    Error as RepoError, GitErrorCode, GitVersion, PatchId, Repo, ResolvedReferenceInfo,
+    Result as RepoResult, Time,
 };
 pub use run::{GitRunInfo, GitRunOpts, GitRunResult};
 pub use snapshot::{WorkingCopyChangesType, WorkingCopySnapshot};

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -277,6 +277,8 @@ pub enum Error {
 /// Result type.
 pub type Result<T> = std::result::Result<T, Error>;
 
+pub use git2::ErrorCode as GitErrorCode;
+
 /// Convert a `git2::Error` into an `eyre::Error` with an auto-generated message.
 pub(super) fn wrap_git_error(error: git2::Error) -> eyre::Error {
     eyre::eyre!("Git error {:?}: {}", error.code(), error.message())

--- a/git-branchless-revset/src/builtins.rs
+++ b/git-branchless-revset/src/builtins.rs
@@ -290,28 +290,9 @@ fn fn_draft(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
 #[instrument]
 fn fn_stack(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
     let arg = eval0_or_1(ctx, name, args)?.unwrap_or_else(|| ctx.dag.head_commit.clone());
-    let draft_commits = ctx
-        .dag
-        .query_draft_commits()
-        .map_err(EvalError::OtherError)?;
-    let stack_roots = ctx.dag.query_roots(draft_commits.clone())?;
-    let stack_ancestors = ctx.dag.query_range(stack_roots, arg)?;
-    let stack = ctx
-        .dag
-        // Note that for a graph like
-        //
-        // ```
-        // O
-        // |
-        // o A
-        // | \
-        // |  o B
-        // |
-        // @ C
-        // ```
-        // this will return `{A, B, C}`, not just `{A, C}`.
-        .query_range(stack_ancestors, draft_commits.clone())?;
-    Ok(stack)
+    ctx.dag
+        .query_stack_commits(arg)
+        .map_err(EvalError::OtherError)
 }
 
 type MatcherFn = dyn Fn(&Repo, &Commit) -> Result<bool, PatternError> + Sync + Send;

--- a/scm-bisect/examples/guessing_game.rs
+++ b/scm-bisect/examples/guessing_game.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::io;
 use std::ops::RangeInclusive;
@@ -38,10 +37,13 @@ impl search::Strategy<Graph> for Strategy {
     fn midpoint(
         &self,
         _graph: &Graph,
-        success_bounds: &HashSet<Node>,
-        failure_bounds: &HashSet<Node>,
+        bounds: &search::Bounds<Node>,
         _statuses: &IndexMap<Node, search::Status>,
     ) -> Result<Option<Node>, Self::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let lower_bound = success_bounds
             .iter()
             .max()

--- a/scm-bisect/src/basic.rs
+++ b/scm-bisect/src/basic.rs
@@ -198,10 +198,13 @@ impl<G: BasicSourceControlGraph> search::Strategy<G> for BasicStrategy {
     fn midpoint(
         &self,
         graph: &G,
-        success_bounds: &HashSet<G::Node>,
-        failure_bounds: &HashSet<G::Node>,
+        bounds: &search::Bounds<G::Node>,
         statuses: &IndexMap<G::Node, search::Status>,
     ) -> Result<Option<G::Node>, G::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let mut nodes_to_search = {
             let implied_success_nodes = graph.ancestors_all(success_bounds.clone())?;
             let implied_failure_nodes = graph.descendants_all(failure_bounds.clone())?;


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1220
* https://github.com/arxanas/git-branchless/pull/1221
* https://github.com/arxanas/git-branchless/pull/1222
* https://github.com/arxanas/git-branchless/pull/1223
* https://github.com/arxanas/git-branchless/pull/1224
* https://github.com/arxanas/git-branchless/pull/1225
* https://github.com/arxanas/git-branchless/pull/1226
* https://github.com/arxanas/git-branchless/pull/1227
* https://github.com/arxanas/git-branchless/pull/1228
* https://github.com/arxanas/git-branchless/pull/1229
* https://github.com/arxanas/git-branchless/pull/1184
* https://github.com/arxanas/git-branchless/pull/1230
* https://github.com/arxanas/git-branchless/pull/1231
* https://github.com/arxanas/git-branchless/pull/1232
* https://github.com/arxanas/git-branchless/pull/1233


---

feat(git): export `GitErrorCode` from `repo`

So that we can call e.g. `Repo::create_branch` and ignore the error if the branch already exists.

