### PR TITLE
smartlog: replace `--reverse` flag with config opt

### DIFF
--- a/git-branchless-lib/src/core/config.rs
+++ b/git-branchless-lib/src/core/config.rs
@@ -108,6 +108,13 @@ pub fn get_smartlog_default_revset(repo: &Repo) -> eyre::Result<String> {
         })
 }
 
+/// Whether to reverse the smartlog direction by default
+#[instrument]
+pub fn get_smartlog_reverse(repo: &Repo) -> eyre::Result<bool> {
+    repo.get_readonly_config()?
+        .get_or("branchless.smartlog.reverse", false)
+}
+
 /// Get the default comment character.
 #[instrument]
 pub fn get_comment_char(repo: &Repo) -> eyre::Result<char> {

--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -127,6 +127,10 @@ pub struct Glyphs {
     /// commit or merged from this parent commit.
     pub commit_merge: &'static str,
 
+    /// Alternative character for `commit_merge` when the smartlog orientation
+    /// is reversed.
+    pub commit_merge_rev: &'static str,
+
     /// Character used to point to the currently-checked-out branch.
     pub branch_arrow: &'static str,
 
@@ -179,6 +183,7 @@ impl Glyphs {
             commit_main_obsolete_head: "%",
             commit_omitted: "#",
             commit_merge: "&",
+            commit_merge_rev: "&",
             branch_arrow: ">",
             bullet_point: "-",
             cycle_arrow: ">",
@@ -204,6 +209,7 @@ impl Glyphs {
             commit_obsolete_head: "⦻",
             commit_omitted: "◌",
             commit_merge: "↓",
+            commit_merge_rev: "↑",
             commit_main: "◇",
             commit_main_head: "◆",
             commit_main_obsolete: "✕",
@@ -223,6 +229,7 @@ impl Glyphs {
     pub fn reverse_order(mut self, reverse: bool) -> Self {
         if reverse {
             std::mem::swap(&mut self.split, &mut self.merge);
+            std::mem::swap(&mut self.commit_merge, &mut self.commit_merge_rev);
         }
         self
     }

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -363,9 +363,8 @@ pub struct SmartlogArgs {
     #[clap(value_parser)]
     pub revset: Option<Revset>,
 
-    /// (Deprecated)
     /// Print the smartlog in the opposite of the usual order, with the latest
-    /// commits first. Can be configured via `branchless.smartlog.reverse`.
+    /// commits first. (DEPRECATED: should be configured with `branchless.smartlog.reverse`)
     #[clap(long)]
     pub reverse: bool,
 

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -363,11 +363,6 @@ pub struct SmartlogArgs {
     #[clap(value_parser)]
     pub revset: Option<Revset>,
 
-    /// Print the smartlog in the opposite of the usual order, with the latest
-    /// commits first.
-    #[clap(long)]
-    pub reverse: bool,
-
     /// Don't automatically add HEAD and the main branch to the list of commits
     /// to present. They will still be added if included in the revset.
     #[clap(long)]

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -363,6 +363,12 @@ pub struct SmartlogArgs {
     #[clap(value_parser)]
     pub revset: Option<Revset>,
 
+    /// (Deprecated)
+    /// Print the smartlog in the opposite of the usual order, with the latest
+    /// commits first. Can be configured via `branchless.smartlog.reverse`.
+    #[clap(long)]
+    pub reverse: bool,
+
     /// Don't automatically add HEAD and the main branch to the list of commits
     /// to present. They will still be added if included in the revset.
     #[clap(long)]

--- a/git-branchless-smartlog/src/lib.rs
+++ b/git-branchless-smartlog/src/lib.rs
@@ -746,6 +746,11 @@ mod render {
         /// The options to use when resolving the revset.
         pub resolve_revset_options: ResolveRevsetOptions,
 
+        /// Deprecated
+        /// Reverse the ordering of items in the smartlog output, list the most
+        /// recent commits first.
+        pub reverse: bool,
+
         /// Normally HEAD and the main branch are included. Set this to exclude them.
         pub exact: bool,
     }
@@ -762,6 +767,7 @@ pub fn smartlog(
         event_id,
         revset,
         resolve_revset_options,
+        reverse,
         exact,
     } = options;
 
@@ -819,9 +825,22 @@ pub fn smartlog(
         exact,
     )?;
 
-    let reverse = get_smartlog_reverse(&repo)?;
+    if reverse {
+        print!(
+            "\
+branchless: WARNING: The `--reverse` flag is deprecated.
+branchless: Please use the `branchless.smartlog.reverse` configuration option.
+"
+        );
+    }
+    let reverse_cfg = get_smartlog_reverse(&repo)?;
+    let reverse_value = match (reverse_cfg, reverse) {
+        (.., true) => true,
+        _ => reverse_cfg,
+    };
+
     let mut lines = render_graph(
-        &effects.reverse_order(reverse),
+        &effects.reverse_order(reverse_value),
         &repo,
         &dag,
         &graph,
@@ -844,7 +863,7 @@ pub fn smartlog(
         ],
     )?
     .into_iter();
-    while let Some(line) = if reverse {
+    while let Some(line) = if reverse_value {
         lines.next_back()
     } else {
         lines.next()
@@ -909,6 +928,7 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
         event_id,
         revset,
         resolve_revset_options,
+        reverse,
         exact,
     } = args;
 
@@ -919,6 +939,7 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
             event_id,
             revset,
             resolve_revset_options,
+            reverse,
             exact,
         },
     )

--- a/git-branchless-smartlog/src/lib.rs
+++ b/git-branchless-smartlog/src/lib.rs
@@ -825,22 +825,18 @@ pub fn smartlog(
         exact,
     )?;
 
-    if reverse {
-        print!(
-            "\
-branchless: WARNING: The `--reverse` flag is deprecated.
-branchless: Please use the `branchless.smartlog.reverse` configuration option.
-"
-        );
-    }
-    let reverse_cfg = get_smartlog_reverse(&repo)?;
-    let reverse_value = match (reverse_cfg, reverse) {
-        (.., true) => true,
-        _ => reverse_cfg,
+    let reverse = if reverse {
+        writeln!(
+            effects.get_error_stream(),
+            "WARNING: The `--reverse` flag is deprecated.\nPlease use the `branchless.smartlog.reverse` configuration option."
+        )?;
+        true
+    } else {
+        get_smartlog_reverse(&repo)?
     };
 
     let mut lines = render_graph(
-        &effects.reverse_order(reverse_value),
+        &effects.reverse_order(reverse),
         &repo,
         &dag,
         &graph,
@@ -863,7 +859,7 @@ branchless: Please use the `branchless.smartlog.reverse` configuration option.
         ],
     )?
     .into_iter();
-    while let Some(line) = if reverse_value {
+    while let Some(line) = if reverse {
         lines.next_back()
     } else {
         lines.next()

--- a/git-branchless-smartlog/src/lib.rs
+++ b/git-branchless-smartlog/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 use git_branchless_invoke::CommandContext;
 use git_branchless_opts::{Revset, SmartlogArgs};
 use lib::core::config::{
-    Hint, get_hint_enabled, get_hint_string, get_smartlog_default_revset,
+    Hint, get_hint_enabled, get_hint_string, get_smartlog_default_revset, get_smartlog_reverse,
     print_hint_suppression_notice,
 };
 use lib::core::repo_ext::RepoExt;
@@ -746,10 +746,6 @@ mod render {
         /// The options to use when resolving the revset.
         pub resolve_revset_options: ResolveRevsetOptions,
 
-        /// Reverse the ordering of items in the smartlog output, list the most
-        /// recent commits first.
-        pub reverse: bool,
-
         /// Normally HEAD and the main branch are included. Set this to exclude them.
         pub exact: bool,
     }
@@ -766,7 +762,6 @@ pub fn smartlog(
         event_id,
         revset,
         resolve_revset_options,
-        reverse,
         exact,
     } = options;
 
@@ -824,6 +819,7 @@ pub fn smartlog(
         exact,
     )?;
 
+    let reverse = get_smartlog_reverse(&repo)?;
     let mut lines = render_graph(
         &effects.reverse_order(reverse),
         &repo,
@@ -913,7 +909,6 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
         event_id,
         revset,
         resolve_revset_options,
-        reverse,
         exact,
     } = args;
 
@@ -924,7 +919,6 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
             event_id,
             revset,
             resolve_revset_options,
-            reverse,
             exact,
         },
     )

--- a/git-branchless-smartlog/tests/test_smartlog.rs
+++ b/git-branchless-smartlog/tests/test_smartlog.rs
@@ -183,6 +183,7 @@ fn test_merge_commit_reverse_order() -> eyre::Result<()> {
     let git = make_git()?;
 
     git.init_repo()?;
+    git.run(&["config", "branchless.smartlog.reverse", "true"])?;
     git.run(&["checkout", "-b", "test1", "master"])?;
     git.commit_file("test1", 1)?;
     git.run(&["checkout", "-b", "test2and3", "master"])?;
@@ -196,7 +197,7 @@ fn test_merge_commit_reverse_order() -> eyre::Result<()> {
         },
     )?;
 
-    let (stdout, _) = git.branchless("smartlog", &["--reverse"])?;
+    let (stdout, _) = git.branchless("smartlog", &[])?;
     insta::assert_snapshot!(stdout, @r###"
     @ fa4e4e1 (> test2and3) Merge branch 'test1' into test2and3
     |\
@@ -499,7 +500,7 @@ fn test_smartlog_hint_abandoned_except_current_commit() -> eyre::Result<()> {
     Ok(())
 }
 
-/// When --reverse is specified hints still appear at the end of output
+/// When branchless.smartlog.reverse is `true`, hints still appear at the end of output
 #[test]
 fn test_smartlog_hint_abandoned_reverse_order() -> eyre::Result<()> {
     let git = make_git()?;
@@ -508,6 +509,7 @@ fn test_smartlog_hint_abandoned_reverse_order() -> eyre::Result<()> {
         return Ok(());
     }
     git.init_repo()?;
+    git.run(&["config", "branchless.smartlog.reverse", "true"])?;
 
     git.detach_head()?;
     git.commit_file("test1", 1)?;
@@ -515,7 +517,7 @@ fn test_smartlog_hint_abandoned_reverse_order() -> eyre::Result<()> {
     git.run(&["checkout", "HEAD^"])?;
     git.run(&["commit", "--amend", "-m", "amended test1"])?;
 
-    let (stdout, _) = git.branchless("smartlog", &["--reverse"])?;
+    let (stdout, _) = git.branchless("smartlog", &[])?;
     insta::assert_snapshot!(stdout, @r###"
     o 96d1c37 create test2.txt
     |

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -317,9 +317,9 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::core::eventlog::from_event_log_db with effects=<Output fancy=false> repo=<Git repository at: "<repo-path>/.git/"> event_log_db=<EventLogDb path=Some("<repo-path>/.git/branchless/db.sqlite3")>
           at some/file/path.rs:123
-       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false, exact: false }
+       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, exact: false }
           at some/file/path.rs:123
-       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
           at some/file/path.rs:123
 
     Suggestion:

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -317,9 +317,9 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::core::eventlog::from_event_log_db with effects=<Output fancy=false> repo=<Git repository at: "<repo-path>/.git/"> event_log_db=<EventLogDb path=Some("<repo-path>/.git/branchless/db.sqlite3")>
           at some/file/path.rs:123
-       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, exact: false }
+       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false, exact: false }
           at some/file/path.rs:123
-       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
           at some/file/path.rs:123
 
     Suggestion:


### PR DESCRIPTION
My perspective, based on my own experience, is that folks generally stick to one log orientation/direction. In principle, the reverse flag can be incorporated by default via an alias, but this doesn’t catch the auto-smartlog that is emitted after some operations. 

This PR adds a Boolean configuration option that replaces the —reverse flag: branchless.smartlog.reverse

This is a breaking CLI change, so I don’t imagine this would incorporated as-is. However, I didn’t want to go too far down this path without considering your thoughts and opinions on how a configuration option may be incorporated. (Not to mention my very limited Rust experience 😅)

What do you think? Thanks for all your work on such a helpful tool!
