### PR TITLE
fix(tests): ignore no-op checkouts in some tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "regex",
  "similar",
 ]
 

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -39,6 +39,7 @@ git-branchless-smartlog = { workspace = true }
 git-branchless-submit = { workspace = true }
 git-branchless-test = { workspace = true }
 git-branchless-undo = { workspace = true }
+insta = { workspace = true, features = ["filters"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 lib = { workspace = true }

--- a/git-branchless/tests/test_amend.rs
+++ b/git-branchless/tests/test_amend.rs
@@ -602,18 +602,16 @@ fn test_amend_undo() -> eyre::Result<()> {
         ]}, {
         insta::assert_snapshot!(stdout, @r###"
         Will apply these actions:
-        1. Move branch foo from 94b1077 create file1.txt
+        #. Move branch foo from 94b1077 create file1.txt
                              to 94b1077 create file1.txt
-        2. Check out from 94b1077 create file1.txt
-                       to 94b1077 create file1.txt
-        3. Restore snapshot for branch foo
+        #. Restore snapshot for branch foo
                     pointing to 94b1077 create file1.txt
                 backed up using b4371f8 branchless: automated working copy snapshot
-        4. Move branch foo from 94b1077 create file1.txt
+        #. Move branch foo from 94b1077 create file1.txt
                              to c0bdfb5 create file1.txt
-        5. Rewrite commit 94b1077 create file1.txt
+        #. Rewrite commit 94b1077 create file1.txt
                       as c0bdfb5 create file1.txt
-        6. Restore snapshot for branch foo
+        #. Restore snapshot for branch foo
                     pointing to c0bdfb5 create file1.txt
                 backed up using a293e0b branchless: automated working copy snapshot
         branchless: running command: <git-executable> checkout a293e0b4502882ced673f83b6742539ee06cbc74 -B foo
@@ -628,7 +626,7 @@ fn test_amend_undo() -> eyre::Result<()> {
         O f777ecc (master) create initial.txt
         |
         @ c0bdfb5 (> foo) create file1.txt
-        Applied 6 inverse events.
+        Applied # inverse events.
         "###);
         });
     }


### PR DESCRIPTION
This makes use of insta's `filters` feature.