### PR TITLE
cleanup: fix lint for Rust 1.77

### DIFF
--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -2485,6 +2485,7 @@ struct PreparedWorkingDirectory {
     path: PathBuf,
 }
 
+#[allow(dead_code)] // fields are not read except by `Debug` implementation`
 #[derive(Debug)]
 enum PrepareWorkingDirectoryError {
     LockFailed(PathBuf),


### PR DESCRIPTION
cleanup: fix lint for Rust 1.77
