### PR TITLE
build: update MSRV to 1.85

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.74
           components: rustfmt, clippy
           override: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74
+          toolchain: 1.85
           components: rustfmt, clippy
           override: true
 

--- a/.github/workflows/linux-git-devel.yml
+++ b/.github/workflows/linux-git-devel.yml
@@ -1,4 +1,4 @@
-name: "Linux (Git devel)"
+name: 'Linux (Git devel)'
 
 on:
   # TODO(#1416): re-enable once tests are passing on Git v2.46+
@@ -54,7 +54,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74
+          toolchain: 1.85
           override: true
 
       - uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Use a tag from https://github.com/git/git/tags
         # Make sure to update `git-version` in the `run-tests` step as well.
-        git-version: ["v2.24.3", "v2.29.2", "v2.33.1", "v2.37.3"]
+        git-version: ['v2.24.3', 'v2.29.2', 'v2.33.1', 'v2.37.3']
 
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
       - name: Package Git
         run: tar -czf git.tar.gz git git-*
 
-      - name: "Upload artifact: git"
+      - name: 'Upload artifact: git'
         uses: actions/upload-artifact@v4
         with:
           name: git-${{ matrix.git-version }}
@@ -58,23 +58,23 @@ jobs:
 
     strategy:
       matrix:
-        git-version: ["v2.24.3", "v2.29.2", "v2.33.1", "v2.37.3"]
+        git-version: ['v2.24.3', 'v2.29.2', 'v2.33.1', 'v2.37.3']
 
     steps:
       - uses: actions/checkout@v4
-      - name: "Download artifact: git"
+      - name: 'Download artifact: git'
         uses: actions/download-artifact@v4
         with:
           name: git-${{ matrix.git-version }}
 
-      - name: "Unpack artifact: git"
+      - name: 'Unpack artifact: git'
         run: tar -xf git.tar.gz
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74
+          toolchain: 1.85
           override: true
 
       - name: Cache dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macOS
 on:
   schedule:
     # Run once every day at 6:40AM UTC.
-    - cron: "40 6 * * *"
+    - cron: '40 6 * * *'
 
   push:
     branches:
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74
+          toolchain: 1.85
           override: true
 
       - name: Cache dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74
+          toolchain: 1.85
           override: true
 
       - name: Cache dependencies

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,10 +2,10 @@ image:
   file: .gitpod/Dockerfile
 tasks:
   - init: |
-      rustup default 1.74
+      rustup default 1.85
       cargo test --no-run
       cargo install cargo-insta
       cargo install git-branchless && git branchless init
 vscode:
   extensions:
-    - "matklad.rust-analyzer"
+    - 'matklad.rust-analyzer'

--- a/git-branchless/Cargo.toml
+++ b/git-branchless/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "git-branchless"
 readme = "../README.md"
 repository = "https://github.com/arxanas/git-branchless"
-rust-version = "1.74"
+rust-version = "1.85"
 version = "0.10.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -64,9 +64,9 @@ man-pages = []
 
 [package.metadata.release]
 pre-release-replacements = [
-  { file = "../CHANGELOG.md", search = "Unreleased", replace = "{{version}}", min = 1 },
-  { file = "../CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}", min = 1 },
-  { file = "../CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly = 1 },
+    { file = "../CHANGELOG.md", search = "Unreleased", replace = "{{version}}", min = 1 },
+    { file = "../CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}", min = 1 },
+    { file = "../CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly = 1 },
 ]
 
 [[test]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Current minimum-supported Rust version
-channel = "1.74"
+channel = "1.85"
 profile = "default"


### PR DESCRIPTION
We are currently pinned to 1.74 which is from late 2023. This updates us to 1.85 (early 2025) which is currently about 6 months old and matches the current MSRV of `jj`.

TBD I need to look in the context of when we last updated our MSRV (in e87ab50) to see if we should use a different version. (ie maybe we should continue following `clap` instead of `jj`)

Ref: e87ab50