### PR TITLE
feat: add `split` command

### DIFF
--- a/git-branchless-init/src/lib.rs
+++ b/git-branchless-init/src/lib.rs
@@ -95,6 +95,7 @@ const ALL_ALIASES: &[(&str, &str)] = &[
     ("restack", "restack"),
     ("reword", "reword"),
     ("sl", "smartlog"),
+    ("split", "split"),
     ("smartlog", "smartlog"),
     ("submit", "submit"),
     ("sw", "switch"),

--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -44,6 +44,9 @@ pub struct CheckOutCommitOptions {
     /// Additional arguments to pass to `git checkout`.
     pub additional_args: Vec<OsString>,
 
+    /// Ignore the `autoSwitchBranches` setting?
+    pub force_detach: bool,
+
     /// Use `git reset` rather than `git checkout`; that is, leave the index and
     /// working copy unchanged, and just adjust the `HEAD` pointer.
     pub reset: bool,
@@ -56,6 +59,7 @@ impl Default for CheckOutCommitOptions {
     fn default() -> Self {
         Self {
             additional_args: Default::default(),
+            force_detach: false,
             reset: false,
             render_smartlog: true,
         }
@@ -116,6 +120,7 @@ pub fn check_out_commit(
 ) -> EyreExitOr<()> {
     let CheckOutCommitOptions {
         additional_args,
+        force_detach,
         reset,
         render_smartlog,
     } = options;
@@ -134,7 +139,7 @@ pub fn check_out_commit(
         create_snapshot(effects, git_run_info, repo, event_log_db, event_tx_id)?;
     }
 
-    let target = if get_auto_switch_branches(repo)? && !reset {
+    let target = if get_auto_switch_branches(repo)? && !reset && !force_detach {
         maybe_get_branch_name(target, oid, repo)?
     } else {
         target

--- a/git-branchless-lib/src/git/index.rs
+++ b/git-branchless-lib/src/git/index.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::core::eventlog::EventTransactionId;
 
-use super::{FileMode, GitRunInfo, GitRunOpts, GitRunResult, MaybeZeroOid, NonZeroOid, Repo};
+use super::{FileMode, GitRunInfo, GitRunOpts, GitRunResult, MaybeZeroOid, NonZeroOid, Repo, Tree};
 
 /// The possible stages for items in the index.
 #[derive(Copy, Clone, Debug)]
@@ -87,6 +87,12 @@ impl Index {
                     FileMode::from(mode)
                 },
             })
+    }
+
+    /// Update the index from the given tree and write it to disk.
+    pub fn update_from_tree(&mut self, tree: &Tree) -> eyre::Result<()> {
+        self.inner.read_tree(&tree.inner)?;
+        self.inner.write().wrap_err("writing index")
     }
 }
 

--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -14,7 +14,7 @@ mod test;
 mod tree;
 
 pub use config::{Config, ConfigRead, ConfigValue, ConfigWrite};
-pub use diff::{process_diff_for_record, Diff};
+pub use diff::{process_diff_for_record, summarize_diff_for_temporary_commit, Diff};
 pub use index::{update_index, Index, IndexEntry, Stage, UpdateIndexCommand};
 pub use object::Commit;
 pub use oid::{MaybeZeroOid, NonZeroOid};

--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -34,4 +34,6 @@ pub use test::{
     make_test_command_slug, SerializedNonZeroOid, SerializedTestResult, TestCommand,
     TEST_ABORT_EXIT_CODE, TEST_INDETERMINATE_EXIT_CODE, TEST_SUCCESS_EXIT_CODE,
 };
-pub use tree::{dehydrate_tree, get_changed_paths_between_trees, hydrate_tree, Tree};
+pub use tree::{
+    dehydrate_tree, get_changed_paths_between_trees, hydrate_tree, make_empty_tree, Tree,
+};

--- a/git-branchless-lib/src/git/status.rs
+++ b/git-branchless-lib/src/git/status.rs
@@ -88,6 +88,20 @@ impl From<git2::FileMode> for FileMode {
     }
 }
 
+impl From<FileMode> for git2::FileMode {
+    fn from(file_mode: FileMode) -> Self {
+        match file_mode {
+            FileMode::Blob => git2::FileMode::Blob,
+            FileMode::BlobExecutable => git2::FileMode::BlobExecutable,
+            FileMode::BlobGroupWritable => git2::FileMode::BlobGroupWritable,
+            FileMode::Commit => git2::FileMode::Commit,
+            FileMode::Link => git2::FileMode::Link,
+            FileMode::Tree => git2::FileMode::Tree,
+            FileMode::Unreadable => git2::FileMode::Unreadable,
+        }
+    }
+}
+
 impl From<i32> for FileMode {
     fn from(file_mode: i32) -> Self {
         if file_mode == i32::from(git2::FileMode::Blob) {

--- a/git-branchless-lib/src/git/tree.rs
+++ b/git-branchless-lib/src/git/tree.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use bstr::ByteVec;
+use git2::build::TreeUpdateBuilder;
 use itertools::Itertools;
 use thiserror::Error;
 use tracing::{instrument, warn};
@@ -114,6 +115,31 @@ impl Tree<'_> {
     pub fn get_oid_for_path(&self, path: &Path) -> Result<Option<MaybeZeroOid>> {
         self.get_path(path)
             .map(|maybe_entry| maybe_entry.map(|entry| entry.inner.id().into()))
+    }
+
+    /// Remove the given path from the Tree, creating a new Tree in the given repo.
+    pub fn remove(&self, repo: &Repo, path: &Path) -> Result<NonZeroOid> {
+        let mut builder = TreeUpdateBuilder::new();
+        let tree_oid = builder
+            .remove(path)
+            .create_updated(&repo.inner, &self.inner)
+            .map_err(Error::BuildTree)?;
+        Ok(make_non_zero_oid(tree_oid))
+    }
+
+    /// Add or replace the given path/entry from the Tree, creating a new Tree in the given repo.
+    pub fn add_or_replace(
+        &self,
+        repo: &Repo,
+        path: &Path,
+        entry: &TreeEntry,
+    ) -> Result<NonZeroOid> {
+        let mut builder = TreeUpdateBuilder::new();
+        let tree_oid = builder
+            .upsert(path, entry.get_oid().into(), entry.get_filemode().into())
+            .create_updated(&repo.inner, &self.inner)
+            .map_err(Error::BuildTree)?;
+        Ok(make_non_zero_oid(tree_oid))
     }
 
     /// Get the (top-level) list of paths in this tree, for testing.
@@ -456,6 +482,7 @@ pub fn hydrate_tree(
     Ok(make_non_zero_oid(tree_oid))
 }
 
+/// Create a new, empty Tree in the given Repo.
 pub fn make_empty_tree(repo: &Repo) -> Result<Tree<'_>> {
     let tree_oid = hydrate_tree(repo, None, Default::default())?;
     repo.find_tree_or_fail(tree_oid)

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -81,6 +81,9 @@ pub struct GitRunOptions {
 
     /// Additional environment variables to start the process with.
     pub env: HashMap<String, String>,
+
+    /// Subdirectory of repo to use as working directory.
+    pub subdir: Option<PathBuf>,
 }
 
 impl Git {
@@ -217,8 +220,14 @@ impl Git {
             expected_exit_code,
             input,
             env,
+            subdir,
         } = options;
 
+        let current_dir = subdir.as_ref().map_or(self.repo_path.clone(), |subdir| {
+            let mut p = self.repo_path.clone();
+            p.push(subdir);
+            p
+        });
         let env: BTreeMap<_, _> = self
             .get_base_env(*time)
             .into_iter()
@@ -229,7 +238,7 @@ impl Git {
             .collect();
         let mut command = Command::new(&self.path_to_git);
         command
-            .current_dir(&self.repo_path)
+            .current_dir(&current_dir)
             .args(args)
             .env_clear()
             .envs(&env);

--- a/git-branchless-lib/tests/test_rewrite_plan.rs
+++ b/git-branchless-lib/tests/test_rewrite_plan.rs
@@ -762,6 +762,7 @@ fn create_and_execute_plan(
         resolve_merge_conflicts: true,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
+            force_detach: false,
             reset: false,
             render_smartlog: false,
         },

--- a/git-branchless-navigation/src/lib.rs
+++ b/git-branchless-navigation/src/lib.rs
@@ -617,6 +617,7 @@ pub fn switch(
         target,
         &CheckOutCommitOptions {
             additional_args,
+            force_detach: false,
             reset: false,
             render_smartlog: true,
         },

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -663,8 +663,12 @@ pub enum Command {
         files: Vec<String>,
 
         /// Restack any descendents onto the split commit, not the extracted commit.
-        #[clap(action, short = 'd', long = "detach")]
+        #[clap(action, short = 'd', long)]
         detach: bool,
+
+        /// After extracting the changes, don't recommit them.
+        #[clap(action, short = 'D', long = "discard", conflicts_with("detach"))]
+        discard: bool,
 
         /// Options for resolving revset expressions.
         #[clap(flatten)]

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -662,6 +662,10 @@ pub enum Command {
         #[clap(value_parser, required = true)]
         files: Vec<String>,
 
+        /// Restack any descendents onto the split commit, not the extracted commit.
+        #[clap(action, short = 'd', long = "detach")]
+        detach: bool,
+
         /// Options for resolving revset expressions.
         #[clap(flatten)]
         resolve_revset_options: ResolveRevsetOptions,

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -652,6 +652,25 @@ pub enum Command {
         subcommand: SnapshotSubcommand,
     },
 
+    /// Split commits.
+    Split {
+        /// Commit to split. If a revset is given, it must resolve to a single commit.
+        #[clap(value_parser)]
+        revset: Revset,
+
+        /// Files to extract from the commit.
+        #[clap(value_parser, required = true)]
+        files: Vec<String>,
+
+        /// Options for resolving revset expressions.
+        #[clap(flatten)]
+        resolve_revset_options: ResolveRevsetOptions,
+
+        /// Options for moving commits.
+        #[clap(flatten)]
+        move_options: MoveOptions,
+    },
+
     /// Push commits to a remote.
     Submit(SubmitArgs),
 

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -662,6 +662,10 @@ pub enum Command {
         #[clap(value_parser, required = true)]
         files: Vec<String>,
 
+        /// Insert the extracted commit before (as a parent of) the split commit.
+        #[clap(action, short = 'b', long)]
+        before: bool,
+
         /// Restack any descendents onto the split commit, not the extracted commit.
         #[clap(action, short = 'd', long)]
         detach: bool,

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -129,6 +129,7 @@ fn record(
             None,
             &CheckOutCommitOptions {
                 additional_args: vec![OsString::from("-b"), OsString::from(branch_name)],
+                force_detach: false,
                 reset: false,
                 render_smartlog: false,
             },
@@ -227,6 +228,7 @@ fn record(
                 checkout_target,
                 &CheckOutCommitOptions {
                     additional_args: vec![],
+                    force_detach: false,
                     reset: false,
                     render_smartlog: false,
                 },

--- a/git-branchless-reword/src/lib.rs
+++ b/git-branchless-reword/src/lib.rs
@@ -292,6 +292,7 @@ pub fn reword(
         resolve_merge_conflicts: false,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
+            force_detach: false,
             reset: false,
             render_smartlog: false,
         },

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -743,6 +743,7 @@ fn extract_checkout_target(
                     target: CheckoutTarget::Oid(*new_oid),
                     options: CheckOutCommitOptions {
                         additional_args: vec!["--detach".into()],
+                        force_detach: false,
                         reset: false,
                         render_smartlog: true,
                     },
@@ -766,6 +767,7 @@ fn extract_checkout_target(
                             }
                             None => Default::default(),
                         },
+                        force_detach: false,
                         reset: false,
                         render_smartlog: true,
                     },
@@ -1077,6 +1079,7 @@ mod tests {
                         additional_args: [
                             "--detach",
                         ],
+                        force_detach: false,
                         reset: false,
                         render_smartlog: true,
                     },

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -112,6 +112,9 @@ name = "test_reword"
 name = "test_snapshot"
 
 [[test]]
+name = "test_split"
+
+[[test]]
 name = "test_sync"
 
 [[test]]

--- a/git-branchless/src/commands/amend.rs
+++ b/git-branchless/src/commands/amend.rs
@@ -203,6 +203,7 @@ pub fn amend(
             Some(target),
             &CheckOutCommitOptions {
                 additional_args: Default::default(),
+                force_detach: false,
                 reset: true,
                 render_smartlog: false,
             },
@@ -297,6 +298,7 @@ pub fn amend(
             resolve_merge_conflicts: move_options.resolve_merge_conflicts,
             check_out_commit_options: CheckOutCommitOptions {
                 additional_args: Default::default(),
+                force_detach: false,
                 reset: false,
                 render_smartlog: false,
             },

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -181,6 +181,7 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
         },
 
         Command::Split {
+            before,
             detach,
             discard,
             files,
@@ -188,11 +189,15 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
             revset,
             move_options,
         } => {
-            let split_mode = match (detach, discard) {
-                (true, false) => split::SplitMode::DetachAfter,
-                (false, true) => split::SplitMode::Discard,
-                (false, false) => split::SplitMode::InsertAfter,
-                (true, true) => {
+            let split_mode = match (before, detach, discard) {
+                (false, true, false) => split::SplitMode::DetachAfter,
+                (false, false, true) => split::SplitMode::Discard,
+                (false, false, false) => split::SplitMode::InsertAfter,
+                (true, false, false) => split::SplitMode::InsertBefore,
+                (true, true, false)
+                | (true, false, true)
+                | (false, true, true)
+                | (true, true, true) => {
                     unreachable!("clap should prevent this")
                 }
             };

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod hide;
 mod repair;
 mod restack;
 mod snapshot;
+mod split;
 mod sync;
 mod wrap;
 
@@ -178,6 +179,20 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
                 snapshot::restore(&effects, &git_run_info, snapshot_oid)?
             }
         },
+
+        Command::Split {
+            files,
+            resolve_revset_options,
+            revset,
+            move_options,
+        } => split::split(
+            &effects,
+            revset,
+            &resolve_revset_options,
+            files,
+            &move_options,
+            &git_run_info,
+        )?,
 
         Command::Submit(args) => git_branchless_submit::command_main(ctx, args)?,
 

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -181,18 +181,27 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
         },
 
         Command::Split {
+            detach,
             files,
             resolve_revset_options,
             revset,
             move_options,
-        } => split::split(
-            &effects,
-            revset,
-            &resolve_revset_options,
-            files,
-            &move_options,
-            &git_run_info,
-        )?,
+        } => {
+            let split_mode = match detach {
+                true => split::SplitMode::DetachAfter,
+                false => split::SplitMode::InsertAfter,
+            };
+
+            split::split(
+                &effects,
+                revset,
+                &resolve_revset_options,
+                files,
+                split_mode,
+                &move_options,
+                &git_run_info,
+            )?
+        }
 
         Command::Submit(args) => git_branchless_submit::command_main(ctx, args)?,
 

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -182,14 +182,19 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
 
         Command::Split {
             detach,
+            discard,
             files,
             resolve_revset_options,
             revset,
             move_options,
         } => {
-            let split_mode = match detach {
-                true => split::SplitMode::DetachAfter,
-                false => split::SplitMode::InsertAfter,
+            let split_mode = match (detach, discard) {
+                (true, false) => split::SplitMode::DetachAfter,
+                (false, true) => split::SplitMode::Discard,
+                (false, false) => split::SplitMode::InsertAfter,
+                (true, true) => {
+                    unreachable!("clap should prevent this")
+                }
             };
 
             split::split(

--- a/git-branchless/src/commands/restack.rs
+++ b/git-branchless/src/commands/restack.rs
@@ -328,6 +328,7 @@ pub fn restack(
         resolve_merge_conflicts,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
+            force_detach: false,
             reset: false,
             render_smartlog: false,
         },

--- a/git-branchless/src/commands/split.rs
+++ b/git-branchless/src/commands/split.rs
@@ -1,0 +1,451 @@
+//! Split commits, extracting changes from a single commit into separate commits.
+
+use eyre::Context;
+use rayon::ThreadPoolBuilder;
+use std::{
+    fmt::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use git_branchless_opts::{MoveOptions, ResolveRevsetOptions, Revset};
+use git_branchless_revset::resolve_commits;
+use lib::{
+    core::{
+        check_out::{check_out_commit, CheckOutCommitOptions, CheckoutTarget},
+        config::get_restack_preserve_timestamps,
+        dag::{CommitSet, Dag},
+        effects::Effects,
+        eventlog::{Event, EventLogDb, EventReplayer},
+        gc::mark_commit_reachable,
+        repo_ext::RepoExt,
+        rewrite::{
+            execute_rebase_plan, move_branches, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
+            ExecuteRebasePlanResult, MergeConflictRemediation, RebasePlanBuilder,
+            RebasePlanPermissions, RepoResource,
+        },
+    },
+    git::{
+        make_empty_tree, CherryPickFastOptions, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
+        ResolvedReferenceInfo,
+    },
+    try_exit_code,
+    util::{ExitCode, EyreExitOr},
+};
+use tracing::instrument;
+
+/// Split a commit and restack its descendants.
+#[instrument]
+pub fn split(
+    effects: &Effects,
+    revset: Revset,
+    resolve_revset_options: &ResolveRevsetOptions,
+    files_to_extract: Vec<String>,
+    move_options: &MoveOptions,
+    git_run_info: &GitRunInfo,
+) -> EyreExitOr<()> {
+    let repo = Repo::from_current_dir()?;
+    let references_snapshot = repo.get_references_snapshot()?;
+    let conn = repo.get_db_conn()?;
+    let event_log_db = EventLogDb::new(&conn)?;
+    let event_replayer = EventReplayer::from_event_log_db(effects, &repo, &event_log_db)?;
+    let event_cursor = event_replayer.make_default_cursor();
+    let mut dag = Dag::open_and_sync(
+        effects,
+        &repo,
+        &event_replayer,
+        event_cursor,
+        &references_snapshot,
+    )?;
+    let now = SystemTime::now();
+    let event_tx_id = event_log_db.make_transaction_id(now, "split")?;
+    let pool = ThreadPoolBuilder::new().build()?;
+    let repo_pool = RepoResource::new_pool(&repo)?;
+
+    let MoveOptions {
+        force_rewrite_public_commits,
+        force_in_memory,
+        force_on_disk,
+        detect_duplicate_commits_via_patch_id,
+        resolve_merge_conflicts,
+        dump_rebase_constraints,
+        dump_rebase_plan,
+    } = *move_options;
+
+    let target_oid: NonZeroOid = match resolve_commits(
+        effects,
+        &repo,
+        &mut dag,
+        &[revset.clone()],
+        resolve_revset_options,
+    ) {
+        Ok(commit_sets) => match dag.commit_set_to_vec(&commit_sets[0])?.as_slice() {
+            [only_commit_oid] => *only_commit_oid,
+            other => {
+                let Revset(expr) = revset;
+                writeln!(
+                    effects.get_error_stream(),
+                    "Expected revset to expand to exactly 1 commit (got {count}): {expr}",
+                    count = other.len(),
+                )?;
+                return Ok(Err(ExitCode(1)));
+            }
+        },
+        Err(err) => {
+            err.describe(effects)?;
+            return Ok(Err(ExitCode(1)));
+        }
+    };
+
+    let permissions = match RebasePlanPermissions::verify_rewrite_set(
+        &dag,
+        BuildRebasePlanOptions {
+            force_rewrite_public_commits,
+            dump_rebase_constraints,
+            dump_rebase_plan,
+            detect_duplicate_commits_via_patch_id,
+        },
+        &vec![target_oid].into_iter().collect(),
+    )? {
+        Ok(permissions) => permissions,
+        Err(err) => {
+            err.describe(effects, &repo, &dag)?;
+            return Ok(Err(ExitCode(1)));
+        }
+    };
+
+    let target_commit = repo.find_commit_or_fail(target_oid)?;
+    let target_tree = target_commit.get_tree()?;
+    let parent_commits = target_commit.get_parents();
+    let (parent_tree, mut remainder_tree) = match parent_commits.as_slice() {
+        // split the commit by removing the changes from the target, and then
+        // cherry picking the orignal target as the "extracted" commit
+        [only_parent] => (only_parent.get_tree()?, target_commit.get_tree()?),
+
+        // no parent: use an empty tree for comparison
+        [] => (make_empty_tree(&repo)?, target_commit.get_tree()?),
+
+        [..] => {
+            writeln!(
+                effects.get_error_stream(),
+                "Cannot split merge commit {}.",
+                target_oid
+            )?;
+            return Ok(Err(ExitCode(1)));
+        }
+    };
+
+    let mut message = match files_to_extract.as_slice() {
+        [] => unreachable!("Clap should have required at least 1 file"),
+        [_] => None,
+        other => Some(format!("{} files", other.len())),
+    };
+
+    let cwd = std::env::current_dir()?;
+    // tuple: (input_file, resolved_path)
+    let resolved_paths_to_extract: eyre::Result<Vec<(String, PathBuf)>> = files_to_extract
+        .into_iter()
+        .map(|file| {
+            let path = Path::new(&file).to_path_buf();
+            let working_copy_path = match repo.get_working_copy_path() {
+                Some(working_copy_path) => working_copy_path,
+                None => {
+                    eyre::bail!("Aborting. Split is not supported in bare root repositories.",)
+                }
+            };
+
+            let path = if cwd != working_copy_path && path.exists() {
+                let mut repo_relative_path = match cwd.strip_prefix(working_copy_path) {
+                    Ok(working_copy_path) => working_copy_path.to_path_buf(),
+                    Err(_) => {
+                        eyre::bail!(
+                            "Error: current working directory is not in the working copy.\n\
+                                            This may be a bug, please report it.",
+                        );
+                    }
+                };
+                repo_relative_path.push(path);
+                repo_relative_path
+            } else if let Some(stripped_filename) = file.strip_prefix(":/") {
+                // https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emltngtltpathgtemegem0READMEememREADMEem
+                Path::new(stripped_filename).to_path_buf()
+            } else {
+                path
+            };
+
+            Ok((file, path))
+        })
+        .collect();
+
+    let resolved_paths_to_extract = match resolved_paths_to_extract {
+        Ok(resolved_paths_to_extract) => resolved_paths_to_extract,
+        Err(err) => {
+            writeln!(effects.get_error_stream(), "{err}")?;
+            return Ok(Err(ExitCode(1)));
+        }
+    };
+
+    for (file, path) in resolved_paths_to_extract.iter() {
+        let path = path.as_path();
+        message = message.or(Some(path.to_string_lossy().to_string()));
+
+        if let Ok(Some(false)) = target_commit.contains_touched_path(path) {
+            writeln!(
+                effects.get_error_stream(),
+                "Aborting: file '{filename}' was not changed in commit {oid}.",
+                filename = path.to_string_lossy(),
+                oid = target_commit.get_short_oid()?
+            )?;
+            return Ok(Err(ExitCode(1)));
+        }
+
+        let parent_entry = match parent_tree.get_path(path) {
+            Ok(entry) => entry,
+            Err(err) => {
+                writeln!(
+                    effects.get_error_stream(),
+                    "uh oh error reading tree entry: {err}.",
+                )?;
+                return Ok(Err(ExitCode(1)));
+            }
+        };
+
+        let target_entry = target_tree.get_path(path)?;
+        let temp_tree_oid = match (parent_entry, target_entry) {
+            // added => remove from remainder commit
+            (None, Some(_)) => remainder_tree.remove(&repo, path)?,
+
+            // deleted or modified => replace w/ parent content in split commit
+            (Some(parent_entry), _) => remainder_tree.add_or_replace(&repo, path, &parent_entry)?,
+
+            (None, _) => {
+                if path.exists() {
+                    writeln!(
+                        effects.get_error_stream(),
+                        "Aborting: the file '{file}' could not be found in this repo.\nPerhaps it's not under version control?",
+                    )?;
+                } else {
+                    writeln!(
+                        effects.get_error_stream(),
+                        "Aborting: the file '{file}' does not exist.",
+                    )?;
+                }
+                return Ok(Err(ExitCode(1)));
+            }
+        };
+
+        remainder_tree = repo
+            .find_tree(temp_tree_oid)?
+            .expect("should have been found");
+    }
+    let message = message.expect("at least 1 file should have been given");
+
+    let remainder_commit_oid =
+        target_commit.amend_commit(None, None, None, None, Some(&remainder_tree))?;
+    let remainder_commit = repo.find_commit_or_fail(remainder_commit_oid)?;
+
+    if remainder_commit.is_empty() {
+        writeln!(
+            effects.get_error_stream(),
+            "Aborting: refusing to split all changes out of commit {oid}.",
+            oid = target_commit.get_short_oid()?,
+        )?;
+        return Ok(Err(ExitCode(1)));
+    };
+
+    event_log_db.add_events(vec![Event::RewriteEvent {
+        timestamp: now.duration_since(UNIX_EPOCH)?.as_secs_f64(),
+        event_tx_id,
+        old_commit_oid: MaybeZeroOid::NonZero(target_oid),
+        new_commit_oid: MaybeZeroOid::NonZero(remainder_commit_oid),
+    }])?;
+
+    let extracted_commit_oid = {
+        let extracted_tree = repo.cherry_pick_fast(
+            &target_commit,
+            &remainder_commit,
+            &CherryPickFastOptions {
+                reuse_parent_tree_if_possible: true,
+            },
+        )?;
+        let extracted_commit_oid = repo.create_commit(
+            None,
+            &target_commit.get_author(),
+            &target_commit.get_committer(),
+            format!("temp(split): {message}").as_str(),
+            &extracted_tree,
+            vec![&remainder_commit],
+        )?;
+
+        // see git-branchless/src/commands/amend.rs:172
+        // TODO maybe this should happen after we've confirmed the rebase has succeeded
+        mark_commit_reachable(&repo, extracted_commit_oid)
+            .wrap_err("Marking commit as reachable for GC purposes.")?;
+
+        event_log_db.add_events(vec![Event::CommitEvent {
+            timestamp: now.duration_since(UNIX_EPOCH)?.as_secs_f64(),
+            event_tx_id,
+            commit_oid: extracted_commit_oid,
+        }])?;
+
+        Some(extracted_commit_oid)
+    };
+
+    // push the new commits into the dag for the rebase planner
+    dag.sync_from_oids(
+        effects,
+        &repo,
+        CommitSet::empty(),
+        match extracted_commit_oid {
+            None => CommitSet::from(remainder_commit_oid),
+            Some(extracted_commit_oid) => vec![remainder_commit_oid, extracted_commit_oid]
+                .into_iter()
+                .collect(),
+        },
+    )?;
+
+    enum TargetState {
+        /// A checked out, detached HEAD
+        DetachedHead,
+        /// A checked out branch
+        CurrentBranch,
+        /// Any other non-checked out commit
+        Other,
+    }
+
+    let head_info = repo.get_head_info()?;
+    let target_state = match head_info {
+        ResolvedReferenceInfo {
+            oid: Some(oid),
+            reference_name: Some(_),
+        } if oid == target_oid => TargetState::CurrentBranch,
+        ResolvedReferenceInfo {
+            oid: Some(oid),
+            reference_name: None,
+        } if oid == target_oid => TargetState::DetachedHead,
+        ResolvedReferenceInfo {
+            oid: _,
+            reference_name: _,
+        } => TargetState::Other,
+    };
+
+    #[derive(Debug)]
+    struct CleanUp {
+        checkout_target: Option<CheckoutTarget>,
+        rewritten_oids: Vec<(NonZeroOid, MaybeZeroOid)>,
+    }
+
+    let cleanup = match (target_state, extracted_commit_oid) {
+        // branch @ split commit checked out: extend branch to include extracted
+        // commit; branch will stay checked out w/o any explicit checkout
+        (TargetState::CurrentBranch, Some(extracted_commit_oid)) => CleanUp {
+            checkout_target: None,
+            rewritten_oids: vec![(target_oid, MaybeZeroOid::NonZero(extracted_commit_oid))],
+        },
+
+        // commit to split checked out as detached HEAD, don't extend any
+        // branches, but explicitly check out the newly split commit
+        (TargetState::DetachedHead, _) => CleanUp {
+            checkout_target: Some(CheckoutTarget::Oid(remainder_commit_oid)),
+            rewritten_oids: vec![(target_oid, MaybeZeroOid::NonZero(remainder_commit_oid))],
+        },
+
+        // some other commit or branch was checked out, default behavior is fine
+        (TargetState::CurrentBranch, _) | (TargetState::Other, _) => CleanUp {
+            checkout_target: None,
+            rewritten_oids: vec![(target_oid, MaybeZeroOid::NonZero(remainder_commit_oid))],
+        },
+    };
+
+    let CleanUp {
+        checkout_target,
+        rewritten_oids,
+    } = cleanup;
+
+    move_branches(
+        effects,
+        git_run_info,
+        &repo,
+        event_tx_id,
+        &(rewritten_oids.into_iter().collect()),
+    )?;
+
+    if checkout_target.is_some() {
+        try_exit_code!(check_out_commit(
+            effects,
+            git_run_info,
+            &repo,
+            &event_log_db,
+            event_tx_id,
+            checkout_target,
+            &CheckOutCommitOptions {
+                additional_args: Default::default(),
+                force_detach: true,
+                reset: false,
+                render_smartlog: false,
+            },
+        )?);
+    }
+
+    let mut builder = RebasePlanBuilder::new(&dag, permissions);
+    let children = dag.query_children(CommitSet::from(target_oid))?;
+    for child in dag.commit_set_to_vec(&children)? {
+        match extracted_commit_oid {
+            None => builder.move_subtree(child, vec![remainder_commit_oid])?,
+            Some(extracted_commit_oid) => {
+                builder.move_subtree(child, vec![extracted_commit_oid])?
+            }
+        }
+    }
+    let rebase_plan = builder.build(effects, &pool, &repo_pool)?;
+
+    let result = match rebase_plan {
+        Ok(None) => {
+            writeln!(effects.get_output_stream(), "Nothing to restack.")?;
+            None
+        }
+        Ok(Some(rebase_plan)) => {
+            let options = ExecuteRebasePlanOptions {
+                now,
+                event_tx_id,
+                preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
+                force_in_memory,
+                force_on_disk,
+                resolve_merge_conflicts,
+                check_out_commit_options: CheckOutCommitOptions {
+                    additional_args: Default::default(),
+                    force_detach: false,
+                    reset: false,
+                    render_smartlog: false,
+                },
+            };
+            Some(execute_rebase_plan(
+                effects,
+                git_run_info,
+                &repo,
+                &event_log_db,
+                &rebase_plan,
+                &options,
+            )?)
+        }
+        Err(err) => {
+            err.describe(effects, &repo, &dag)?;
+            return Ok(Err(ExitCode(1)));
+        }
+    };
+
+    match result {
+        None | Some(ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ }) => {
+            try_exit_code!(git_run_info
+                .run_direct_no_wrapping(Some(event_tx_id), &["branchless", "smartlog"])?);
+            Ok(Ok(()))
+        }
+
+        Some(ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info }) => {
+            failed_merge_info.describe(effects, &repo, MergeConflictRemediation::Retry)?;
+            Ok(Err(ExitCode(1)))
+        }
+
+        Some(ExecuteRebasePlanResult::Failed { exit_code }) => Ok(Err(exit_code)),
+    }
+}

--- a/git-branchless/src/commands/sync.rs
+++ b/git-branchless/src/commands/sync.rs
@@ -94,6 +94,7 @@ pub fn sync(
         resolve_merge_conflicts,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
+            force_detach: false,
             reset: false,
             render_smartlog: false,
         },

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -737,6 +737,9 @@ fn test_install_man_pages() -> eyre::Result<()> {
     git\-branchless\-smartlog(1)
     `smartlog` command
     .TP
+    git\-branchless\-split(1)
+    Split commits
+    .TP
     git\-branchless\-submit(1)
     Push commits to a remote
     .TP

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -32,7 +32,7 @@ fn test_split_detached_head() -> eyre::Result<()> {
             |
             @ 2932db7 first commit
             |
-            o c159d6a temp(split): test2.txt
+            o 01523cc temp(split): test2.txt (+1)
         "###);
     }
 
@@ -91,7 +91,7 @@ fn test_split_added_file() -> eyre::Result<()> {
             |
             @ 2f9e232 first commit
             |
-            o 067feb9 temp(split): test2.txt
+            o c4b067e temp(split): test2.txt (+1)
         "###);
     }
 
@@ -148,7 +148,7 @@ fn test_split_modified_file() -> eyre::Result<()> {
             |
             @ 495b4c0 first commit
             |
-            o 590b05e temp(split): test1.txt
+            o 5375cb6 temp(split): test1.txt (+1/-1)
         "###);
     }
 
@@ -215,7 +215,7 @@ fn test_split_deleted_file() -> eyre::Result<()> {
             |
             @ 495b4c0 first commit
             |
-            o bfc063a temp(split): test1.txt
+            o de6e4df temp(split): test1.txt (-1)
         "###);
     }
 
@@ -268,7 +268,7 @@ fn test_split_multiple_files() -> eyre::Result<()> {
             |
             @ 8e5c74b first commit
             |
-            o 0b1f3c6 temp(split): 2 files
+            o 57020b0 temp(split): 2 files (+2)
         "###);
     }
 
@@ -324,7 +324,7 @@ fn test_split_detached_branch() -> eyre::Result<()> {
             |
             @ 2932db7 (branch-name) first commit
             |
-            o c159d6a temp(split): test2.txt
+            o 01523cc temp(split): test2.txt (+1)
         "###);
     }
 
@@ -368,7 +368,7 @@ fn test_split_attached_branch() -> eyre::Result<()> {
             |
             o 2932db7 first commit
             |
-            @ c159d6a (> branch-name) temp(split): test2.txt
+            @ 01523cc (> branch-name) temp(split): test2.txt (+1)
         "###);
 
         let (stdout, _stderr) = git.run(&["status", "--short"])?;
@@ -407,17 +407,17 @@ fn test_split_restacks_descendents() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
             Attempting rebase in-memory...
-            [1/1] Committed as: 71d03a3 create test3.txt
+            [1/1] Committed as: a629a22 create test3.txt
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 71d03a33c534eda4253fc8772a4c0d5e9515127c
+            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
             o 2932db7 first commit
             |
-            o c159d6a temp(split): test2.txt
+            o 01523cc temp(split): test2.txt (+1)
             |
-            @ 71d03a3 create test3.txt
+            @ a629a22 create test3.txt
         "###);
     }
 
@@ -468,17 +468,17 @@ fn test_split_undo_works() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
             Attempting rebase in-memory...
-            [1/1] Committed as: 71d03a3 create test3.txt
+            [1/1] Committed as: a629a22 create test3.txt
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 71d03a33c534eda4253fc8772a4c0d5e9515127c
+            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
             o 2932db7 first commit
             |
-            o c159d6a temp(split): test2.txt
+            o 01523cc temp(split): test2.txt (+1)
             |
-            @ 71d03a3 create test3.txt
+            @ a629a22 create test3.txt
         "###);
     }
 
@@ -561,7 +561,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             |
             @ d9d41a3 first commit
             |
-            o fc76a91 temp(split): subdir/test3.txt
+            o 98da165 temp(split): subdir/test3.txt (+1)
         "###);
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
@@ -593,7 +593,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             |
             @ 0cb8154 first commit
             |
-            o 5d2c1d0 temp(split): subdir/test1.txt
+            o 89564a0 temp(split): subdir/test1.txt (+1)
         "###);
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
@@ -625,7 +625,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             |
             @ 9122046 first commit
             |
-            o ba3abaf temp(split): test2.txt
+            o c3d37e6 temp(split): test2.txt (+1)
         "###);
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
@@ -657,7 +657,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             |
             @ 6d0cd9b first commit
             |
-            o 2f03a38 temp(split): test1.txt
+            o 9eeb11b temp(split): test1.txt (+1)
         "###);
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -440,6 +440,69 @@ fn test_split_restacks_descendents() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_split_detach() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    git.commit_file("test3", 1)?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 3d220e0 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--detach"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: f88fbe5 create test3.txt
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout f88fbe5901493ffe1c669cdb8aa5f056dc0bb605
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o 2932db7 first commit
+            |\
+            | o 01523cc temp(split): test2.txt (+1)
+            |
+            @ f88fbe5 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+
+        let (split_commit, _stderr) = git.run(&["query", "--raw", "exactly(siblings(HEAD), 1)"])?;
+        let (stdout, _stderr) =
+            git.run(&["show", "--pretty=format:", "--stat", split_commit.trim()])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_split_undo_works() -> eyre::Result<()> {
     let git = make_git()?;
     git.init_repo()?;

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -1,0 +1,745 @@
+use std::path::PathBuf;
+
+use lib::testing::{make_git, GitRunOptions};
+
+#[test]
+fn test_split_detached_head() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ e48cdc5 first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 2932db7 first commit
+            |
+            o c159d6a temp(split): test2.txt
+        "###);
+    }
+
+    {
+        git.branchless("next", &[])?;
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_added_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.commit_file("test1", 1)?;
+
+    git.write_file_txt("test1", "updated contents")?;
+    git.write_file_txt("test2", "new contents")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 0f6059d first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 2f9e232b389b1bc8035f4e5bde79f262c0af020c
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 2f9e232 first commit
+            |
+            o 067feb9 temp(split): test2.txt
+        "###);
+    }
+
+    {
+        git.branchless("next", &[])?;
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_modified_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.commit_file("test1", 1)?;
+    git.write_file_txt("test1", "updated contents")?;
+    git.write_file_txt("test2", "new contents")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 0f6059d first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 495b4c0 first commit
+            |
+            o 590b05e temp(split): test1.txt
+        "###);
+    }
+
+    {
+        git.branchless("next", &[])?;
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_deleted_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.commit_file("test1", 1)?;
+
+    git.delete_file("test1")?;
+    git.write_file_txt("test2", "new contents")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 94e9c28 first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 -
+            test2.txt | 1 +
+            2 files changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 495b4c0 first commit
+            |
+            o bfc063a temp(split): test1.txt
+        "###);
+    }
+
+    {
+        git.branchless("next", &[])?;
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 -
+            1 file changed, 1 deletion(-)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_multiple_files() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ e48cdc5 first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "test3.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 8e5c74b7a1f09fc7ee1754763c810e3f00fe9b05
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 8e5c74b first commit
+            |
+            o 0b1f3c6 temp(split): 2 files
+        "###);
+    }
+
+    {
+        git.branchless("next", &[])?;
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_detached_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+    git.run(&["branch", "branch-name"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ e48cdc5 (branch-name) first commit
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: processing 1 update: branch branch-name
+            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 2932db7 (branch-name) first commit
+            |
+            o c159d6a temp(split): test2.txt
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_attached_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+    git.run(&["switch", "-c", "branch-name"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ e48cdc5 (> branch-name) first commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["status"])?;
+        insta::assert_snapshot!(&stdout, @"
+            On branch branch-name
+            nothing to commit, working tree clean
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: processing 1 update: branch branch-name
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            o 2932db7 first commit
+            |
+            @ c159d6a (> branch-name) temp(split): test2.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["status", "--short"])?;
+        insta::assert_snapshot!(&stdout, @r#""#);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_restacks_descendents() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    git.commit_file("test3", 1)?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 3d220e0 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: 71d03a3 create test3.txt
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout 71d03a33c534eda4253fc8772a4c0d5e9515127c
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o 2932db7 first commit
+            |
+            o c159d6a temp(split): test2.txt
+            |
+            @ 71d03a3 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_undo_works() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    git.commit_file("test3", 1)?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 3d220e0 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: 71d03a3 create test3.txt
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout 71d03a33c534eda4253fc8772a4c0d5e9515127c
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o 2932db7 first commit
+            |
+            o c159d6a temp(split): test2.txt
+            |
+            @ 71d03a3 create test3.txt
+        "###);
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    {
+        let (_stdout, _stderr) = git.branchless("undo", &["--yes"])?;
+
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+            O f777ecc (master) create initial.txt
+            |
+            o e48cdc5 first commit
+            |
+            @ 3d220e0 create test3.txt
+            "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "root contents1")?;
+    git.write_file_txt("test2", "root contents2")?;
+    git.write_file_txt("subdir/test1", "subdir contents1")?;
+    git.write_file_txt("subdir/test3", "subdir contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 2998051 first commit
+        "###);
+    }
+
+    {
+        // test3.txt only exists in subdir
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", "test3.txt"],
+            &GitRunOptions {
+                subdir: Some(PathBuf::from("subdir")),
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout d9d41a308e25a71884831c865c356da43cc5294e
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ d9d41a3 first commit
+            |
+            o fc76a91 temp(split): subdir/test3.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            subdir/test1.txt | 1 +
+            test1.txt        | 1 +
+            test2.txt        | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+    }
+
+    {
+        // test1.txt exists in root and subdir; try to resolve relative to cwd
+
+        git.branchless("undo", &["--yes"])?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", "test1.txt"],
+            &GitRunOptions {
+                subdir: Some(PathBuf::from("subdir")),
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 0cb81546d386a2064603c05ce7dc9759591f5a93
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 0cb8154 first commit
+            |
+            o 5d2c1d0 temp(split): subdir/test1.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            subdir/test3.txt | 1 +
+            test1.txt        | 1 +
+            test2.txt        | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+    }
+
+    {
+        // test2.txt only exists in root; resolve it relative to root
+
+        git.branchless("undo", &["--yes"])?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", "test2.txt"],
+            &GitRunOptions {
+                subdir: Some(PathBuf::from("subdir")),
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 912204674dfda3ab5fe089dddd1c9bf17b3c2965
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 9122046 first commit
+            |
+            o ba3abaf temp(split): test2.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            subdir/test1.txt | 1 +
+            subdir/test3.txt | 1 +
+            test1.txt        | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+    }
+
+    {
+        // test1.txt exists in root and subdir; support : to resolve relative to root
+
+        git.branchless("undo", &["--yes"])?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", ":/test1.txt"],
+            &GitRunOptions {
+                subdir: Some(PathBuf::from("subdir")),
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stdout, @r###"
+            branchless: running command: <git-executable> checkout 6d0cd9b8fb1938e50250f30427a0d4865b351f2f
+            Nothing to restack.
+            O f777ecc (master) create initial.txt
+            |
+            @ 6d0cd9b first commit
+            |
+            o 2f03a38 temp(split): test1.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            subdir/test1.txt | 1 +
+            subdir/test3.txt | 1 +
+            test2.txt        | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_unchanged_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 8e5c74b first commit
+        "###);
+    }
+
+    {
+        let (_stdout, stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", "initial.txt"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stderr, @r###"
+            Aborting: file 'initial.txt' was not changed in commit 8e5c74b.
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_will_not_split_to_empty_commit() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 8e5c74b first commit
+        "###);
+    }
+
+    {
+        let (_stdout, stderr) = git.branchless_with_options(
+            "split",
+            &["HEAD", "test1.txt"],
+            &GitRunOptions {
+                expected_exit_code: 1,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(&stderr, @r###"
+            Aborting: refusing to split all changes out of commit 8e5c74b.
+        "###);
+    }
+
+    Ok(())
+}

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -739,6 +739,358 @@ fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_split_insert_before_added_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    // new files
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    // modified file
+    git.commit_file("test3", 1)?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 3d220e0 create test3.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test3.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--before"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/2] Committed as: 7014c04 first commit
+            [2/2] Committed as: 22bd240 create test3.txt
+            branchless: processing 2 rewritten commits
+            branchless: running command: <git-executable> checkout 22bd2405a4660938b88615fb2b1283bfa2a52f8e
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o d02e8c5 temp(split): test2.txt (+1)
+            |
+            o 7014c04 first commit
+            |
+            @ 22bd240 create test3.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_insert_before_modified_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    // new files
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    // modified files
+    git.write_file_txt("test2", "contents2 again")?;
+    git.write_file_txt("test3", "contents3 again")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "second commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 7249f22 second commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 2 +-
+            test3.txt | 2 +-
+            2 files changed, 2 insertions(+), 2 deletions(-)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: 38fe8b7 second commit
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout 38fe8b76f889772efd0dd5cc1acb6ac02c85f9fb
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o e48cdc5 first commit
+            |
+            o 188b0a1 temp(split): test2.txt (+1/-1)
+            |
+            @ 38fe8b7 second commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test3.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_insert_before_deleted_file() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    // new files
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    // modified files
+    git.delete_file("test2")?;
+    git.write_file_txt("test3", "contents3 again")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "second commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 98ebe2f second commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 -
+            test3.txt | 2 +-
+            2 files changed, 1 insertion(+), 2 deletions(-)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: f8502a2 second commit
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout f8502a26000b8f90597f6861d7f3c0330fdf4351
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o e48cdc5 first commit
+            |
+            o e5b771d temp(split): test2.txt (-1)
+            |
+            @ f8502a2 second commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 -
+            1 file changed, 1 deletion(-)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test3.txt | 2 +-
+            1 file changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_insert_before_attached_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+    git.run(&["switch", "-c", "branch-name"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 4d11d02 (> branch-name) first commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: c678b65 first commit
+            branchless: processing 1 update: branch branch-name
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout branch-name
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o d02e8c5 temp(split): test2.txt (+1)
+            |
+            @ c678b65 (> branch-name) first commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_split_insert_before_detached_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+    git.run(&["branch", "branch-name"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 4d11d02 (branch-name) first commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
+        insta::assert_snapshot!(&stdout, @r###"
+            Attempting rebase in-memory...
+            [1/1] Committed as: c678b65 first commit
+            branchless: processing 1 update: branch branch-name
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout c678b6529d8f33a6903e25f70327464bd77f1ca1
+            In-memory rebase succeeded.
+            O f777ecc (master) create initial.txt
+            |
+            o d02e8c5 temp(split): test2.txt (+1)
+            |
+            @ c678b65 (branch-name) first commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test2.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_split_undo_works() -> eyre::Result<()> {
     let git = make_git()?;
     git.init_repo()?;


### PR DESCRIPTION
This adds a `git split` command to extract changes from commits. This mostly addresses #180, except for the `-i/--interactive` part. The split and rebase happens in-memory, so it should be fast. The command signature is

`git [branchless] split <revset> <file> [<file>...]`

- `<revset>` must resolve to a single commit (or just be a single commit, or `@`, etc)
- if only one file is given, then the file name is used in the extracted commit message
- if 2+ files are split out, then `<n> files` is used in the extracted commit message
- in either case, a brief insert/delete summary is also used, eg `(+2/-5)`
  - eg `temp(split): lib.rs (+5)` or `temp(split): 3 files (+3/-3)`

#### Implemented flags

These alter how the split/rebase happens:

- _default_ (no flags) is "insert after": extracted changes are inserted into commit graph as a child of the target commit
  - any children of the target commit are rebased onto the extracted commit
  - eg `A - B - C` → `A - B' - b - C`
- `--detach`: similar to above, but
  - children of the target commit are rebased onto the _newly split target_ commit, not onto the extracted commit
  - eg `A - B - C` → `A - B' - C` and `B' - b`
  - that is: `b` and `C` are now both children of `B'`
- `--discard`: similar to `--detach`, but after extracting the changes, they are simply discarded
  - eg `A - B - C` → `A - B' - C`
- `--before`: the extracted changes are inserted as a parent of the newly split target commit
  - children of the target commit are rebased onto the _newly split target_ commit
  - eg `A - B - C` → `A - b - B' - C`
- with `--detach` and `--discard`, rebase conflicts are possible, and are  intended to be resolved in the same way are for `git move` conflicts

#### Status

This is "works for me" and has been stable and useful over months of personal testing. That said, the code is mostly OK, but there are still a few FIXME/TODOs to resolve, and I'm certain that the code could be more idiomatic or branchless
in general. I have written a bunch of tests, but it's possible that I have overlooked some edges.

Any and all feedback is welcome. I'm happy with this as is, but I'm looking forward to some review helping me be really proud of it. =)

#### Specific areas needing feedback and review

- The temporary commit messages. Style, format, etc. The code that generates  them feels sort of complicated; maybe it's not pulling its weight, and we  should use a simpler or more familiar option?
- The structure and flow of the business logic still confuses me a bit, and I  suspect I'm overlooking some simplifications. For example, the variable names  used for the new commits (`extracted_commit` and `remainder_commit`) feel good, but they  actually mean the opposite if the `--before` flag is passed. :shrug: I've  commented this to explain, but I'm hoping someone else will have some  suggestions.
- I introduced a `force_detach` field to `CheckOutCommitOptions` in order to alter the behavior of the "automatically checkout branch" feature. This is because I was having issues w/ a detached branch becoming attached/checked out after being split. This seems like something that may not be needed, but it's the best that I could come up with at this time. If it *is* unnecessary, it's a self-contained change (commit 972d430 `refactor: add force_detach checkout option`) with good test coverage in other commands as well as in this new command, so it should be straightforward to back out later.,
