### PR TITLE
fix: make tests independent of system locale

### DIFF
--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -191,6 +191,7 @@ impl Git {
             ("GIT_COMMITTER_DATE", date),
             ("GIT_EDITOR", git_editor),
             ("GIT_EXEC_PATH", self.git_exec_path.as_os_str().into()),
+            ("LC_ALL", "C".into()),
             ("PATH", new_path),
             (TEST_GIT, self.path_to_git.as_os_str().into()),
             (


### PR DESCRIPTION
At least on macOS, the tests are failing if the system locale is not set to English. This change pins the git locale to `C` so they work independent of the system locale.

Example test failure (macOS 14.6.1, German system locale):

```
────────────┬───────────────────────────────────────────────────────────────────
    0       │-HEAD detached from 96d1c37
    1       │-Changes to be committed:
    2       │-  (use "git restore --staged <file>..." to unstage)
    3       │-  new file:   test3.txt
          0 │+HEAD losgelöst von 96d1c37
          1 │+Zum Commit vorgemerkte Änderungen:
          2 │+  (benutzen Sie "git restore --staged <Datei>..." zum Entfernen aus der Staging-Area)
          3 │+  neue Datei:     test3.txt
    4     4 │
    5       │-Changes to be committed:
          5 │+Zum Commit vorgemerkte Änderungen:
    6     6 │ diff --git c/test3.txt i/test3.txt
    7     7 │ new file mode 100644
    8     8 │ index 0000000..4706e16
    9     9 │ --- /dev/null
────────────┴───────────────────────────────────────────────────────────────────
To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.
The application panicked (crashed).
Message:  snapshot assertion for 'amend_with_children-3' failed in line 45
Location: /private/tmp/nix-build-git-branchless-0.9.0.drv-0/git-branchless-0.9.0-vendor.tar.gz/insta/src/runtime.rs:563

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.


failures:
    test_amend_merge
    test_amend_with_children
    test_amend_with_working_copy

test result: FAILED. 12 passed; 3 failed; 0 ignored; 0 measured; 2 filtered out; finished in 6.94s

error: test failed, to rerun pass `--test test_amend`
```