### PR TITLE
feat(move): add --dry-run to support testing in-memory rebases

### DIFF
--- a/git-branchless-lib/tests/test_rewrite_plan.rs
+++ b/git-branchless-lib/tests/test_rewrite_plan.rs
@@ -759,6 +759,7 @@ fn create_and_execute_plan(
         preserve_timestamps: false,
         force_in_memory: false,
         force_on_disk: false,
+        dry_run: false,
         resolve_merge_conflicts: true,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -550,6 +550,10 @@ pub enum Command {
         /// Only supported if the moved subtree has a single head.
         #[clap(action, short = 'I', long = "insert")]
         insert: bool,
+
+        /// Test whether an in-memory rebase would succeed.
+        #[clap(action, long = "dry-run", conflicts_with = "force_on_disk")]
+        dry_run: bool,
     },
 
     /// Move to a later commit in the current stack.

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -554,6 +554,7 @@ To proceed anyways, run: git move -f -s 'siblings(.)",
         preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
         force_in_memory: true,
         force_on_disk: false,
+        dry_run: false,
         resolve_merge_conflicts: false,
         check_out_commit_options: Default::default(),
     };
@@ -566,7 +567,8 @@ To proceed anyways, run: git move -f -s 'siblings(.)",
         &execute_options,
     )?;
     match result {
-        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => Ok(Ok(())),
+        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ }
+        | ExecuteRebasePlanResult::WouldSucceed => Ok(Ok(())),
         ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info } => {
             failed_merge_info.describe(effects, &repo, MergeConflictRemediation::Insert)?;
             Ok(Ok(()))

--- a/git-branchless-reword/src/lib.rs
+++ b/git-branchless-reword/src/lib.rs
@@ -289,6 +289,7 @@ pub fn reword(
         preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
         force_in_memory: true,
         force_on_disk: false,
+        dry_run: false,
         resolve_merge_conflicts: false,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
@@ -315,7 +316,8 @@ pub fn reword(
         }
         ExecuteRebasePlanResult::Succeeded {
             rewritten_oids: None,
-        } => Ok(Ok(())),
+        }
+        | ExecuteRebasePlanResult::WouldSucceed => Ok(Ok(())),
         ExecuteRebasePlanResult::DeclinedToMerge {
             failed_merge_info: _,
         } => {

--- a/git-branchless-submit/src/phabricator.rs
+++ b/git-branchless-submit/src/phabricator.rs
@@ -354,6 +354,7 @@ impl Forge for PhabricatorForge<'_> {
             preserve_timestamps: true,
             force_in_memory: true,
             force_on_disk: false,
+            dry_run: false,
             resolve_merge_conflicts: false,
             check_out_commit_options: CheckOutCommitOptions {
                 render_smartlog: false,
@@ -485,7 +486,8 @@ Differential Revision: https://phabricator.example.com/D000$(git rev-list --coun
             } => rewritten_oids,
             ExecuteRebasePlanResult::Succeeded {
                 rewritten_oids: None,
-            } => {
+            }
+            | ExecuteRebasePlanResult::WouldSucceed => {
                 warn!("No rewritten commit OIDs were produced by rebase plan execution");
                 Default::default()
             }
@@ -602,6 +604,7 @@ Differential Revision: https://phabricator.example.com/D000$(git rev-list --coun
             preserve_timestamps: true,
             force_in_memory: true,
             force_on_disk: false,
+            dry_run: false,
             resolve_merge_conflicts: false,
             check_out_commit_options: CheckOutCommitOptions {
                 render_smartlog: false,

--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -411,6 +411,7 @@ BUG: Expected resolved_interactive ({resolved_interactive:?}) to match interacti
                 preserve_timestamps: get_restack_preserve_timestamps(repo)?,
                 force_in_memory,
                 force_on_disk: *force_on_disk,
+                dry_run: false,
                 resolve_merge_conflicts: *resolve_merge_conflicts,
                 check_out_commit_options: CheckOutCommitOptions {
                     render_smartlog: false,
@@ -726,6 +727,7 @@ fn set_abort_trap(
             preserve_timestamps: true,
             force_in_memory: false,
             force_on_disk: true,
+            dry_run: false,
             resolve_merge_conflicts: false,
             check_out_commit_options: CheckOutCommitOptions {
                 render_smartlog: false,
@@ -733,7 +735,8 @@ fn set_abort_trap(
             },
         },
     )? {
-        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => {
+        ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ }
+        | ExecuteRebasePlanResult::WouldSucceed => {
             // Do nothing.
         }
         ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info } => {
@@ -2091,6 +2094,7 @@ fn apply_fixes(
             execute_options,
         )? {
             ExecuteRebasePlanResult::Succeeded { rewritten_oids } => rewritten_oids,
+            ExecuteRebasePlanResult::WouldSucceed => return Ok(Ok(())),
             ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info } => {
                 writeln!(effects.get_output_stream(), "BUG: encountered merge conflicts during git test fix, but we should not be applying any patches: {failed_merge_info:?}")?;
                 return Ok(Err(ExitCode(1)));

--- a/git-branchless/src/commands/amend.rs
+++ b/git-branchless/src/commands/amend.rs
@@ -294,6 +294,7 @@ pub fn amend(
             event_tx_id,
             force_in_memory: move_options.force_in_memory,
             force_on_disk: move_options.force_on_disk,
+            dry_run: false,
             preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
             resolve_merge_conflicts: move_options.resolve_merge_conflicts,
             check_out_commit_options: CheckOutCommitOptions {
@@ -313,7 +314,8 @@ pub fn amend(
         )? {
             ExecuteRebasePlanResult::Succeeded {
                 rewritten_oids: None,
-            } => {}
+            }
+            | ExecuteRebasePlanResult::WouldSucceed => {}
 
             ExecuteRebasePlanResult::Succeeded {
                 rewritten_oids: Some(rewritten_oids),

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -96,6 +96,7 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
             move_options,
             fixup,
             insert,
+            dry_run,
         } => git_branchless_move::r#move(
             &effects,
             &git_run_info,
@@ -107,6 +108,7 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
             &move_options,
             fixup,
             insert,
+            dry_run,
         )?,
 
         Command::Next {

--- a/git-branchless/src/commands/restack.rs
+++ b/git-branchless/src/commands/restack.rs
@@ -183,6 +183,8 @@ fn restack_commits(
             Ok(Ok(()))
         }
 
+        ExecuteRebasePlanResult::WouldSucceed => Ok(Ok(())),
+
         ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info } => {
             failed_merge_info.describe(effects, &repo, merge_conflict_remediation)?;
             Ok(Err(ExitCode(1)))
@@ -325,6 +327,7 @@ pub fn restack(
         preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
         force_in_memory,
         force_on_disk,
+        dry_run: false,
         resolve_merge_conflicts,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),

--- a/git-branchless/src/commands/split.rs
+++ b/git-branchless/src/commands/split.rs
@@ -555,6 +555,7 @@ pub fn split(
                 preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
                 force_in_memory,
                 force_on_disk,
+                dry_run: false,
                 resolve_merge_conflicts,
                 check_out_commit_options: CheckOutCommitOptions {
                     additional_args: Default::default(),
@@ -579,7 +580,9 @@ pub fn split(
     };
 
     match result {
-        None | Some(ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ }) => {
+        None
+        | Some(ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ })
+        | Some(ExecuteRebasePlanResult::WouldSucceed) => {
             try_exit_code!(git_run_info
                 .run_direct_no_wrapping(Some(event_tx_id), &["branchless", "smartlog"])?);
             Ok(Ok(()))

--- a/git-branchless/src/commands/sync.rs
+++ b/git-branchless/src/commands/sync.rs
@@ -91,6 +91,7 @@ pub fn sync(
         preserve_timestamps: get_restack_preserve_timestamps(&repo)?,
         force_in_memory,
         force_on_disk,
+        dry_run: false,
         resolve_merge_conflicts,
         check_out_commit_options: CheckOutCommitOptions {
             additional_args: Default::default(),
@@ -427,6 +428,9 @@ fn execute_plans(
             match result {
                 ExecuteRebasePlanResult::Succeeded { rewritten_oids: _ } => {
                     success_commits.push(root_commit);
+                }
+                ExecuteRebasePlanResult::WouldSucceed => {
+                    // Do nothing.
                 }
                 ExecuteRebasePlanResult::DeclinedToMerge { failed_merge_info } => {
                     failed_merge_commits.push((root_commit, failed_merge_info));


### PR DESCRIPTION
I have found this useful to find the exact commit that introduced a conflict for an out of date stack:

```
TEST_COMMAND='
git move \
    -s "current($OLD_COMMIT)" \
    -d $BRANCHLESS_TEST_COMMIT \
    --in-memory \
    --dry-run
'

git test run \
    "current($OLD_COMMIT)..main" \
    --exec "$TEST_COMMAND"
    --jobs 8 \
    --strategy worktree
    --search binary
```

This example was able to search through 372 commits in only 40 iterations, finding the exact commit where the conflict was created. This made the resolution a lot easier vs just rebasing directly onto main and having to deal with potentially numerous, combined conflicts.