### PR TITLE
build: add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Current minimum-supported Rust version
+channel = "1.74"
+profile = "default"


### PR DESCRIPTION
build: add `rust-toolchain.toml`

It seems easier for contributors to get started if the compiler version is already configured; plus, this will presumably make it so that I don't have to set the Rust version with `rustup override` whenever I create a new worktree.
