### PR TITLE
[6/15] feat(submit): make forges branch-agnostic

### DIFF
--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -23,8 +23,8 @@ pub use reference::{
 };
 pub use repo::{
     message_prettify, AmendFastOptions, CherryPickFastOptions, CreateCommitFastError,
-    Error as RepoError, GitVersion, PatchId, Repo, ResolvedReferenceInfo, Result as RepoResult,
-    Time,
+    Error as RepoError, GitErrorCode, GitVersion, PatchId, Repo, ResolvedReferenceInfo,
+    Result as RepoResult, Time,
 };
 pub use run::{GitRunInfo, GitRunOpts, GitRunResult};
 pub use snapshot::{WorkingCopyChangesType, WorkingCopySnapshot};

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -277,6 +277,8 @@ pub enum Error {
 /// Result type.
 pub type Result<T> = std::result::Result<T, Error>;
 
+pub use git2::ErrorCode as GitErrorCode;
+
 /// Convert a `git2::Error` into an `eyre::Error` with an auto-generated message.
 pub(super) fn wrap_git_error(error: git2::Error) -> eyre::Error {
     eyre::eyre!("Git error {:?}: {}", error.code(), error.message())

--- a/git-branchless-revset/src/builtins.rs
+++ b/git-branchless-revset/src/builtins.rs
@@ -290,28 +290,9 @@ fn fn_draft(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
 #[instrument]
 fn fn_stack(ctx: &mut Context, name: &str, args: &[Expr]) -> EvalResult {
     let arg = eval0_or_1(ctx, name, args)?.unwrap_or_else(|| ctx.dag.head_commit.clone());
-    let draft_commits = ctx
-        .dag
-        .query_draft_commits()
-        .map_err(EvalError::OtherError)?;
-    let stack_roots = ctx.dag.query_roots(draft_commits.clone())?;
-    let stack_ancestors = ctx.dag.query_range(stack_roots, arg)?;
-    let stack = ctx
-        .dag
-        // Note that for a graph like
-        //
-        // ```
-        // O
-        // |
-        // o A
-        // | \
-        // |  o B
-        // |
-        // @ C
-        // ```
-        // this will return `{A, B, C}`, not just `{A, C}`.
-        .query_range(stack_ancestors, draft_commits.clone())?;
-    Ok(stack)
+    ctx.dag
+        .query_stack_commits(arg)
+        .map_err(EvalError::OtherError)
 }
 
 type MatcherFn = dyn Fn(&Repo, &Commit) -> Result<bool, PatternError> + Sync + Send;

--- a/git-branchless-submit/src/branch_forge.rs
+++ b/git-branchless-submit/src/branch_forge.rs
@@ -142,7 +142,7 @@ impl Forge for BranchForge<'_> {
 
             let commit_status = match branch_infos.as_slice() {
                 [] => CommitStatus {
-                    submit_status: SubmitStatus::Unsubmitted,
+                    submit_status: SubmitStatus::Local,
                     remote_name: None,
                     local_branch_name: None,
                     remote_branch_name: None,

--- a/git-branchless-submit/src/branch_forge.rs
+++ b/git-branchless-submit/src/branch_forge.rs
@@ -144,8 +144,8 @@ impl Forge for BranchForge<'_> {
                 [] => CommitStatus {
                     submit_status: SubmitStatus::Local,
                     remote_name: None,
-                    local_branch_name: None,
-                    remote_branch_name: None,
+                    local_commit_name: None,
+                    remote_commit_name: None,
                 },
 
                 [BranchInfo {
@@ -156,8 +156,8 @@ impl Forge for BranchForge<'_> {
                     None => CommitStatus {
                         submit_status: SubmitStatus::Unsubmitted,
                         remote_name: None,
-                        local_branch_name: Some(branch_name.clone()),
-                        remote_branch_name: None,
+                        local_commit_name: Some(branch_name.clone()),
+                        remote_commit_name: None,
                     },
 
                     Some(upstream_branch) => CommitStatus {
@@ -167,16 +167,16 @@ impl Forge for BranchForge<'_> {
                             SubmitStatus::NeedsUpdate
                         },
                         remote_name: remote_name.clone(),
-                        local_branch_name: Some(branch_name.clone()),
-                        remote_branch_name: Some(upstream_branch.get_name()?.to_owned()),
+                        local_commit_name: Some(branch_name.clone()),
+                        remote_commit_name: Some(upstream_branch.get_name()?.to_owned()),
                     },
                 },
 
                 _branch_infos => CommitStatus {
                     submit_status: SubmitStatus::Unknown,
                     remote_name: None,
-                    local_branch_name: None,
-                    remote_branch_name: None,
+                    local_commit_name: None,
+                    remote_commit_name: None,
                 },
             };
             commit_statuses.insert(*commit_oid, commit_status);
@@ -196,10 +196,10 @@ impl Forge for BranchForge<'_> {
                 let CommitStatus {
                     submit_status: _,
                     remote_name: _,
-                    local_branch_name,
-                    remote_branch_name: _,
+                    local_commit_name,
+                    remote_commit_name: _,
                 } = commit_status;
-                local_branch_name.clone()
+                local_commit_name.clone()
             })
             .sorted()
             .collect_vec();
@@ -244,12 +244,12 @@ These remotes are available: {}",
             Ok(Ok(commits
                 .into_iter()
                 .filter_map(|(commit_oid, commit_status)| {
-                    commit_status.local_branch_name.map(|local_branch_name| {
+                    commit_status.local_commit_name.map(|local_commit_name| {
                         (
                             commit_oid,
                             CreateStatus {
                                 final_commit_oid: commit_oid,
-                                local_branch_name,
+                                local_commit_name,
                             },
                         )
                     })
@@ -269,9 +269,9 @@ These remotes are available: {}",
                 CommitStatus {
                     submit_status: _,
                     remote_name: Some(remote_name),
-                    local_branch_name: Some(local_branch_name),
-                    remote_branch_name: _,
-                } => Some((remote_name, local_branch_name)),
+                    local_commit_name: Some(local_commit_name),
+                    remote_commit_name: _,
+                } => Some((remote_name, local_commit_name)),
                 commit_status => {
                     warn!(
                         ?commit_status,

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -53,7 +53,12 @@ lazy_static! {
 /// The status of a commit, indicating whether it needs to be updated remotely.
 #[derive(Clone, Debug)]
 pub enum SubmitStatus {
-    /// The commit exists locally but has not been pushed remotely.
+    /// The commit exists locally and there is no intention to push it to the
+    /// remote.
+    Local,
+
+    /// The commit exists locally and will eventually be pushed to the remote,
+    /// but it has not been pushed yet.
     Unsubmitted,
 
     /// It could not be determined whether the remote commit exists.
@@ -273,14 +278,25 @@ fn submit(
     let statuses = try_exit_code!(forge.query_status(commit_set)?);
     debug!(?statuses, "Commit statuses");
 
-    let (unsubmitted_commits, commits_to_update, commits_to_skip): (
+    #[allow(clippy::type_complexity)]
+    let (_local_commits, unsubmitted_commits, commits_to_update, commits_to_skip): (
+        HashMap<NonZeroOid, CommitStatus>,
         HashMap<NonZeroOid, CommitStatus>,
         HashMap<NonZeroOid, CommitStatus>,
         HashMap<NonZeroOid, CommitStatus>,
     ) = statuses.into_iter().fold(Default::default(), |acc, elem| {
-        let (mut unsubmitted, mut to_update, mut to_skip) = acc;
+        let (mut local, mut unsubmitted, mut to_update, mut to_skip) = acc;
         let (commit_oid, commit_status) = elem;
         match commit_status {
+            CommitStatus {
+                submit_status: SubmitStatus::Local,
+                remote_name: _,
+                local_branch_name: _,
+                remote_branch_name: _,
+            } => {
+                local.insert(commit_oid, commit_status);
+            }
+
             CommitStatus {
                 submit_status: SubmitStatus::Unsubmitted,
                 remote_name: _,
@@ -322,7 +338,7 @@ fn submit(
                 remote_branch_name: _,
             } => {}
         }
-        (unsubmitted, to_update, to_skip)
+        (local, unsubmitted, to_update, to_skip)
     });
 
     let (created_branches, uncreated_branches): (BTreeSet<String>, BTreeSet<String>) = {

--- a/git-branchless-submit/src/phabricator.rs
+++ b/git-branchless-submit/src/phabricator.rs
@@ -307,8 +307,8 @@ impl Forge for PhabricatorForge<'_> {
                         None => SubmitStatus::Unsubmitted,
                     },
                     remote_name: None,
-                    local_branch_name: None,
-                    remote_branch_name: None,
+                    local_commit_name: None,
+                    remote_commit_name: None,
                 };
                 (commit_oid, status)
             })
@@ -535,7 +535,7 @@ Differential Revision: https://phabricator.example.com/D000$(git rev-list --coun
                 commit_oid,
                 CreateStatus {
                     final_commit_oid,
-                    local_branch_name,
+                    local_commit_name: local_branch_name,
                 },
             );
         }
@@ -545,7 +545,7 @@ Differential Revision: https://phabricator.example.com/D000$(git rev-list --coun
             .map(|create_status| {
                 let CreateStatus {
                     final_commit_oid,
-                    local_branch_name: _,
+                    local_commit_name: _,
                 } = create_status;
                 *final_commit_oid
             })

--- a/git-branchless-submit/tests/test_phabricator_forge.rs
+++ b/git-branchless-submit/tests/test_phabricator_forge.rs
@@ -75,7 +75,7 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Using command execution strategy: working-copy
         branchless: running command: <git-executable> rebase --abort
-        Created 2 branches: D0002, D0003
+        Submitted 2 commits: D0002, D0003
         "###);
     }
 
@@ -84,9 +84,9 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         O f777ecc (master) create initial.txt
         |
-        o 55af3db (D0002) D0002 create test1.txt
+        o 55af3db D0002 create test1.txt
         |
-        @ ccb7fd5 (D0003) D0003 create test2.txt
+        @ ccb7fd5 D0003 create test2.txt
         "###);
     }
 
@@ -149,7 +149,7 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
         Setting D0002 as stack root (no dependencies)
         Stacking D0003 on top of D0002
         Using command execution strategy: worktree
-        Created 2 branches: D0002, D0003
+        Submitted 2 commits: D0002, D0003
         "###);
     }
 
@@ -158,9 +158,9 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         O f777ecc (master) create initial.txt
         |
-        o 55af3db (D0002) D0002 create test1.txt
+        o 55af3db D0002 create test1.txt
         |
-        @ ccb7fd5 (D0003) D0003 create test2.txt
+        @ ccb7fd5 D0003 create test2.txt
         "###);
     }
 
@@ -204,7 +204,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Using command execution strategy: working-copy
         branchless: running command: <git-executable> rebase --abort
-        Created 2 branches: D0002, D0003
+        Submitted 2 commits: D0002, D0003
         "###);
     }
 

--- a/git-branchless-submit/tests/test_submit.rs
+++ b/git-branchless-submit/tests/test_submit.rs
@@ -58,9 +58,9 @@ fn test_submit() -> eyre::Result<()> {
         let (stdout, stderr) = cloned_repo.run(&["submit"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-        Skipped 2 branches (not yet on remote): bar, qux
-        These branches were skipped because they were not already associated with a remote repository. To
-        create and push them, retry this operation with the --create option.
+        Skipped 2 commits (not yet on remote): bar, qux
+        These commits were skipped because they were not already associated with a remote
+        repository. To submit them, retry this operation with the --create option.
         "###);
     }
 
@@ -68,9 +68,9 @@ fn test_submit() -> eyre::Result<()> {
         let (stdout, stderr) = cloned_repo.run(&["submit", "--dry-run"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-        Would skip 2 branches (not yet on remote): bar, qux
-        These branches would be skipped because they are not already associated with a remote repository. To
-        create and push them, retry this operation with the --create option.
+        Would skip 2 commits (not yet on remote): bar, qux
+        These commits would be skipped because they are not already associated with a remote
+        repository. To submit them, retry this operation with the --create option.
         "###);
     }
 
@@ -78,7 +78,7 @@ fn test_submit() -> eyre::Result<()> {
         let (stdout, stderr) = cloned_repo.run(&["submit", "--create", "--dry-run"])?;
         insta::assert_snapshot!(stderr, @"");
         insta::assert_snapshot!(stdout, @r###"
-        Would create 2 branches: bar, qux
+        Would submit 2 commits: bar, qux
         "###);
     }
 
@@ -98,7 +98,7 @@ fn test_submit() -> eyre::Result<()> {
         branchless: running command: <git-executable> push --set-upstream origin bar qux
         branch 'bar' set up to track 'origin/bar'.
         branch 'qux' set up to track 'origin/qux'.
-        Created 2 branches: bar, qux
+        Submitted 2 commits: bar, qux
         "###);
     }
 
@@ -128,8 +128,8 @@ fn test_submit() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> fetch origin refs/heads/bar refs/heads/qux
         branchless: running command: <git-executable> push --force-with-lease origin qux
-        Pushed 1 branch: qux
-        Skipped 1 branch (already up-to-date): bar
+        Updated 1 commit: qux
+        Skipped 1 commit (already up-to-date): bar
         "###);
     }
 
@@ -144,7 +144,7 @@ fn test_submit() -> eyre::Result<()> {
         "###);
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> fetch origin refs/heads/bar refs/heads/qux
-        Skipped 2 branches (already up-to-date): bar, qux
+        Skipped 2 commits (already up-to-date): bar, qux
         "###);
     }
 
@@ -301,7 +301,7 @@ fn test_submit_up_to_date_branch() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> push --set-upstream origin feature
         branch 'feature' set up to track 'origin/feature'.
-        Created 1 branch: feature
+        Submitted 1 commit: feature
         "###);
     }
 
@@ -315,7 +315,7 @@ fn test_submit_up_to_date_branch() -> eyre::Result<()> {
         "###);
         insta::assert_snapshot!(stdout, @r###"
         branchless: running command: <git-executable> fetch origin refs/heads/feature
-        Skipped 1 branch (already up-to-date): feature
+        Skipped 1 commit (already up-to-date): feature
         "###);
     }
 

--- a/scm-bisect/examples/guessing_game.proptest-regressions
+++ b/scm-bisect/examples/guessing_game.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 67760b0a17386062ba77f3c425a851fa115bcdcb9fbe2697c66e2a1867e600a7 # shrinks to inputs = [Less, Less, Less, Greater, Less, Less, Less]
+cc 30da0c32ee62618d38b87f1ef1fe8b135a6703ca4b5965e29da5ecf47f5860e9 # shrinks to input = 0
+cc f7618c6f857bd07b2c8f1b086c2ca175e73d1a6189b1d14d7ffb0f7ddd35ae68 # shrinks to input = 100

--- a/scm-bisect/examples/guessing_game.rs
+++ b/scm-bisect/examples/guessing_game.rs
@@ -1,0 +1,135 @@
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::io;
+use std::ops::RangeInclusive;
+
+use indexmap::IndexMap;
+use scm_bisect::search;
+
+type Node = isize;
+
+#[derive(Debug)]
+struct Graph;
+
+impl search::Graph for Graph {
+    type Node = Node;
+
+    type Error = Infallible;
+
+    fn is_ancestor(
+        &self,
+        ancestor: Self::Node,
+        descendant: Self::Node,
+    ) -> Result<bool, Self::Error> {
+        // Note that a node is always considered an ancestor of itself.
+        Ok(ancestor <= descendant)
+    }
+}
+
+#[derive(Debug)]
+struct Strategy {
+    range: RangeInclusive<Node>,
+}
+
+impl search::Strategy<Graph> for Strategy {
+    type Error = Infallible;
+
+    fn midpoint(
+        &self,
+        _graph: &Graph,
+        success_bounds: &HashSet<Node>,
+        failure_bounds: &HashSet<Node>,
+        _statuses: &IndexMap<Node, search::Status>,
+    ) -> Result<Option<Node>, Self::Error> {
+        let lower_bound = success_bounds
+            .iter()
+            .max()
+            .copied()
+            .unwrap_or_else(|| self.range.start() - 1);
+        let upper_bound = failure_bounds
+            .iter()
+            .min()
+            .copied()
+            .unwrap_or_else(|| self.range.end() + 1);
+        let midpoint = if lower_bound < upper_bound - 1 {
+            (lower_bound + upper_bound) / 2
+        } else {
+            return Ok(None);
+        };
+        assert!(self.range.contains(&midpoint));
+        Ok(Some(midpoint))
+    }
+}
+
+fn play<E>(mut read_input: impl FnMut(isize) -> Result<Ordering, E>) -> Result<Option<isize>, E> {
+    let search_range = 0..=100;
+    let mut search = search::Search::new(Graph, search_range.clone());
+    let strategy = Strategy {
+        range: search_range,
+    };
+
+    let result = loop {
+        let guess = {
+            let mut guess = search.search(&strategy).unwrap();
+            match guess.next_to_search.next() {
+                Some(guess) => guess.unwrap(),
+                None => {
+                    break None;
+                }
+            }
+        };
+        let input = read_input(guess)?;
+        match input {
+            Ordering::Less => search.notify(guess, search::Status::Failure).unwrap(),
+            Ordering::Greater => search.notify(guess, search::Status::Success).unwrap(),
+            Ordering::Equal => {
+                break Some(guess);
+            }
+        }
+    };
+    Ok(result)
+}
+
+fn main() -> io::Result<()> {
+    println!("Think of a number between 0 and 100.");
+    let result = play(|guess| -> io::Result<_> {
+        println!("Is your number {guess}? [<=>]");
+        let result = loop {
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            match input.trim() {
+                "<" => break Ordering::Less,
+                "=" => break Ordering::Equal,
+                ">" => break Ordering::Greater,
+                _ => println!("Please enter '<', '=', or '>'."),
+            }
+        };
+        Ok(result)
+    })?;
+    match result {
+        Some(result) => println!("I win! Your number was: {result}"),
+        None => println!("I give up!"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest::proptest! {
+        #[test]
+        fn test_no_crashes_on_valid_input(inputs: Vec<Ordering>) {
+            struct Exit;
+            let mut iter = inputs.into_iter();
+            let _: Result<Option<isize>, Exit> = play(move |_| iter.next().ok_or(Exit));
+        }
+
+        #[test]
+        fn test_finds_number(input in 0..=100_isize) {
+            let result = play(|guess| -> Result<Ordering, Infallible> { Ok(input.cmp(&guess)) });
+            assert_eq!(result, Ok(Some(input)));
+        }
+    }
+}

--- a/scm-bisect/examples/guessing_game.rs
+++ b/scm-bisect/examples/guessing_game.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::io;
 use std::ops::RangeInclusive;
@@ -38,10 +37,13 @@ impl search::Strategy<Graph> for Strategy {
     fn midpoint(
         &self,
         _graph: &Graph,
-        success_bounds: &HashSet<Node>,
-        failure_bounds: &HashSet<Node>,
+        bounds: &search::Bounds<Node>,
         _statuses: &IndexMap<Node, search::Status>,
     ) -> Result<Option<Node>, Self::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let lower_bound = success_bounds
             .iter()
             .max()

--- a/scm-bisect/src/basic.rs
+++ b/scm-bisect/src/basic.rs
@@ -198,10 +198,13 @@ impl<G: BasicSourceControlGraph> search::Strategy<G> for BasicStrategy {
     fn midpoint(
         &self,
         graph: &G,
-        success_bounds: &HashSet<G::Node>,
-        failure_bounds: &HashSet<G::Node>,
+        bounds: &search::Bounds<G::Node>,
         statuses: &IndexMap<G::Node, search::Status>,
     ) -> Result<Option<G::Node>, G::Error> {
+        let search::Bounds {
+            success: success_bounds,
+            failure: failure_bounds,
+        } = bounds;
         let mut nodes_to_search = {
             let implied_success_nodes = graph.ancestors_all(success_bounds.clone())?;
             let implied_failure_nodes = graph.descendants_all(failure_bounds.clone())?;


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1220
* https://github.com/arxanas/git-branchless/pull/1221
* https://github.com/arxanas/git-branchless/pull/1222
* https://github.com/arxanas/git-branchless/pull/1223
* https://github.com/arxanas/git-branchless/pull/1224
* https://github.com/arxanas/git-branchless/pull/1225
* https://github.com/arxanas/git-branchless/pull/1226
* https://github.com/arxanas/git-branchless/pull/1227
* https://github.com/arxanas/git-branchless/pull/1228
* https://github.com/arxanas/git-branchless/pull/1229
* https://github.com/arxanas/git-branchless/pull/1184
* https://github.com/arxanas/git-branchless/pull/1230
* https://github.com/arxanas/git-branchless/pull/1231
* https://github.com/arxanas/git-branchless/pull/1232
* https://github.com/arxanas/git-branchless/pull/1233


---

feat(submit): make forges branch-agnostic

It was previously assumed that all forges would want to create and operate on branches, and, in fact, the calling `git-branchless-submit` code would even create the branches returned by `CreateStatus`. This has turned out not to be the case. For example, the Phabricator forge embeds the commit identifier in the (updated) commit message, and doesn't need a branch (and, in practice, it's turned out to be more annoying than useful to create the branches as shorthand identifiers).

This commit removes the auto-branch-creation behavior and updates the terminology to be branch-agnostic and refer to "commits" instead of "branches".

As a result, commits are now "submitted" at the beginning of their submission lifecycle, and future pushes (etc.) are "updates". This doesn't exactly make sense with the name of the `--create` flag, since we never refer to "creating" a commit anywhere, only "submitting" one, so we might want to change that flag name or terminology in the future.

