### PR TITLE
ci: use MSRV for lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.74
           components: rustfmt, clippy
           override: true
 


### PR DESCRIPTION
The lint job has always been run against Rust stable, but all other CI jobs use MSRV, and all lints have recently started failing with same issue as in #1585 (inability to build an outdated dependency on current stable).