### PR TITLE
[1/2] feat(smartlog): switch from `⊘` to `◌` for synthetic omitted-commit nodes

### DIFF
--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -202,7 +202,7 @@ impl Glyphs {
             commit_visible_head: "●",
             commit_obsolete: "✕",
             commit_obsolete_head: "⦻",
-            commit_omitted: "⊘",
+            commit_omitted: "◌",
             commit_merge: "↓",
             commit_main: "◇",
             commit_main_head: "◆",


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1230
* https://github.com/arxanas/git-branchless/pull/1231


---

feat(smartlog): switch from `⊘` to `◌` for synthetic omitted-commit nodes

This seems like a strictly more understandable icon. (Originally suggested by @martinvonz for jj.)

