### PR TITLE
cleanup: rm dead code for (feature = "man-pages") & recycle for a new (feature = "separate-binaries")

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708373374,
-        "narHash": "sha256-yEyDvDj/YQc4GOZa/cXx6YUzexD8uv1rUvD6SJVr6UI=",
+        "lastModified": 1728249353,
+        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93e1c2d08467d1117ebac45689469613a9fe8453",
+        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
           nativeBuildInputs = with pkgs.buildPackages; [
             cargo # with shell completions, instead of cargo-auditable
             git # for testing
+            cargo-insta # for updating insta snapshots
           ] ++ nativeBuildInputs;
 
           env = with pkgs.buildPackages; {

--- a/git-branchless-init/Cargo.toml
+++ b/git-branchless-init/Cargo.toml
@@ -22,4 +22,4 @@ tracing = { workspace = true }
 assert_cmd = { workspace = true }
 
 [features]
-man-pages = []
+separate-binaries = []

--- a/git-branchless-init/src/lib.rs
+++ b/git-branchless-init/src/lib.rs
@@ -311,7 +311,7 @@ fn uninstall_hooks(effects: &Effects, git_run_info: &GitRunInfo, repo: &Repo) ->
 ///   subcommand is included in the `man` invocation, so it can show more specific
 ///   help.
 fn should_use_wrapped_command_alias() -> bool {
-    cfg!(feature = "man-pages")
+    cfg!(feature = "separate-binaries") // unimplemented
 }
 
 #[instrument]

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -635,14 +635,6 @@ impl Repo {
         Ok(self.get_branchless_dir()?.join("dag2"))
     }
 
-    /// Get the directory to store man-pages. Note that this is the `man`
-    /// directory, and not a subsection thereof. `git-branchless` man-pages must
-    /// go into the `man/man1` directory to be found by `man`.
-    #[instrument]
-    pub fn get_man_dir(&self) -> Result<PathBuf> {
-        Ok(self.get_branchless_dir()?.join("man"))
-    }
-
     /// Get a directory suitable for storing temporary files.
     ///
     /// In particular, this directory is guaranteed to be on the same filesystem

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -60,7 +60,7 @@ tracing-subscriber = { workspace = true }
 insta = { workspace = true }
 
 [features]
-man-pages = []
+separate-binaries = []
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
Hi! I was exploring the clap related code to see if we can generate completions, and accidentally came across some dead code on the removed "man-pages" feature. This patch:
- Removes dead code for (feature = "man-pages"), which has been deleted since #205. This avoids confusion with the current working implementation, namely the "install-man-pages" command.
- Renames some probably useful (feature = "man-pages") to an unimplemented (feature = "separate-binaries") which is more descriptive. This is unimplemented for now, but it could be revived in the future so it would probably be useful to keep the code?
- Adds nix devShells for the development environment and bumps nixpkgs.