### PR TITLE
Add `--exact` flag to skip adding `main` and `HEAD` in `smartlog`

### DIFF
--- a/git-branchless-navigation/src/lib.rs
+++ b/git-branchless-navigation/src/lib.rs
@@ -507,6 +507,7 @@ pub fn switch(
         &event_replayer,
         event_cursor,
         &commits,
+        false,
     )?;
 
     let initial_query = match switch_options {

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -345,6 +345,11 @@ pub struct SmartlogArgs {
     #[clap(long)]
     pub reverse: bool,
 
+    /// Don't automatically add HEAD and the main branch to the list of commits
+    /// to present. They will still be added if included in the revset.
+    #[clap(long)]
+    pub exact: bool,
+
     /// Options for resolving revset expressions.
     #[clap(flatten)]
     pub resolve_revset_options: ResolveRevsetOptions,

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -77,7 +77,15 @@ fn render_cursor_smartlog(
     };
 
     let commits = resolve_default_smartlog_commits(effects, repo, &mut dag)?;
-    let graph = make_smartlog_graph(effects, repo, &dag, event_replayer, event_cursor, &commits)?;
+    let graph = make_smartlog_graph(
+        effects,
+        repo,
+        &dag,
+        event_replayer,
+        event_cursor,
+        &commits,
+        false,
+    )?;
     let result = render_graph(
         effects,
         repo,

--- a/git-branchless/src/commands/bug_report.rs
+++ b/git-branchless/src/commands/bug_report.rs
@@ -133,7 +133,15 @@ fn describe_event_cursor(
     let glyphs = Glyphs::text();
     let effects = Effects::new(glyphs.clone());
     let commits = resolve_default_smartlog_commits(&effects, repo, dag)?;
-    let graph = make_smartlog_graph(&effects, repo, dag, event_replayer, event_cursor, &commits)?;
+    let graph = make_smartlog_graph(
+        &effects,
+        repo,
+        dag,
+        event_replayer,
+        event_cursor,
+        &commits,
+        false,
+    )?;
     let graph_lines = render_graph(
         &effects,
         repo,

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -316,9 +316,9 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::core::eventlog::from_event_log_db with effects=<Output fancy=false> repo=<Git repository at: "<repo-path>/.git/"> event_log_db=<EventLogDb path=Some("<repo-path>/.git/branchless/db.sqlite3")>
           at some/file/path.rs:123
-       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false }
+       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false, exact: false }
           at some/file/path.rs:123
-       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
           at some/file/path.rs:123
 
     Suggestion:


### PR DESCRIPTION
As discussed in https://github.com/arxanas/git-branchless/discussions/1240, I would like to be able to present smartlogs without including `main` or `HEAD`. After discussion in this PR, the flag is named `--exact`.

I've added tests and everything appears to be green. Let me know your thoughts!