### PR TITLE
feat(switch): accept revset arguments, and explicitly support `-` shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `scm-record` upgraded to [v0.5.0](https://github.com/arxanas/scm-record/releases/tag/v0.5.0).
+- (#1463): `git switch` now accepts a revset whose sole head will be checked out
 
 ## [v0.10.0] - 2024-10-10
 

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -938,6 +938,9 @@ impl Repo {
             return Err(Error::UnsupportedRevParseSpec(spec.to_owned()));
         }
 
+        // `libgit2` doesn't understand that `-` is short for `@{-1}`
+        let spec = if spec == "-" { "@{-1}" } else { spec };
+
         match self.inner.revparse_single(spec) {
             Ok(object) => match object.into_commit() {
                 Ok(commit) => Ok(Some(Commit { inner: commit })),

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -172,13 +172,15 @@ pub struct SwitchOptions {
 
     /// The commit or branch to check out.
     ///
+    /// If a revset is provided, it must evaluate to set with exactly 1 head.
+    ///
     /// If this is not provided, then interactive commit selection starts as
     /// if `--interactive` were passed.
     ///
     /// If this is provided and the `--interactive` flag is passed, this
     /// text is used to pre-fill the interactive commit selector.
     #[clap(value_parser)]
-    pub target: Option<String>,
+    pub target: Option<Revset>,
 }
 
 /// Internal use.

--- a/git-branchless/tests/test_navigation.rs
+++ b/git-branchless/tests/test_navigation.rs
@@ -909,6 +909,67 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
         "###);
     }
 
+    {
+        // switching back to "last checkout"
+        let (stdout, _stderr) = git.branchless("switch", &["@{-1}"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout @{-1}
+        O f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
+    }
+
+    {
+        // switching back to "last checkout"
+        let (stdout, _stderr) = git.branchless("switch", &["-"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout -
+        @ f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        o fe65c1f create test2.txt
+        "###);
+    }
+
+    {
+        // switching back to "last checkout" will also checkout last checked out
+        // branch, if any
+
+        let (stdout, _stderr) = git.branchless("switch", &["master"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout master
+        @ f777ecc (> master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        o fe65c1f create test2.txt
+        "###);
+
+        let (stdout, _stderr) = git.branchless("switch", &["@{-2}"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout @{-2}
+        O f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        @ fe65c1f create test2.txt
+        "###);
+
+        let (stdout, _stderr) = git.branchless("switch", &["-"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout -
+        @ f777ecc (> master) create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        |
+        o fe65c1f create test2.txt
+        "###);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This updated `git switch` to accept a revset as it's argument, and also to support `-` (to checkout previously checked out branch/commit) by passing it through to git.

The revset parameter must evaluate to a set with a single head, and I've found this handy in cases like `current(...)` to move to the latest version of a commit if I had an old smartlog or SHA still on screen or such, and also `switch foo:` for when I have a branch ref handy but I really want to checkout the latest detached commit in that stack.

But with revset support added, `switch -` broke because it looked a poorly formed revset:
```
Message:  A fatal error occurred:
   0: parse error in "-": parse error: Unrecognized token `-` found at 0:1
      Expected one of "(", "..", ":", "::", a commit/branch/tag or a string literal
   1: parse error: Unrecognized token `-` found at 0:1
      Expected one of "(", "..", ":", "::", a commit/branch/tag or a string literal
```
The last commit in this stack adds an explicit check for `-` so that this support is restored. 

Apparently, `revparse_single()` in `libgit2` doesn't support this. ~~I didn't patch `-` support into `repo.revparse_single_commit()` but I'm thinking as I write this that perhaps that may be better? There is already a special case in that function to work around another `libgit2` issue, and I suppose we could detect if the passed spec is `-` and then pass `@{-1}` to `revparse_single()` instead. 🤔 ~~ **edit** I made this change and it seems to be working.
