### PR TITLE
chore: ignore direnv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 # Jetbrains products to develop git-branchless! File an issue and I will apply
 # on your behalf.
 .idea
+
+# Direnv: https://github.com/direnv/direnv
+/.direnv/
+/.envrc


### PR DESCRIPTION
For us Nix(OS) developers, useful with: `echo 'use flake' > .envrc` to automatically load the development shell for this project.