### PR TITLE
Fix for Bug #1321 - Support symbolic refs in tx lines for git 2.45

### DIFF
--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -698,6 +698,18 @@ impl Repo {
         }
     }
 
+    /// Get the OID for a given [ReferenceName] if it exists.
+    #[instrument]
+    pub fn reference_name_to_oid(&self, name: &ReferenceName) -> Result<MaybeZeroOid> {
+        match self.inner.refname_to_id(name.as_str()) {
+            Ok(git2_oid) => Ok(MaybeZeroOid::from(git2_oid)),
+            Err(source) => Err(Error::FindReference {
+                source,
+                name: name.clone(),
+            }),
+        }
+    }
+
     /// Set the `HEAD` reference directly to the provided `oid`. Does not touch
     /// the working copy.
     #[instrument]


### PR DESCRIPTION
In git 2.45, reference transactions now support symbolic refs (see:
https://github.com/git/git/commit/a8ae923f85da6434c3faf9c39719d6d5e5c77e65)

To support this, we add a transaction reference resolver that's capable of
looking up the Oid for a named reference. It requires a repository object to
do this successfully.

To support the functionality, a new `refname_to_id` function is added to the
Repo object that calls the similarly named method on the inner repository to
get the `git2::Oid` for a given reference name.