### PR TITLE
feat(submit): support multiple revset arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This allows `git sync my-branch` to work as expected, instead of needing to use `git sync 'stack(my-branch)'`. The behavior of `git sync` when called without arguments is not affected by this change. If you rely on the previous behavior, please use `git move -x <commit(s)/revset> -d 'main()'` instead.
 - (#1169) `git record` now accepts multible `--message` arguments.
 - (#1130) `branches()` revset function now accepts an optional text pattern argument to limit which branches are matched.
+- (#1244) `git submit` now accepts multiple argements/revsets
 
 ### Fixed
 

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -387,7 +387,7 @@ pub struct SubmitArgs {
     /// The commits to push. All branches attached to those commits will be
     /// pushed.
     #[clap(value_parser, default_value = "stack()")]
-    pub revset: Revset,
+    pub revsets: Vec<Revset>,
 
     /// Options for resolving revset expressions.
     #[clap(flatten)]

--- a/git-branchless-submit/tests/test_submit.rs
+++ b/git-branchless-submit/tests/test_submit.rs
@@ -64,6 +64,28 @@ fn test_submit() -> eyre::Result<()> {
         "###);
     }
 
+    // test handling of revset argument (should be identical to above)
+    {
+        let (stdout, stderr) = cloned_repo.run(&["submit", "bar+qux"])?;
+        insta::assert_snapshot!(stderr, @"");
+        insta::assert_snapshot!(stdout, @r###"
+        Skipped 2 commits (not yet on remote): bar, qux
+        These commits were skipped because they were not already associated with a remote
+        repository. To submit them, retry this operation with the --create option.
+        "###);
+    }
+
+    // test handling of multiple revset arguments (should be identical to above)
+    {
+        let (stdout, stderr) = cloned_repo.run(&["submit", "bar", "qux"])?;
+        insta::assert_snapshot!(stderr, @"");
+        insta::assert_snapshot!(stdout, @r###"
+        Skipped 2 commits (not yet on remote): bar, qux
+        These commits were skipped because they were not already associated with a remote
+        repository. To submit them, retry this operation with the --create option.
+        "###);
+    }
+
     {
         let (stdout, stderr) = cloned_repo.run(&["submit", "--dry-run"])?;
         insta::assert_snapshot!(stderr, @"");


### PR DESCRIPTION
I have a bunch of stale branches that I don't want to think about while I work on newer stuff, so I often find myself running `git sync branch-1 branch-2 ...` and then `git submit branch-1 branch-2 ...` ... only for `submit` to tell me that it doesn't support multiple args. 😢  I usually resort to concating them to `branch-1+branch-2+...`, but I would prefer `submit` to do that for me, so here we are. 😄 

