### PR TITLE
[3/7] feat(submit): support passing `--jobs`

### DIFF
--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -408,6 +408,11 @@ pub struct SubmitArgs {
     #[clap(short = 'm', long = "message")]
     pub message: Option<String>,
 
+    /// If the forge supports it, how many jobs to execute in parallel. The
+    /// value `0` indicates to use all CPUs.
+    #[clap(short = 'j', long = "jobs")]
+    pub num_jobs: Option<usize>,
+
     /// If the forge supports it and uses a tool that needs access to the
     /// working copy, what kind of execution strategy to use.
     #[clap(short = 's', long = "strategy")]

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -192,6 +192,7 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         create,
         draft,
         message,
+        num_jobs,
         execution_strategy,
         dry_run,
     } = args;
@@ -204,6 +205,7 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         create,
         draft,
         message,
+        num_jobs,
         execution_strategy,
         dry_run,
     )
@@ -218,6 +220,7 @@ fn submit(
     create: bool,
     draft: bool,
     message: Option<String>,
+    num_jobs: Option<usize>,
     execution_strategy: Option<TestExecutionStrategy>,
     dry_run: bool,
 ) -> EyreExitOr<()> {
@@ -253,7 +256,7 @@ fn submit(
         bisect: false,
         no_cache: true,
         interactive: false,
-        jobs: None,
+        jobs: num_jobs,
         verbosity: Verbosity::None,
         apply_fixes: false,
     };


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1353
* https://github.com/arxanas/git-branchless/pull/1354
* https://github.com/arxanas/git-branchless/pull/1355
* https://github.com/arxanas/git-branchless/pull/1356
* https://github.com/arxanas/git-branchless/pull/1202
* https://github.com/arxanas/git-branchless/pull/1357
* https://github.com/arxanas/git-branchless/pull/1358


---

feat(submit): support passing `--jobs`

This is currently used only by the Phabricator forge, which uses the `git test` infrastructure to run `arc` on several commits at once. I don't know how well it works when an error occurs.

