### PR TITLE
feat(smartlog): switch from ◯ to ○ for visible commit nodes

### DIFF
--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -198,7 +198,7 @@ impl Glyphs {
             vertical_ellipsis: "⋮",
             split: "━┓",
             merge: "━┛",
-            commit_visible: "◯",
+            commit_visible: "○",
             commit_visible_head: "●",
             commit_obsolete: "✕",
             commit_obsolete_head: "⦻",


### PR DESCRIPTION
U+25EF is unicode LARGE CIRCLE thus would be rendered visibly larger than other node. I believe U+25CB WHITE CIRCLE should be used instead.

Bellow is the list of icons used to denote commit node

| node | symbol |
|---|---|
| commit_visible(before) | ◯ |
| commit_visible(this PR) | ○ |
| commit_visible_head | ● |
| commit_obsolete | ✕ |
| commit_obsolete_head | ⦻ |
| commit_omitted | ◌ |
| commit_merge | ↓ |
| commit_main | ◇ |
| commit_main_head | ◆ |
| commit_main_obsolete | ✕ |
| commit_main_obsolete_head | ❖ |

