### PR TITLE
build: bump git2 0.19 -> 0.20 to unlock ^ref spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -2100,9 +2100,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ git-branchless-smartlog = { version = "0.10.0", path = "git-branchless-smartlog"
 git-branchless-submit = { version = "0.10.0", path = "git-branchless-submit" }
 git-branchless-test = { version = "0.10.0", path = "git-branchless-test" }
 git-branchless-undo = { version = "0.10.0", path = "git-branchless-undo" }
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.0", default-features = false }
 glob = "0.3.2"
 indexmap = "2.7.0"
 indicatif = { version = "0.17.9", features = ["improved_unicode"] }

--- a/git-branchless-invoke/src/lib.rs
+++ b/git-branchless-invoke/src/lib.rs
@@ -117,12 +117,12 @@ fn install_tracing(effects: Effects) -> eyre::Result<impl Drop> {
 
 #[instrument]
 fn install_libgit2_tracing() {
-    fn git_trace(level: git2::TraceLevel, msg: &str) {
-        info!("[{:?}]: {}", level, msg);
+    fn git_trace(level: git2::TraceLevel, msg: &[u8]) {
+        info!("[{:?}]: {}", level, String::from_utf8_lossy(msg));
     }
 
-    if !git2::trace_set(git2::TraceLevel::Trace, git_trace) {
-        warn!("Failed to install libgit2 tracing");
+    if let Err(err) = git2::trace_set(git2::TraceLevel::Trace, git_trace) {
+        warn!("Failed to install libgit2 tracing: {err}");
     }
 }
 


### PR DESCRIPTION
Closes #1444.

This depends on libgit2 1.9.0 which is contained in git2 0.20.