### PR TITLE
proposal: reduce dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,43 @@
 version: 2
 
+# Reference and docs for this file:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
 updates:
+  # group cargo deps into a single monthly PR
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "build:"
+    groups:
+      deps:
+        patterns: 
+          - "*"
+    ignore:
+      - dependency-name: git2
+      - dependency-name: clap_mangen
+          
+  # flakey or problematic deps are still submitted individually
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "build:"
+    allow:
+      - dependency-name: git2
+      - dependency-name: clap_mangen
 
+  # group GH actions deps into a single monthly PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "build:"
+    groups:
+      actions-deps:
+        patterns: 
+          - "*"


### PR DESCRIPTION
Of the last 100 commits to `master` over 75 have been `dependabot` updates. While I like the atomic nature of these, this feels like a lot of history noise, and also merging all of the dependabot PRs is usually an easy but tedious task that gets in the way of other maintenance tasks and updates.

Proposal:
- reduce dependabot updates from `weekly` to `monthly`
- group most dependency updates into a single PR, instead of atomic updates of 1-dep-per-pr
- provide a way to keep "known troublesome" deps on a 1-dep-per-pr cadence
  - `git2` and `clap_mangen` are treated this way because they both have [pending](https://github.com/arxanas/git-branchless/pull/1547) [PRs](https://github.com/arxanas/git-branchless/pull/1600) that are failing CI

My feeling is that this still gives us regular, reasonably frequent dep updates, while still reducing the amount noise and chores we have to deal with. It should still give us a reasonable target for bisecting any regressions, should any occur.

~~I have not yet tested this, and I'll need to do that before proceeding. In the meantime, I want to park this for discussion.~~ **Update:** I have not been able to find a way to test this before merging it. Apparently GH no longer provides a way to [validate dependabot configs](https://github.com/dependabot/dependabot-core/issues/4605). I did try [the dependabot cli](https://github.com/dependabot/cli) but the initial results were inconclusive[^1] and digging into *why* they were inconclusive seems more involved that just merging and seeing what happens.

The docs for `dependabot.yml` are at https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

[^1]: I got the same results on master on this branch, but those didn't match what we're seeing in actual PRs. Also each run took 30 minutes!