### PR TITLE
[1/1] Revert "testing: forward `RUST_LOG` environment variable" for Nix's sake

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -185,7 +185,7 @@ impl Git {
         let git_editor = OsString::from(":");
 
         let new_path = self.get_path_for_env();
-        let mut envs = vec![
+        let envs = vec![
             ("GIT_CONFIG_NOSYSTEM", OsString::from("1")),
             ("GIT_AUTHOR_DATE", date.clone()),
             ("GIT_COMMITTER_DATE", date),
@@ -193,18 +193,11 @@ impl Git {
             ("GIT_EXEC_PATH", self.git_exec_path.as_os_str().into()),
             ("PATH", new_path),
             (TEST_GIT, self.path_to_git.as_os_str().into()),
-        ];
-        if let Some(test_separate_command_binaries) =
-            std::env::var_os(TEST_SEPARATE_COMMAND_BINARIES)
-        {
-            envs.push((
+            (
                 TEST_SEPARATE_COMMAND_BINARIES,
-                test_separate_command_binaries,
-            ));
-        }
-        if let Some(rust_log) = std::env::var_os("RUST_LOG") {
-            envs.push(("RUST_LOG", rust_log));
-        }
+                std::env::var_os(TEST_SEPARATE_COMMAND_BINARIES).unwrap_or_default(),
+            ),
+        ];
 
         envs.into_iter()
             .map(|(key, value)| (OsString::from(key), value))


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1243


---

Revert "testing: forward `RUST_LOG` environment variable" for Nix's sake

This reverts commit aff490b3477b29119dcba8431bee9ac22d2564ab. That commit seems to cause Nix build failures for some reason that I don't want to diagnose at present.

Example logs (https://github.com/arxanas/git-branchless/actions/runs/7902491612/job/21568284520):

```
git-branchless> ---- test_init_basic stdout ----
git-branchless> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
git-branchless> Snapshot: init_basic
git-branchless> Source: git-branchless/tests/test_init.rs:221
git-branchless> ────────────────────────────────────────────────────────────────────────────────
git-branchless> Expression: stderr
git-branchless> ────────────────────────────────────────────────────────────────────────────────
git-branchless> +new results
git-branchless> ────────────┬───────────────────────────────────────────────────────────────────
git-branchless>           0 │+␛[2m2024-02-14T14:16:52.608444Z␛[0m ␛[33m WARN␛[0m ␛[2mindexedlog::log::fold␛[0m␛[2m:␛[0m cannot load FoldState: "<repo-path>/.git/branchless/dag2/iddag/fold-cover": cannot read FoldState␊
git-branchless>           1 │+Caused by 1 errors:␊
git-branchless>           2 │+- No such file or directory (os error 2)␊
git-branchless> ────────────┴───────────────────────────────────────────────────────────────────
git-branchless> To update snapshots run `cargo insta review`
git-branchless> Stopped on the first failure. Run `cargo insta test` to run all snapshots.
git-branchless> The application panicked (crashed).
git-branchless> Message:  snapshot assertion for 'init_basic' failed in line 221
git-branchless> Location: /build/cargo-vendor-dir/insta-1.34.0/src/runtime.rs:563
git-branchless>   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
git-branchless>                                 ⋮ 7 frames hidden ⋮
git-branchless>    8: insta::runtime::finalize_assertion::hb6bdb67eac0db117
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>    9: insta::runtime::assert_snapshot::hb62eaea0ef631241
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   10: test_init::test_init_basic::h7e3572226c6e968e
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   11: test_init::test_init_basic::{{closure}}::ha95c017bcb969a3b
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   12: core::ops::function::FnOnce::call_once::h3c22253808b3b504
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   13: test::__rust_begin_short_backtrace::h398d1a26526ed5ba
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   14: core::ops::function::FnOnce::call_once{{vtable.shim}}::h18837446474d6947
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   15: test::run_test_in_process::he69b81fa0b10df3d
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   16: std::sys_common::backtrace::__rust_begin_short_backtrace::h64cb29d4266abbdc
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   17: core::ops::function::FnOnce::call_once{{vtable.shim}}::h214c7cf736b08605
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   18: std::sys::unix::thread::Thread::new::thread_start::hed45a1c6881e221b
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   19: start_thread<unknown>
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   20: __clone3<unknown>
git-branchless>       at <unknown source file>:<unknown line>
git-branchless> Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
git-branchless> Run with RUST_BACKTRACE=full to include source snippets.
git-branchless> ---- test_init_prompt_for_main_branch stdout ----
git-branchless> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
git-branchless> Snapshot: init_prompt_for_main_branch
git-branchless> Source: git-branchless/tests/test_init.rs:260
git-branchless> ────────────────────────────────────────────────────────────────────────────────
git-branchless> Expression: stderr
git-branchless> ────────────────────────────────────────────────────────────────────────────────
git-branchless> +new results
git-branchless> ────────────┬───────────────────────────────────────────────────────────────────
git-branchless>           0 │+␛[2m2024-02-14T14:16:52.756960Z␛[0m ␛[33m WARN␛[0m ␛[2mindexedlog::log::fold␛[0m␛[2m:␛[0m cannot load FoldState: "<repo-path>/.git/branchless/dag2/iddag/fold-cover": cannot read FoldState␊
git-branchless>           1 │+Caused by 1 errors:␊
git-branchless>           2 │+- No such file or directory (os error 2)␊
git-branchless> ────────────┴───────────────────────────────────────────────────────────────────
git-branchless> To update snapshots run `cargo insta review`
git-branchless> Stopped on the first failure. Run `cargo insta test` to run all snapshots.
git-branchless> The application panicked (crashed).
git-branchless> Message:  snapshot assertion for 'init_prompt_for_main_branch' failed in line 260
git-branchless> Location: /build/cargo-vendor-dir/insta-1.34.0/src/runtime.rs:563
git-branchless>   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
git-branchless>                                 ⋮ 7 frames hidden ⋮
git-branchless>    8: insta::runtime::finalize_assertion::hb6bdb67eac0db117
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>    9: insta::runtime::assert_snapshot::hb62eaea0ef631241
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   10: test_init::test_init_prompt_for_main_branch::h1a02ecb23fce265e
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   11: test_init::test_init_prompt_for_main_branch::{{closure}}::hb8a916f7fa706b51
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   12: core::ops::function::FnOnce::call_once::hba4d15088d5b711e
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   13: test::__rust_begin_short_backtrace::h398d1a26526ed5ba
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   14: core::ops::function::FnOnce::call_once{{vtable.shim}}::h18837446474d6947
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   15: test::run_test_in_process::he69b81fa0b10df3d
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   16: std::sys_common::backtrace::__rust_begin_short_backtrace::h64cb29d4266abbdc
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   17: core::ops::function::FnOnce::call_once{{vtable.shim}}::h214c7cf736b08605
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   18: std::sys::unix::thread::Thread::new::thread_start::hed45a1c6881e221b
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   19: start_thread<unknown>
git-branchless>       at <unknown source file>:<unknown line>
git-branchless>   20: __clone3<unknown>
git-branchless>       at <unknown source file>:<unknown line>
git-branchless> Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
git-branchless> Run with RUST_BACKTRACE=full to include source snippets.
git-branchless> failures:
git-branchless>     test_init_basic
git-branchless>     test_init_prompt_for_main_branch
git-branchless> test result: FAILED. 14 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s
git-branchless> error: test failed, to rerun pass `--test test_init`
error: builder for '/nix/store/6h1p0s422b3jldf2m6bw7lrkppc2c0ny-git-branchless.drv' failed with exit code 101;
       last 10 log lines:
       > Run with RUST_BACKTRACE=full to include source snippets.
       >
       >
       > failures:
       >     test_init_basic
       >     test_init_prompt_for_main_branch
       >
       > test result: FAILED. 14 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s
       >
       > error: test failed, to rerun pass `--test test_init`
       For full logs, run 'nix log /nix/store/6h1p0s422b3jldf2m6bw7lrkppc2c0ny-git-branchless.drv'.
```

