### PR TITLE
refactor(core): re-export formatting symbols from `cursive_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,6 @@ dependencies = [
  "bugreport",
  "color-eyre",
  "console",
- "cursive_core",
  "esl01-dag",
  "eyre",
  "fslock",
@@ -1475,7 +1474,6 @@ version = "0.9.0"
 dependencies = [
  "clap 4.5.7",
  "color-eyre",
- "cursive_core",
  "eyre",
  "git-branchless-lib",
  "git-branchless-opts",
@@ -1501,7 +1499,7 @@ dependencies = [
  "concolor",
  "console",
  "criterion",
- "cursive",
+ "cursive_core",
  "esl01-dag",
  "eyre",
  "futures",
@@ -1546,7 +1544,6 @@ dependencies = [
 name = "git-branchless-navigation"
 version = "0.9.0"
 dependencies = [
- "cursive",
  "esl01-dag",
  "eyre",
  "git-branchless-lib",
@@ -1588,8 +1585,6 @@ dependencies = [
 name = "git-branchless-record"
 version = "0.9.0"
 dependencies = [
- "cursive",
- "cursive_buffered_backend",
  "esl01-dag",
  "eyre",
  "git-branchless-invoke",
@@ -1651,7 +1646,6 @@ dependencies = [
 name = "git-branchless-smartlog"
 version = "0.9.0"
 dependencies = [
- "cursive_core",
  "esl01-dag",
  "eyre",
  "git-branchless-invoke",
@@ -1667,7 +1661,6 @@ name = "git-branchless-submit"
 version = "0.9.0"
 dependencies = [
  "clap 4.5.7",
- "cursive_core",
  "esl01-dag",
  "eyre",
  "git-branchless-invoke",
@@ -1696,7 +1689,6 @@ dependencies = [
  "bstr",
  "clap 4.5.7",
  "crossbeam",
- "cursive",
  "esl01-dag",
  "eyre",
  "fslock",

--- a/git-branchless-invoke/Cargo.toml
+++ b/git-branchless-invoke/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.9.0"
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
-cursive_core = { workspace = true }
 eyre = { workspace = true }
 git-branchless-opts = { workspace = true }
 git2 = { workspace = true }

--- a/git-branchless-invoke/src/lib.rs
+++ b/git-branchless-invoke/src/lib.rs
@@ -21,13 +21,11 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use clap::{CommandFactory, FromArgMatches, Parser};
-use cursive_core::theme::BaseColor;
-use cursive_core::utils::markup::StyledString;
 use eyre::Context;
 use git_branchless_opts::{ColorSetting, GlobalArgs};
 use lib::core::config::env_vars::{get_git_exec_path, get_path_to_git};
 use lib::core::effects::Effects;
-use lib::core::formatting::Glyphs;
+use lib::core::formatting::{BaseColor, Glyphs, StyledString};
 use lib::git::GitRunInfo;
 use lib::git::{Repo, RepoError};
 use lib::util::{ExitCode, EyreExitOr};

--- a/git-branchless-lib/Cargo.toml
+++ b/git-branchless-lib/Cargo.toml
@@ -51,7 +51,7 @@ chrono = { workspace = true }
 color-eyre = { workspace = true }
 concolor = { workspace = true }
 console = { workspace = true }
-cursive = { workspace = true }
+cursive_core = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }

--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -4,13 +4,12 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cursive::theme::BaseColor;
-use cursive::utils::markup::StyledString;
 use eyre::Context;
 use itertools::Itertools;
 use tracing::instrument;
 
 use crate::core::config::get_auto_switch_branches;
+use crate::core::formatting::{BaseColor, StyledString};
 use crate::git::{
     update_index, CategorizedReferenceName, GitRunInfo, MaybeZeroOid, NonZeroOid, ReferenceName,
     Repo, Stage, UpdateIndexCommand, WorkingCopySnapshot,

--- a/git-branchless-lib/src/core/config.rs
+++ b/git-branchless-lib/src/core/config.rs
@@ -4,12 +4,10 @@ use std::ffi::OsString;
 use std::fmt::Write;
 use std::path::PathBuf;
 
-use cursive::theme::{BaseColor, Effect, Style};
-use cursive::utils::markup::StyledString;
 use eyre::Context;
 use tracing::{instrument, warn};
 
-use crate::core::formatting::StyledStringBuilder;
+use crate::core::formatting::{BaseColor, Effect, Style, StyledString, StyledStringBuilder};
 use crate::git::{ConfigRead, GitRunInfo, GitRunOpts, Repo};
 
 use super::effects::Effects;

--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -6,9 +6,9 @@
 
 use std::fmt::Display;
 
-use cursive::theme::{Effect, Style};
-use cursive::utils::markup::StyledString;
-use cursive::utils::span::Span;
+pub use cursive_core::theme::{BaseColor, Color, ColorType, Effect, Style};
+pub use cursive_core::utils::markup::StyledString;
+pub use cursive_core::utils::span::Span;
 
 /// Pluralize a quantity, as appropriate. Example:
 ///
@@ -369,7 +369,6 @@ fn render_style_as_ansi(content: &str, style: Style) -> eyre::Result<String> {
     let Style { effects, color } = style;
     let output = {
         use console::style;
-        use cursive::theme::{BaseColor, Color, ColorType};
         let output = content.to_string();
         match color.front {
             ColorType::Palette(_) => {

--- a/git-branchless-lib/src/core/node_descriptors.rs
+++ b/git-branchless-lib/src/core/node_descriptors.rs
@@ -8,8 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use bstr::{ByteSlice, ByteVec};
-use cursive::theme::BaseColor;
-use cursive::utils::markup::StyledString;
 use lazy_static::lazy_static;
 use regex::Regex;
 use tracing::instrument;
@@ -18,14 +16,14 @@ use crate::core::config::{
     get_commit_descriptors_branches, get_commit_descriptors_differential_revision,
     get_commit_descriptors_relative_time,
 };
+use crate::core::eventlog::{Event, EventCursor, EventReplayer};
+use crate::core::formatting::Glyphs;
+use crate::core::formatting::{BaseColor, StyledString, StyledStringBuilder};
+use crate::core::repo_ext::RepoReferencesSnapshot;
+use crate::core::rewrite::find_rewrite_target;
 use crate::git::{
     CategorizedReferenceName, Commit, NonZeroOid, ReferenceName, Repo, ResolvedReferenceInfo,
 };
-
-use super::eventlog::{Event, EventCursor, EventReplayer};
-use super::formatting::{Glyphs, StyledStringBuilder};
-use super::repo_ext::RepoReferencesSnapshot;
-use super::rewrite::find_rewrite_target;
 
 /// An object which can be rendered in the smartlog.
 #[derive(Clone, Debug)]

--- a/git-branchless-lib/src/git/object.rs
+++ b/git-branchless-lib/src/git/object.rs
@@ -1,12 +1,10 @@
 use std::path::Path;
 
 use bstr::{BString, ByteSlice};
-use cursive::theme::BaseColor;
-use cursive::utils::markup::StyledString;
 use git2::message_trailers_bytes;
 use tracing::instrument;
 
-use crate::core::formatting::{Glyphs, StyledStringBuilder};
+use crate::core::formatting::{BaseColor, Glyphs, StyledString, StyledStringBuilder};
 use crate::core::node_descriptors::{
     render_node_descriptors, CommitMessageDescriptor, CommitOidDescriptor, NodeObject, Redactor,
 };

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -20,8 +20,6 @@ use std::{io, time};
 
 use bstr::ByteVec;
 use chrono::NaiveDateTime;
-use cursive::theme::BaseColor;
-use cursive::utils::markup::StyledString;
 use git2::DiffOptions;
 use itertools::Itertools;
 use thiserror::Error;
@@ -29,7 +27,7 @@ use tracing::{instrument, warn};
 
 use crate::core::effects::{Effects, OperationType};
 use crate::core::eventlog::EventTransactionId;
-use crate::core::formatting::Glyphs;
+use crate::core::formatting::{BaseColor, Glyphs, StyledString};
 use crate::git::config::{Config, ConfigRead};
 use crate::git::object::Blob;
 use crate::git::oid::{make_non_zero_oid, MaybeZeroOid, NonZeroOid};

--- a/git-branchless-navigation/Cargo.toml
+++ b/git-branchless-navigation/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/arxanas/git-branchless"
 version = "0.9.0"
 
 [dependencies]
-cursive = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 git-branchless-opts = { workspace = true }

--- a/git-branchless-navigation/src/lib.rs
+++ b/git-branchless-navigation/src/lib.rs
@@ -17,9 +17,6 @@ use std::ffi::OsString;
 use std::fmt::Write;
 use std::time::SystemTime;
 
-use cursive::theme::BaseColor;
-use cursive::utils::markup::StyledString;
-
 use lib::core::check_out::{check_out_commit, CheckOutCommitOptions, CheckoutTarget};
 use lib::core::repo_ext::RepoExt;
 use lib::util::{ExitCode, EyreExitOr};
@@ -32,7 +29,7 @@ use lib::core::config::get_next_interactive;
 use lib::core::dag::{sorted_commit_set, CommitSet, Dag};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{EventLogDb, EventReplayer};
-use lib::core::formatting::Pluralize;
+use lib::core::formatting::{BaseColor, Pluralize, StyledString};
 use lib::core::node_descriptors::{
     BranchesDescriptor, CommitMessageDescriptor, CommitOidDescriptor,
     DifferentialRevisionDescriptor, NodeDescriptor, Redactor, RelativeTimeDescriptor,

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -408,6 +408,11 @@ pub struct SubmitArgs {
     #[clap(short = 'm', long = "message")]
     pub message: Option<String>,
 
+    /// If the forge supports it, how many jobs to execute in parallel. The
+    /// value `0` indicates to use all CPUs.
+    #[clap(short = 'j', long = "jobs")]
+    pub num_jobs: Option<usize>,
+
     /// If the forge supports it and uses a tool that needs access to the
     /// working copy, what kind of execution strategy to use.
     #[clap(short = 's', long = "strategy")]

--- a/git-branchless-record/Cargo.toml
+++ b/git-branchless-record/Cargo.toml
@@ -7,8 +7,6 @@ repository = "https://github.com/arxanas/git-branchless"
 version = "0.9.0"
 
 [dependencies]
-cursive = { version = "0.20.0", default-features = false, features = [ "crossterm-backend", ] }
-cursive_buffered_backend = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 git-branchless-invoke = { workspace = true }

--- a/git-branchless-smartlog/Cargo.toml
+++ b/git-branchless-smartlog/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/arxanas/git-branchless"
 version = "0.9.0"
 
 [dependencies]
-cursive_core = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 git-branchless-invoke = { workspace = true }

--- a/git-branchless-smartlog/src/lib.rs
+++ b/git-branchless-smartlog/src/lib.rs
@@ -377,14 +377,13 @@ mod render {
     use std::cmp::Ordering;
     use std::collections::HashSet;
 
-    use cursive_core::theme::{BaseColor, Effect};
-    use cursive_core::utils::markup::StyledString;
     use tracing::instrument;
 
     use lib::core::dag::{CommitSet, Dag};
     use lib::core::effects::Effects;
-    use lib::core::formatting::{set_effect, Pluralize};
-    use lib::core::formatting::{Glyphs, StyledStringBuilder};
+    use lib::core::formatting::{
+        set_effect, BaseColor, Effect, Glyphs, Pluralize, StyledString, StyledStringBuilder,
+    };
     use lib::core::node_descriptors::{render_node_descriptors, NodeDescriptor};
     use lib::git::{NonZeroOid, Repo};
 

--- a/git-branchless-submit/Cargo.toml
+++ b/git-branchless-submit/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.9.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cursive_core = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 git-branchless-invoke = { workspace = true }

--- a/git-branchless-submit/src/github.rs
+++ b/git-branchless-submit/src/github.rs
@@ -5,8 +5,6 @@ use std::env;
 use std::fmt::{Debug, Write};
 use std::hash::Hash;
 
-use cursive_core::theme::Effect;
-use cursive_core::utils::markup::StyledString;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use lib::core::config::get_main_branch_name;
@@ -15,6 +13,7 @@ use lib::core::dag::Dag;
 use lib::core::effects::Effects;
 use lib::core::effects::OperationType;
 use lib::core::eventlog::EventLogDb;
+use lib::core::formatting::{Effect, StyledString};
 use lib::core::repo_ext::RepoExt;
 use lib::core::repo_ext::RepoReferencesSnapshot;
 use lib::git::CategorizedReferenceName;

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -186,13 +186,13 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         git_run_info,
     } = ctx;
     let SubmitArgs {
-        create,
-        draft,
-        strategy,
         revsets,
         resolve_revset_options,
-        forge,
+        forge_kind,
+        create,
+        draft,
         message,
+        execution_strategy,
         dry_run,
     } = args;
     submit(
@@ -200,11 +200,11 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         &git_run_info,
         revsets,
         &resolve_revset_options,
+        forge_kind,
         create,
         draft,
-        strategy,
-        forge,
         message,
+        execution_strategy,
         dry_run,
     )
 }
@@ -214,11 +214,11 @@ fn submit(
     git_run_info: &GitRunInfo,
     revsets: Vec<Revset>,
     resolve_revset_options: &ResolveRevsetOptions,
+    forge_kind: Option<ForgeKind>,
     create: bool,
     draft: bool,
-    execution_strategy: Option<TestExecutionStrategy>,
-    forge_kind: Option<ForgeKind>,
     message: Option<String>,
+    execution_strategy: Option<TestExecutionStrategy>,
     dry_run: bool,
 ) -> EyreExitOr<()> {
     let repo = Repo::from_current_dir()?;

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -18,7 +18,6 @@ use std::fmt::{Debug, Write};
 use std::time::SystemTime;
 
 use branch_forge::BranchForge;
-use cursive_core::theme::{BaseColor, Effect, Style};
 use git_branchless_invoke::CommandContext;
 use git_branchless_test::{RawTestOptions, ResolvedTestOptions, Verbosity};
 use github::GithubForge;
@@ -27,7 +26,9 @@ use lazy_static::lazy_static;
 use lib::core::dag::{union_all, CommitSet, Dag};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{EventLogDb, EventReplayer};
-use lib::core::formatting::{Pluralize, StyledStringBuilder};
+use lib::core::formatting::{
+    BaseColor, Effect, Pluralize, Style, StyledStringBuilder,
+};
 use lib::core::repo_ext::{RepoExt, RepoReferencesSnapshot};
 use lib::git::{GitRunInfo, NonZeroOid, Repo};
 use lib::try_exit_code;

--- a/git-branchless-submit/src/lib.rs
+++ b/git-branchless-submit/src/lib.rs
@@ -192,6 +192,7 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         create,
         draft,
         message,
+        num_jobs,
         execution_strategy,
         dry_run,
     } = args;
@@ -204,6 +205,7 @@ pub fn command_main(ctx: CommandContext, args: SubmitArgs) -> EyreExitOr<()> {
         create,
         draft,
         message,
+        num_jobs,
         execution_strategy,
         dry_run,
     )
@@ -218,6 +220,7 @@ fn submit(
     create: bool,
     draft: bool,
     message: Option<String>,
+    num_jobs: Option<usize>,
     execution_strategy: Option<TestExecutionStrategy>,
     dry_run: bool,
 ) -> EyreExitOr<()> {
@@ -253,7 +256,7 @@ fn submit(
         bisect: false,
         no_cache: true,
         interactive: false,
-        jobs: None,
+        jobs: num_jobs,
         verbosity: Verbosity::None,
         apply_fixes: false,
     };

--- a/git-branchless-submit/src/phabricator.rs
+++ b/git-branchless-submit/src/phabricator.rs
@@ -8,8 +8,6 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use cursive_core::theme::Effect;
-use cursive_core::utils::markup::StyledString;
 use git_branchless_opts::Revset;
 use git_branchless_test::{
     run_tests, FixInfo, ResolvedTestOptions, TestOutput, TestResults, TestStatus,
@@ -21,7 +19,10 @@ use lib::core::check_out::CheckOutCommitOptions;
 use lib::core::dag::{CommitSet, Dag};
 use lib::core::effects::{Effects, OperationType, WithProgress};
 use lib::core::eventlog::EventLogDb;
-use lib::core::formatting::StyledStringBuilder;
+use lib::core::formatting::{
+    Effect, StyledString,
+    StyledStringBuilder,
+};
 use lib::core::rewrite::{
     execute_rebase_plan, BuildRebasePlanError, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
     ExecuteRebasePlanResult, RebasePlanBuilder, RebasePlanPermissions, RepoResource,

--- a/git-branchless-submit/src/phabricator.rs
+++ b/git-branchless-submit/src/phabricator.rs
@@ -365,7 +365,7 @@ impl Forge for PhabricatorForge<'_> {
                 .map_err(|err| Error::VerifyPermissions { source: err })?
                 .map_err(Error::BuildRebasePlan)?;
         let command = if !should_mock() {
-            let mut args = vec!["arc", "diff", "--create", "--verbatim"];
+            let mut args = vec!["arc", "diff", "--create", "--verbatim", "--allow-untracked"];
             if *draft {
                 args.push("--draft");
             }
@@ -614,7 +614,14 @@ Differential Revision: https://phabricator.example.com/D000$(git rev-list --coun
                 .map_err(Error::BuildRebasePlan)?;
         let test_options = ResolvedTestOptions {
             command: if !should_mock() {
-                let mut args = vec!["arc", "diff", "--head", "HEAD", "HEAD^"];
+                let mut args = vec![
+                    "arc",
+                    "diff",
+                    "--head",
+                    "HEAD",
+                    "HEAD^",
+                    "--allow-untracked",
+                ];
                 args.extend(match message {
                     Some(message) => ["-m", message.as_ref()],
                     None => ["-m", "update"],

--- a/git-branchless-test/Cargo.toml
+++ b/git-branchless-test/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.9.0"
 bstr = { workspace = true }
 clap = { workspace = true }
 crossbeam = { workspace = true }
-cursive = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 fslock = { workspace = true }

--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -24,8 +24,6 @@ use std::time::SystemTime;
 use bstr::ByteSlice;
 use clap::ValueEnum;
 use crossbeam::channel::{Receiver, RecvError};
-use cursive::theme::{BaseColor, Effect, Style};
-use cursive::utils::markup::StyledString;
 
 use eyre::WrapErr;
 use fslock::LockFile;
@@ -43,7 +41,10 @@ use lib::core::effects::{icons, Effects, OperationIcon, OperationType};
 use lib::core::eventlog::{
     EventLogDb, EventReplayer, EventTransactionId, BRANCHLESS_TRANSACTION_ID_ENV_VAR,
 };
-use lib::core::formatting::{Glyphs, Pluralize, StyledStringBuilder};
+use lib::core::formatting::{
+    BaseColor, Effect, Glyphs, Pluralize, Style, StyledString,
+    StyledStringBuilder,
+};
 use lib::core::repo_ext::RepoExt;
 use lib::core::rewrite::{
     execute_rebase_plan, BuildRebasePlanOptions, ExecuteRebasePlanOptions, ExecuteRebasePlanResult,

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -21,31 +21,31 @@ use std::time::SystemTime;
 
 use cursive_core::event::Key;
 use cursive_core::traits::Resizable;
-use cursive_core::utils::markup::StyledString;
 use cursive_core::views::{
     Dialog, EditView, LinearLayout, OnEventView, Panel, ScrollView, TextView,
 };
 use cursive_core::{Cursive, CursiveRunner};
 use eyre::Context;
-use lib::core::check_out::{check_out_commit, CheckOutCommitOptions, CheckoutTarget};
-use lib::core::repo_ext::RepoExt;
-use lib::try_exit_code;
-use lib::util::{ExitCode, EyreExitOr};
 use tracing::instrument;
 
-use crate::tui::{with_siv, SingletonView};
 use git_branchless_revset::resolve_default_smartlog_commits;
 use git_branchless_smartlog::{make_smartlog_graph, render_graph};
+use lib::core::check_out::{check_out_commit, CheckOutCommitOptions, CheckoutTarget};
 use lib::core::dag::{CommitSet, Dag};
 use lib::core::effects::Effects;
 use lib::core::eventlog::{Event, EventCursor, EventLogDb, EventReplayer, EventTransactionId};
-use lib::core::formatting::{Glyphs, Pluralize, StyledStringBuilder};
+use lib::core::formatting::{Glyphs, Pluralize, StyledString, StyledStringBuilder};
 use lib::core::node_descriptors::{
     BranchesDescriptor, CommitMessageDescriptor, CommitOidDescriptor,
     DifferentialRevisionDescriptor, ObsolescenceExplanationDescriptor, Redactor,
     RelativeTimeDescriptor,
 };
+use lib::core::repo_ext::RepoExt;
 use lib::git::{CategorizedReferenceName, GitRunInfo, MaybeZeroOid, Repo, ResolvedReferenceInfo};
+use lib::try_exit_code;
+use lib::util::{ExitCode, EyreExitOr};
+
+use crate::tui::{with_siv, SingletonView};
 
 fn render_cursor_smartlog(
     effects: &Effects,
@@ -999,7 +999,8 @@ pub fn undo(
 pub mod testing {
     use std::io::Read;
 
-    use cursive_core::{Cursive, CursiveRunner};
+    pub use cursive_core::event::Key;
+    pub use cursive_core::{Cursive, CursiveRunner};
 
     use lib::core::dag::Dag;
     use lib::core::effects::Effects;

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -21,7 +21,6 @@ bstr = { workspace = true }
 bugreport = { workspace = true }
 color-eyre = { workspace = true }
 console = { workspace = true }
-cursive_core = { workspace = true }
 eden_dag = { workspace = true }
 eyre = { workspace = true }
 fslock = { workspace = true }

--- a/git-branchless/src/commands/snapshot.rs
+++ b/git-branchless/src/commands/snapshot.rs
@@ -4,12 +4,11 @@
 use std::fmt::Write;
 use std::time::SystemTime;
 
-use cursive_core::theme::BaseColor;
-use cursive_core::utils::markup::StyledString;
 use eyre::Context;
 use lib::core::check_out::{create_snapshot, restore_snapshot};
 use lib::core::effects::Effects;
 use lib::core::eventlog::EventLogDb;
+use lib::core::formatting::{BaseColor, StyledString};
 use lib::git::{GitRunInfo, GitRunResult, NonZeroOid, Repo, WorkingCopySnapshot};
 use lib::util::{ExitCode, EyreExitOr};
 

--- a/git-branchless/src/commands/sync.rs
+++ b/git-branchless/src/commands/sync.rs
@@ -1,6 +1,5 @@
 //! Implements the `git sync` command.
 
-use cursive_core::theme::BaseColor;
 use lib::try_exit_code;
 use std::fmt::Write;
 use std::time::SystemTime;
@@ -17,7 +16,7 @@ use lib::core::config::get_restack_preserve_timestamps;
 use lib::core::dag::{sorted_commit_set, union_all, CommitSet, Dag};
 use lib::core::effects::{Effects, OperationType, WithProgress};
 use lib::core::eventlog::{EventLogDb, EventReplayer};
-use lib::core::formatting::{Pluralize, StyledStringBuilder};
+use lib::core::formatting::{BaseColor, Pluralize, StyledStringBuilder};
 use lib::core::rewrite::{
     execute_rebase_plan, BuildRebasePlanError, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
     ExecuteRebasePlanResult, FailedMergeInfo, RebasePlan, RebasePlanBuilder, RebasePlanPermissions,

--- a/git-branchless/tests/test_undo.rs
+++ b/git-branchless/tests/test_undo.rs
@@ -2,7 +2,7 @@ use std::mem::swap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use git_branchless_undo::testing::{select_past_event, undo_events};
+use git_branchless_undo::testing::{select_past_event, undo_events, Cursive, CursiveRunner, Key};
 use git_branchless_undo::tui::testing::{
     screen_to_string, CursiveTestingBackend, CursiveTestingEvent,
 };
@@ -13,9 +13,6 @@ use lib::core::formatting::Glyphs;
 use lib::core::repo_ext::RepoExt;
 use lib::git::{GitRunInfo, GitVersion, Repo};
 use lib::testing::{make_git, trim_lines, Git, GitInitOptions, GitRunOptions};
-
-use cursive_core::event::Key;
-use cursive_core::{Cursive, CursiveRunner};
 use lib::util::ExitCode;
 
 fn run_select_past_event(


### PR DESCRIPTION
refactor(core): re-export formatting symbols from `cursive_core`

This should have been done from the beginning, since we operate on these symbols in several places for formatting. This would also help a migration away from `cursive`, since now only two modules have direct dependencies on `cursive`/`cursive_core`:

- git-branchless-lib for general output formatting.
- git-branchless-undo for the interactive undo UI.
