### PR TITLE
fix: allow deleting a branch when config entries contain multivars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
@@ -2068,9 +2068,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ git-branchless-smartlog = { version = "0.9.0", path = "git-branchless-smartlog" 
 git-branchless-submit = { version = "0.9.0", path = "git-branchless-submit" }
 git-branchless-test = { version = "0.9.0", path = "git-branchless-test" }
 git-branchless-undo = { version = "0.9.0", path = "git-branchless-undo" }
-git2 = { version = "0.18.3", default-features = false }
+git2 = { version = "0.19.0", default-features = false }
 glob = "0.3.0"
 indexmap = "2.2.6"
 indicatif = { version = "0.17.8", features = ["improved_unicode"] }


### PR DESCRIPTION
The problem has been fixed in recent libgit2 releases, as included in git2-rs 0.19.

Fix #1200 

Note: this needs to be merged after #1392 in order for the CI to be green