### PR TITLE
fix(hooks): different PATH's name on windows and linux

### DIFF
--- a/git-branchless-lib/src/git/run.rs
+++ b/git-branchless-lib/src/git/run.rs
@@ -418,6 +418,11 @@ impl GitRunInfo {
             if let Some(path) = env.get(OsStr::new("PATH")) {
                 path_components.extend(std::env::split_paths(path));
             }
+            // On windows, PATH's name defaults to "Path".
+            #[cfg(target_os = "windows")]
+            if let Some(path) = env.get(OsStr::new("Path")) {
+                path_components.extend(std::env::split_paths(path));
+            }
             std::env::join_paths(path_components).wrap_err("Joining path components")?
         };
 


### PR DESCRIPTION
Closes #1256, closes #370, closes #1144

