### PR TITLE
feat(record): add `--new` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
 name = "git-branchless-record"
 version = "0.11.1"
 dependencies = [
+ "chrono",
  "cursive",
  "cursive_buffered_backend",
  "eyre",

--- a/git-branchless-lib/src/git/mod.rs
+++ b/git-branchless-lib/src/git/mod.rs
@@ -23,8 +23,8 @@ pub use reference::{
 };
 pub use repo::{
     AmendFastOptions, CherryPickFastOptions, CreateCommitFastError, Error as RepoError,
-    GitErrorCode, GitVersion, PatchId, Repo, ResolvedReferenceInfo, Result as RepoResult, Time,
-    message_prettify,
+    GitErrorCode, GitVersion, PatchId, Repo, ResolvedReferenceInfo, Result as RepoResult,
+    Signature, Time, message_prettify,
 };
 pub use run::{GitRunInfo, GitRunOpts, GitRunResult};
 pub use snapshot::{WorkingCopyChangesType, WorkingCopySnapshot};

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -1703,6 +1703,18 @@ impl std::fmt::Debug for Signature<'_> {
 }
 
 impl<'repo> Signature<'repo> {
+    /// Create a new signature.
+    #[instrument]
+    pub fn new(name: &str, email: &str, now: &SystemTime) -> Result<Self> {
+        Ok({
+            Signature {
+                inner: git2::Signature::now(name, email).map_err(Error::CreateSignature)?,
+            }
+            .update_timestamp(*now)?
+        })
+    }
+
+    /// Create an automated signature, for internal use.
     #[instrument]
     pub fn automated() -> Result<Self> {
         Ok(Signature {
@@ -1752,10 +1764,12 @@ impl<'repo> Signature<'repo> {
         }
     }
 
+    /// Get the name applied to this signature.
     pub fn get_name(&self) -> Option<&str> {
         self.inner.name()
     }
 
+    /// Get the email applied to this signature.
     pub fn get_email(&self) -> Option<&str> {
         self.inner.email()
     }

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -62,7 +62,7 @@ fn get_shell_utils_dir() -> Option<PathBuf> {
 
 const DUMMY_NAME: &str = "Testy McTestface";
 const DUMMY_EMAIL: &str = "test@example.com";
-const DUMMY_DATE: &str = "Wed 29 Oct 12:34:56 2020 PDT";
+const DUMMY_DATE: &str = "Thu, 29 Oct 2020 12:34:56";
 
 /// Wrapper around the Git executable, for testing.
 #[derive(Clone, Debug)]
@@ -218,7 +218,7 @@ impl Git {
     pub fn get_base_env(&self, time: isize) -> Vec<(OsString, OsString)> {
         // Required for determinism, as these values will be baked into the commit
         // hash.
-        let date: OsString = format!("{DUMMY_DATE} -{time:0>2}").into();
+        let date: OsString = format!("{DUMMY_DATE} -{time:0>2}00").into();
 
         // Fake "editor" which accepts the default contents of any commit
         // messages. Usually, we can set this with `git commit -m`, but we have

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -228,15 +228,24 @@ impl Git {
         // ":" is understood by `git` to skip editing.
         let git_editor = OsString::from(":");
 
+        // Set timezone to avoid snapshot conflicts between local machines in
+        // different timezones, and CI. This may only affect places where we
+        // create wholely new commits, eg `record --new`.
+        let git_timezone = OsString::from("UTC");
+
         let new_path = self.get_path_for_env();
         let envs = vec![
             ("GIT_CONFIG_NOSYSTEM", OsString::from("1")),
+            // Note that git also supports a GIT_TEST_DATE_NOW env var, which
+            // may come in useful in the future:
+            // https://github.com/git/git/blob/7bcaabddcf68bd0702697da5904c3b68c52f94cf/date.c#L128
             ("GIT_AUTHOR_DATE", date.clone()),
             ("GIT_COMMITTER_DATE", date),
             ("GIT_EDITOR", git_editor),
             ("GIT_EXEC_PATH", self.git_exec_path.as_os_str().into()),
             ("LC_ALL", "C".into()),
             ("PATH", new_path),
+            ("TZ", git_timezone),
             (TEST_GIT, self.path_to_git.as_os_str().into()),
             (
                 TEST_SEPARATE_COMMAND_BINARIES,

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -351,6 +351,10 @@ pub struct RecordArgs {
     #[clap(action, short = 's', long = "stash", conflicts_with_all(&["create", "detach"]))]
     pub stash: bool,
 
+    /// Create an empty commit, leaving any changes uncommitted.
+    #[clap(action, long = "new", conflicts_with("stash"))]
+    pub new: bool,
+
     /// How should newly encountered, untracked files be handled?
     #[clap(value_parser, long = "untracked", conflicts_with_all(&["interactive"]))]
     pub untracked_file_strategy: Option<UntrackedFileStrategy>,

--- a/git-branchless-record/Cargo.toml
+++ b/git-branchless-record/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/arxanas/git-branchless"
 version = "0.11.1"
 
 [dependencies]
+chrono = { workspace = true }
 cursive = { version = "0.21.1", default-features = false, features = [
     "crossterm-backend",
 ] }

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -14,6 +14,8 @@ use std::ffi::OsString;
 use std::fmt::Write;
 use std::time::SystemTime;
 
+use chrono::DateTime;
+use eyre::OptionExt;
 use git_branchless_invoke::CommandContext;
 use git_branchless_opts::{MessageArgs, RecordArgs, ResolveRevsetOptions, Revset};
 use git_branchless_reword::{ResolveFixupCommitError, edit_message, resolve_commit_to_fixup};
@@ -32,9 +34,10 @@ use lib::core::rewrite::{
 };
 use lib::core::untracked_file_cache::{UntrackedFileStrategy, process_untracked_files};
 use lib::git::{
-    CategorizedReferenceName, FileMode, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
-    ResolvedReferenceInfo, Stage, UpdateIndexCommand, WorkingCopyChangesType, WorkingCopySnapshot,
-    process_diff_for_record, summarize_diff_for_temporary_commit, update_index,
+    CategorizedReferenceName, ConfigRead, FileMode, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
+    ResolvedReferenceInfo, Signature, Stage, UpdateIndexCommand, WorkingCopyChangesType,
+    WorkingCopySnapshot, process_diff_for_record, summarize_diff_for_temporary_commit,
+    update_index,
 };
 use lib::try_exit_code;
 use lib::util::{ExitCode, EyreExitOr};
@@ -62,6 +65,7 @@ pub fn command_main(ctx: CommandContext, args: RecordArgs) -> EyreExitOr<()> {
         detach,
         insert,
         stash,
+        new,
         untracked_file_strategy,
     } = args;
     record(
@@ -74,6 +78,7 @@ pub fn command_main(ctx: CommandContext, args: RecordArgs) -> EyreExitOr<()> {
         detach,
         insert,
         stash,
+        new,
         untracked_file_strategy,
     )
 }
@@ -89,6 +94,7 @@ fn record(
     detach: bool,
     insert: bool,
     stash: bool,
+    new: bool,
     untracked_file_strategy: Option<UntrackedFileStrategy>,
 ) -> EyreExitOr<()> {
     let now = SystemTime::now();
@@ -97,19 +103,31 @@ fn record(
     let event_log_db = EventLogDb::new(&conn)?;
     let event_tx_id = event_log_db.make_transaction_id(now, "record")?;
 
-    try_exit_code!(create_commit_with_changes(
-        &repo,
-        git_run_info,
-        effects,
-        &event_log_db,
-        &event_tx_id,
-        messages,
-        commit_to_fixup,
-        interactive,
-        branch_name,
-        stash,
-        untracked_file_strategy
-    )?);
+    if new {
+        try_exit_code!(create_new_commit(
+            &repo,
+            &now,
+            git_run_info,
+            effects,
+            &event_log_db,
+            &event_tx_id,
+            messages,
+        )?);
+    } else {
+        try_exit_code!(create_commit_with_changes(
+            &repo,
+            git_run_info,
+            effects,
+            &event_log_db,
+            &event_tx_id,
+            messages,
+            commit_to_fixup,
+            interactive,
+            branch_name,
+            stash,
+            untracked_file_strategy
+        )?);
+    }
 
     if detach || stash {
         let head_info = repo.get_head_info()?;
@@ -425,6 +443,93 @@ fn create_commit_with_changes(
         };
         git_run_info.run_direct_no_wrapping(Some(*event_tx_id), &args)
     }
+}
+
+#[instrument]
+fn create_new_commit(
+    repo: &Repo,
+    now: &SystemTime,
+    git_run_info: &GitRunInfo,
+    effects: &Effects,
+    event_log_db: &EventLogDb,
+    event_tx_id: &EventTransactionId,
+    messages: Vec<String>,
+) -> EyreExitOr<()> {
+    let head_info = repo.get_head_info()?;
+    let current_commit_oid = match head_info {
+        ResolvedReferenceInfo {
+            oid: Some(oid),
+            reference_name: _,
+        } => oid,
+        ResolvedReferenceInfo {
+            oid: None,
+            reference_name: _,
+        } => unimplemented!("unborn head"),
+    };
+
+    let current_commit = repo.find_commit_or_fail(current_commit_oid)?;
+    let current_tree = current_commit.get_tree()?;
+
+    let (author, committer) = {
+        let config = repo.get_readonly_config()?;
+        let name: String = config
+            .get("user.name")?
+            .ok_or_eyre("no user.name configured")?;
+        let email: String = config
+            .get("user.email")?
+            .ok_or_eyre("no user.email configured")?;
+
+        let (author_date, committer_date) = {
+            let author_date = std::env::var("GIT_AUTHOR_DATE")
+                .ok()
+                .and_then(|date| DateTime::parse_from_rfc2822(&date).ok())
+                .map(|datetime| datetime.into())
+                .unwrap_or(*now);
+
+            let committer_date = std::env::var("GIT_COMMITTER_DATE")
+                .ok()
+                .and_then(|date| DateTime::parse_from_rfc2822(&date).ok())
+                .map(|datetime| datetime.into())
+                .unwrap_or(*now);
+
+            (author_date, committer_date)
+        };
+
+        (
+            Signature::new(&name, &email, &author_date)?,
+            Signature::new(&name, &email, &committer_date)?,
+        )
+    };
+
+    let new_oid = repo.create_commit(
+        None,
+        &author,
+        &committer,
+        &messages.join("\n\n"),
+        &current_tree,
+        vec![&current_commit],
+    )?;
+
+    // TODO: move branch if ref_name
+    // TODO: mark commit reachable (will show in sl if descendants, but not if detached)
+    // FIXME: --new --create <branch> doesn't seem to work
+
+    try_exit_code!(check_out_commit(
+        effects,
+        git_run_info,
+        repo,
+        event_log_db,
+        *event_tx_id,
+        Some(CheckoutTarget::Oid(new_oid)),
+        &CheckOutCommitOptions {
+            additional_args: vec![],
+            force_detach: false,
+            reset: false,
+            render_smartlog: false,
+        },
+    )?);
+
+    Ok(Ok(()))
 }
 
 #[instrument]

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -97,194 +97,19 @@ fn record(
     let event_log_db = EventLogDb::new(&conn)?;
     let event_tx_id = event_log_db.make_transaction_id(now, "record")?;
 
-    let (snapshot, working_copy_changes_type, files_to_add) = {
-        let head_info = repo.get_head_info()?;
-        let index = repo.get_index()?;
-        let (snapshot, _status) =
-            repo.get_status(effects, git_run_info, &index, &head_info, Some(event_tx_id))?;
-
-        let working_copy_changes_type = snapshot.get_working_copy_changes_type()?;
-        let files_to_add = match working_copy_changes_type {
-            WorkingCopyChangesType::None => {
-                let files_to_add = if interactive {
-                    Vec::new()
-                } else {
-                    try_exit_code!(process_untracked_files(
-                        effects,
-                        git_run_info,
-                        &repo,
-                        event_tx_id,
-                        untracked_file_strategy,
-                    )?)
-                };
-
-                if files_to_add.is_empty() {
-                    writeln!(
-                        effects.get_output_stream(),
-                        "There are no changes to tracked files in the working copy to commit."
-                    )?;
-                    return Ok(Ok(()));
-                } else {
-                    files_to_add
-                }
-            }
-            WorkingCopyChangesType::Unstaged | WorkingCopyChangesType::Staged if interactive => {
-                Vec::new()
-            }
-            WorkingCopyChangesType::Staged => Vec::new(),
-            WorkingCopyChangesType::Unstaged => {
-                try_exit_code!(process_untracked_files(
-                    effects,
-                    git_run_info,
-                    &repo,
-                    event_tx_id,
-                    untracked_file_strategy,
-                )?)
-            }
-            WorkingCopyChangesType::Conflicts => {
-                writeln!(
-                    effects.get_output_stream(),
-                    "Cannot commit changes while there are unresolved merge conflicts."
-                )?;
-                writeln!(
-                    effects.get_output_stream(),
-                    "Resolve them and try again. Aborting."
-                )?;
-                return Ok(Err(ExitCode(1)));
-            }
-        };
-
-        (snapshot, working_copy_changes_type, files_to_add)
-    };
-
-    if let Some(branch_name) = branch_name {
-        try_exit_code!(check_out_commit(
-            effects,
-            git_run_info,
-            &repo,
-            &event_log_db,
-            event_tx_id,
-            None,
-            &CheckOutCommitOptions {
-                additional_args: vec![OsString::from("-b"), OsString::from(branch_name)],
-                force_detach: false,
-                reset: false,
-                render_smartlog: false,
-            },
-        )?);
-    }
-
-    if interactive {
-        if working_copy_changes_type == WorkingCopyChangesType::Staged {
-            writeln!(
-                effects.get_output_stream(),
-                "Cannot select changes interactively while there are already staged changes."
-            )?;
-            writeln!(
-                effects.get_output_stream(),
-                "Either commit or unstage your changes and try again. Aborting."
-            )?;
-            return Ok(Err(ExitCode(1)));
-        } else {
-            try_exit_code!(record_interactive(
-                effects,
-                git_run_info,
-                &repo,
-                &snapshot,
-                event_tx_id,
-                messages,
-            )?);
-        }
-    } else {
-        if !files_to_add.is_empty() {
-            // call `git add` for the new untracked files to be commited
-            //
-            // Note that `git commit` has some functionality for this, by
-            // listing files as arguments to the commit command. However, the
-            // docs for that state "the commit will ignore changes staged in the
-            // index, and instead record the current content of the listed files
-            // (which must already be known to Git);" (See
-            // https://git-scm.com/docs/git-commit#_description, item 3)
-            //
-            // The implication is that new working copy files would cause the
-            // commit to ignore any changes in the index, which is not what we
-            // want. Looking into this can be future scope; it could avoid this
-            // extra call to `git add`. On the other hand, this extra call is
-            // not very onerous.
-
-            let args = {
-                let mut args = vec!["add".to_string()];
-                // use repo-canonical paths even if adding in a repo subdir
-                args.extend(files_to_add.iter().map(|p| format!(":/{p}")));
-                args
-            };
-            let _ = git_run_info.run_direct_no_wrapping(Some(event_tx_id), &args)?;
-        }
-
-        let messages = if messages.is_empty() && stash {
-            get_default_stash_message(&repo, effects, &snapshot, &working_copy_changes_type)
-                .map(|message| vec![message])?
-        } else {
-            messages
-        };
-        let args = {
-            let mut args = vec!["commit".to_string()];
-            args.extend(
-                messages
-                    .iter()
-                    .flat_map(|message| ["--message".to_string(), message.to_string()]),
-            );
-            if working_copy_changes_type == WorkingCopyChangesType::Unstaged {
-                args.push("--all".to_string());
-            }
-            if let Some(revset) = commit_to_fixup {
-                let event_replayer =
-                    EventReplayer::from_event_log_db(effects, &repo, &event_log_db)?;
-                let event_cursor = event_replayer.make_default_cursor();
-                let references_snapshot = repo.get_references_snapshot()?;
-                let mut dag = Dag::open_and_sync(
-                    effects,
-                    &repo,
-                    &event_replayer,
-                    event_cursor,
-                    &references_snapshot,
-                )?;
-                let head: Option<&[lib::git::Commit<'_>]> =
-                    snapshot.head_commit.as_ref().map(std::slice::from_ref);
-                let commit = match resolve_commit_to_fixup(
-                    &repo,
-                    &mut dag,
-                    effects,
-                    &revset,
-                    &ResolveRevsetOptions::default(),
-                    head,
-                )? {
-                    Ok(commit) => commit,
-                    Err(ResolveFixupCommitError::NotAnAncestor) => {
-                        writeln!(
-                            effects.get_error_stream(),
-                            "The commit supplied to --fixup must be an ancestor of the commit being created.\nAborting.",
-                        )?;
-                        return Ok(Err(ExitCode(1)));
-                    }
-                    Err(ResolveFixupCommitError::MoreThanOneCommit {
-                        revset_to_fixup,
-                        commit_count,
-                    }) => {
-                        writeln!(
-                            effects.get_error_stream(),
-                            "--fixup expects exactly 1 commit, but '{revset_to_fixup}' evaluated to {commit_count}.\nAborting.",
-                        )?;
-                        return Ok(Err(ExitCode(1)));
-                    }
-                };
-                let commit = commit.get_oid().to_string();
-                args.extend(["--fixup".to_string(), commit]);
-            };
-            args
-        };
-        try_exit_code!(git_run_info.run_direct_no_wrapping(Some(event_tx_id), &args)?);
-    }
+    try_exit_code!(create_commit_with_changes(
+        &repo,
+        git_run_info,
+        effects,
+        &event_log_db,
+        &event_tx_id,
+        messages,
+        commit_to_fixup,
+        interactive,
+        branch_name,
+        stash,
+        untracked_file_strategy
+    )?);
 
     if detach || stash {
         let head_info = repo.get_head_info()?;
@@ -392,6 +217,214 @@ fn record(
     }
 
     Ok(Ok(()))
+}
+
+#[instrument]
+fn create_commit_with_changes(
+    repo: &Repo,
+    git_run_info: &GitRunInfo,
+    effects: &Effects,
+    event_log_db: &EventLogDb,
+    event_tx_id: &EventTransactionId,
+    messages: Vec<String>,
+    commit_to_fixup: Option<Revset>,
+    interactive: bool,
+    branch_name: Option<String>,
+    stash: bool,
+    untracked_file_strategy: Option<UntrackedFileStrategy>,
+) -> EyreExitOr<()> {
+    let (snapshot, working_copy_changes_type, files_to_add) = {
+        let head_info = repo.get_head_info()?;
+        let index = repo.get_index()?;
+        let (snapshot, _status) = repo.get_status(
+            effects,
+            git_run_info,
+            &index,
+            &head_info,
+            Some(*event_tx_id),
+        )?;
+
+        let working_copy_changes_type = snapshot.get_working_copy_changes_type()?;
+        let files_to_add = match working_copy_changes_type {
+            WorkingCopyChangesType::None => {
+                let files_to_add = if interactive {
+                    Vec::new()
+                } else {
+                    try_exit_code!(process_untracked_files(
+                        effects,
+                        git_run_info,
+                        repo,
+                        *event_tx_id,
+                        untracked_file_strategy,
+                    )?)
+                };
+
+                if files_to_add.is_empty() {
+                    writeln!(
+                        effects.get_output_stream(),
+                        "There are no changes to tracked files in the working copy to commit."
+                    )?;
+                    return Ok(Ok(()));
+                } else {
+                    files_to_add
+                }
+            }
+            WorkingCopyChangesType::Unstaged | WorkingCopyChangesType::Staged if interactive => {
+                Vec::new()
+            }
+            WorkingCopyChangesType::Staged => Vec::new(),
+            WorkingCopyChangesType::Unstaged => {
+                try_exit_code!(process_untracked_files(
+                    effects,
+                    git_run_info,
+                    repo,
+                    *event_tx_id,
+                    untracked_file_strategy,
+                )?)
+            }
+            WorkingCopyChangesType::Conflicts => {
+                writeln!(
+                    effects.get_output_stream(),
+                    "Cannot commit changes while there are unresolved merge conflicts."
+                )?;
+                writeln!(
+                    effects.get_output_stream(),
+                    "Resolve them and try again. Aborting."
+                )?;
+                return Ok(Err(ExitCode(1)));
+            }
+        };
+
+        (snapshot, working_copy_changes_type, files_to_add)
+    };
+
+    if let Some(branch_name) = branch_name {
+        try_exit_code!(check_out_commit(
+            effects,
+            git_run_info,
+            repo,
+            event_log_db,
+            *event_tx_id,
+            None,
+            &CheckOutCommitOptions {
+                additional_args: vec![OsString::from("-b"), OsString::from(branch_name)],
+                force_detach: false,
+                reset: false,
+                render_smartlog: false,
+            },
+        )?);
+    }
+
+    if interactive {
+        if working_copy_changes_type == WorkingCopyChangesType::Staged {
+            writeln!(
+                effects.get_output_stream(),
+                "Cannot select changes interactively while there are already staged changes."
+            )?;
+            writeln!(
+                effects.get_output_stream(),
+                "Either commit or unstage your changes and try again. Aborting."
+            )?;
+            Ok(Err(ExitCode(1)))
+        } else {
+            record_interactive(
+                effects,
+                git_run_info,
+                repo,
+                &snapshot,
+                *event_tx_id,
+                messages,
+            )
+        }
+    } else {
+        if !files_to_add.is_empty() {
+            // call `git add` for the new untracked files to be commited
+            //
+            // Note that `git commit` has some functionality for this, by
+            // listing files as arguments to the commit command. However, the
+            // docs for that state "the commit will ignore changes staged in the
+            // index, and instead record the current content of the listed files
+            // (which must already be known to Git);" (See
+            // https://git-scm.com/docs/git-commit#_description, item 3)
+            //
+            // The implication is that new working copy files would cause the
+            // commit to ignore any changes in the index, which is not what we
+            // want. Looking into this can be future scope; it could avoid this
+            // extra call to `git add`. On the other hand, this extra call is
+            // not very onerous.
+
+            let args = {
+                let mut args = vec!["add".to_string()];
+                // use repo-canonical paths even if adding in a repo subdir
+                args.extend(files_to_add.iter().map(|p| format!(":/{p}")));
+                args
+            };
+            let _ = git_run_info.run_direct_no_wrapping(Some(*event_tx_id), &args)?;
+        }
+
+        let messages = if messages.is_empty() && stash {
+            get_default_stash_message(repo, effects, &snapshot, &working_copy_changes_type)
+                .map(|message| vec![message])?
+        } else {
+            messages
+        };
+        let args = {
+            let mut args = vec!["commit".to_string()];
+            args.extend(
+                messages
+                    .iter()
+                    .flat_map(|message| ["--message".to_string(), message.to_string()]),
+            );
+            if working_copy_changes_type == WorkingCopyChangesType::Unstaged {
+                args.push("--all".to_string());
+            }
+            if let Some(revset) = commit_to_fixup {
+                let event_replayer = EventReplayer::from_event_log_db(effects, repo, event_log_db)?;
+                let event_cursor = event_replayer.make_default_cursor();
+                let references_snapshot = repo.get_references_snapshot()?;
+                let mut dag = Dag::open_and_sync(
+                    effects,
+                    repo,
+                    &event_replayer,
+                    event_cursor,
+                    &references_snapshot,
+                )?;
+                let head: Option<&[lib::git::Commit<'_>]> =
+                    snapshot.head_commit.as_ref().map(std::slice::from_ref);
+                let commit = match resolve_commit_to_fixup(
+                    repo,
+                    &mut dag,
+                    effects,
+                    &revset,
+                    &ResolveRevsetOptions::default(),
+                    head,
+                )? {
+                    Ok(commit) => commit,
+                    Err(ResolveFixupCommitError::NotAnAncestor) => {
+                        writeln!(
+                            effects.get_error_stream(),
+                            "The commit supplied to --fixup must be an ancestor of the commit being created.\nAborting.",
+                        )?;
+                        return Ok(Err(ExitCode(1)));
+                    }
+                    Err(ResolveFixupCommitError::MoreThanOneCommit {
+                        revset_to_fixup,
+                        commit_count,
+                    }) => {
+                        writeln!(
+                            effects.get_error_stream(),
+                            "--fixup expects exactly 1 commit, but '{revset_to_fixup}' evaluated to {commit_count}.\nAborting.",
+                        )?;
+                        return Ok(Err(ExitCode(1)));
+                    }
+                };
+                let commit = commit.get_oid().to_string();
+                args.extend(["--fixup".to_string(), commit]);
+            };
+            args
+        };
+        git_run_info.run_direct_no_wrapping(Some(*event_tx_id), &args)
+    }
 }
 
 #[instrument]

--- a/git-branchless-record/src/lib.rs
+++ b/git-branchless-record/src/lib.rs
@@ -12,10 +12,10 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fmt::Write;
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::DateTime;
-use eyre::OptionExt;
+use eyre::{OptionExt, WrapErr};
 use git_branchless_invoke::CommandContext;
 use git_branchless_opts::{MessageArgs, RecordArgs, ResolveRevsetOptions, Revset};
 use git_branchless_reword::{ResolveFixupCommitError, edit_message, resolve_commit_to_fixup};
@@ -24,8 +24,9 @@ use lib::core::check_out::{CheckOutCommitOptions, CheckoutTarget, check_out_comm
 use lib::core::config::{get_commit_template, get_restack_preserve_timestamps};
 use lib::core::dag::{CommitSet, Dag};
 use lib::core::effects::{Effects, OperationType};
-use lib::core::eventlog::{EventLogDb, EventReplayer, EventTransactionId};
+use lib::core::eventlog::{Event as LogEvent, EventLogDb, EventReplayer, EventTransactionId};
 use lib::core::formatting::Pluralize;
+use lib::core::gc::mark_commit_reachable;
 use lib::core::repo_ext::RepoExt;
 use lib::core::rewrite::{
     BuildRebasePlanError, BuildRebasePlanOptions, ExecuteRebasePlanOptions,
@@ -34,10 +35,10 @@ use lib::core::rewrite::{
 };
 use lib::core::untracked_file_cache::{UntrackedFileStrategy, process_untracked_files};
 use lib::git::{
-    CategorizedReferenceName, ConfigRead, FileMode, GitRunInfo, MaybeZeroOid, NonZeroOid, Repo,
-    ResolvedReferenceInfo, Signature, Stage, UpdateIndexCommand, WorkingCopyChangesType,
-    WorkingCopySnapshot, process_diff_for_record, summarize_diff_for_temporary_commit,
-    update_index,
+    CategorizedReferenceName, ConfigRead, FileMode, GitRunInfo, MaybeZeroOid, NonZeroOid,
+    ReferenceName, Repo, ResolvedReferenceInfo, Signature, Stage, UpdateIndexCommand,
+    WorkingCopyChangesType, WorkingCopySnapshot, process_diff_for_record,
+    summarize_diff_for_temporary_commit, update_index,
 };
 use lib::try_exit_code;
 use lib::util::{ExitCode, EyreExitOr};
@@ -112,6 +113,7 @@ fn record(
             &event_log_db,
             &event_tx_id,
             messages,
+            branch_name,
         )?);
     } else {
         try_exit_code!(create_commit_with_changes(
@@ -454,13 +456,14 @@ fn create_new_commit(
     event_log_db: &EventLogDb,
     event_tx_id: &EventTransactionId,
     messages: Vec<String>,
+    branch_name: Option<String>,
 ) -> EyreExitOr<()> {
     let head_info = repo.get_head_info()?;
-    let current_commit_oid = match head_info {
+    let (current_commit_oid, existing_ref_name) = match head_info {
         ResolvedReferenceInfo {
             oid: Some(oid),
-            reference_name: _,
-        } => oid,
+            reference_name,
+        } => (oid, reference_name),
         ResolvedReferenceInfo {
             oid: None,
             reference_name: _,
@@ -510,9 +513,35 @@ fn create_new_commit(
         vec![&current_commit],
     )?;
 
-    // TODO: move branch if ref_name
-    // TODO: mark commit reachable (will show in sl if descendants, but not if detached)
-    // FIXME: --new --create <branch> doesn't seem to work
+    mark_commit_reachable(repo, new_oid)
+        .wrap_err("Marking commit as reachable for GC purposes.")?;
+    event_log_db.add_events(vec![LogEvent::CommitEvent {
+        timestamp: now.duration_since(UNIX_EPOCH)?.as_secs_f64(),
+        event_tx_id: *event_tx_id,
+        commit_oid: new_oid,
+    }])?;
+
+    let checkout_target = if let Some(name) = branch_name {
+        // --create <branch>: create the new branch at the new commit.
+        try_exit_code!(git_run_info.run(
+            effects,
+            Some(*event_tx_id),
+            &["branch", &name, &new_oid.to_string()],
+        )?);
+        let ref_name = ReferenceName::from(format!("refs/heads/{name}"));
+        CheckoutTarget::Reference(ref_name)
+    } else if let Some(ref_name) = existing_ref_name {
+        // On a named branch: advance it to the new commit, mirroring `git commit`.
+        try_exit_code!(git_run_info.run(
+            effects,
+            Some(*event_tx_id),
+            &["update-ref", ref_name.as_str(), &new_oid.to_string()],
+        )?);
+        CheckoutTarget::Reference(ref_name)
+    } else {
+        // Detached HEAD, no --create: check out by OID.
+        CheckoutTarget::Oid(new_oid)
+    };
 
     try_exit_code!(check_out_commit(
         effects,
@@ -520,12 +549,10 @@ fn create_new_commit(
         repo,
         event_log_db,
         *event_tx_id,
-        Some(CheckoutTarget::Oid(new_oid)),
+        Some(checkout_target),
         &CheckOutCommitOptions {
-            additional_args: vec![],
-            force_detach: false,
-            reset: false,
             render_smartlog: false,
+            ..Default::default()
         },
     )?);
 

--- a/git-branchless-record/tests/test_record.rs
+++ b/git-branchless-record/tests/test_record.rs
@@ -526,7 +526,8 @@ fn test_record_new() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout f25fe40ff47319c8b8c61a32c03f2c3558aacadd --
+        branchless: running command: <git-executable> update-ref refs/heads/master f25fe40ff47319c8b8c61a32c03f2c3558aacadd
+        branchless: running command: <git-executable> checkout master --
         M	test1.txt
         "###);
 
@@ -542,9 +543,7 @@ fn test_record_new() -> eyre::Result<()> {
         let stdout = git.smartlog()?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d (master) create test1.txt
-        |
-        @ f25fe40 empty commit 1
+        @ f25fe40 (> master) empty commit 1
         "###);
     }
 
@@ -561,7 +560,8 @@ fn test_record_new() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 46ba0c4efce07dc705498e7b79f7116d4e9ef7a3 --
+        branchless: running command: <git-executable> update-ref refs/heads/master 46ba0c4efce07dc705498e7b79f7116d4e9ef7a3
+        branchless: running command: <git-executable> checkout master --
         M	test1.txt
         "###);
 
@@ -577,11 +577,7 @@ fn test_record_new() -> eyre::Result<()> {
         let stdout = git.smartlog()?;
         insta::assert_snapshot!(stdout, @r###"
         :
-        O 62fc20d (master) create test1.txt
-        |
-        o f25fe40 empty commit 1
-        |
-        @ 46ba0c4 empty commit 2
+        @ 46ba0c4 (> master) empty commit 2
         "###);
     }
 
@@ -624,7 +620,8 @@ fn test_record_new_uses_user_name_and_email() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout d4aea9dcdb2ad9ddedc964de9e782aad5a97b864 --
+        branchless: running command: <git-executable> update-ref refs/heads/master d4aea9dcdb2ad9ddedc964de9e782aad5a97b864
+        branchless: running command: <git-executable> checkout master --
         M	test1.txt
         "###);
 
@@ -1360,6 +1357,100 @@ fn test_record_fixup() -> eyre::Result<()> {
     The commit supplied to --fixup must be an ancestor of the commit being created.
     Aborting.
     ");
+
+    Ok(())
+}
+
+#[test]
+fn test_record_new_moves_branch() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    {
+        // Switch to a new branch and then create a new commit. The branch
+        // pointer should advance with the new commit.
+        git.run(&["switch", "--create", "test"])?;
+        git.branchless("record", &["-m", "empty commit 1", "--new"])?;
+
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ 1fa4693 (> test) empty commit 1
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_record_new_marks_commit_reachable() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+
+    let stdout = git.smartlog()?;
+    insta::assert_snapshot!(stdout, @r###"
+        :
+        @ 62fc20d (master) create test1.txt
+    "###);
+
+    {
+        // Create new commit then switch back to master.
+        git.branchless("record", &["-m", "empty commit 1", "--new"])?;
+        git.run(&["switch", "master"])?;
+
+        // The new commit should still appear in the smartlog even though no
+        // branch points to it.
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        @ 62fc20d (> master) create test1.txt
+        |
+        o dc158fa empty commit 1
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_record_new_with_create() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let stdout = git.smartlog()?;
+    insta::assert_snapshot!(stdout, @r###"
+        :
+        @ 62fc20d (> master) create test1.txt
+    "###);
+
+    {
+        // Create a new commit and a new branch, which should be checked out.
+        git.branchless(
+            "record",
+            &["-m", "empty commit 1", "--new", "--create", "foo"],
+        )?;
+
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        @ dc158fa (> foo) empty commit 1
+        "###);
+    }
 
     Ok(())
 }

--- a/git-branchless-record/tests/test_record.rs
+++ b/git-branchless-record/tests/test_record.rs
@@ -504,6 +504,200 @@ fn test_record_staged_changes_interactive() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_record_new() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    git.commit_file("test1", 1)?;
+
+    {
+        // --new w/ changes in the working copy
+        git.write_file_txt("test1", "new test1 contents\n")?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "record",
+            &["-m", "empty commit 1", "--new"],
+            &GitRunOptions {
+                time: 2,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout f25fe40ff47319c8b8c61a32c03f2c3558aacadd --
+        M	test1.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        commit f25fe40ff47319c8b8c61a32c03f2c3558aacadd
+        Author: Testy McTestface <test@example.com>
+        Date:   Thu Oct 29 14:34:56 2020 +0000
+
+            empty commit 1
+        "###);
+
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        @ f25fe40 empty commit 1
+        "###);
+    }
+
+    {
+        // --new w/ changes in the index
+        git.run(&["add", "test1.txt"])?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "record",
+            &["-m", "empty commit 2", "--new"],
+            &GitRunOptions {
+                time: 2,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout 46ba0c4efce07dc705498e7b79f7116d4e9ef7a3 --
+        M	test1.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show"])?;
+        insta::assert_snapshot!(stdout, @r###"
+        commit 46ba0c4efce07dc705498e7b79f7116d4e9ef7a3
+        Author: Testy McTestface <test@example.com>
+        Date:   Thu Oct 29 14:34:56 2020 +0000
+
+            empty commit 2
+        "###);
+
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        :
+        O 62fc20d (master) create test1.txt
+        |
+        o f25fe40 empty commit 1
+        |
+        @ 46ba0c4 empty commit 2
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_record_new_uses_user_name_and_email() -> eyre::Result<()> {
+    let git = make_git()?;
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--name-only"])?;
+        insta::assert_snapshot!(stdout, @r###"
+            commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+            Author: Testy McTestface <test@example.com>
+            Date:   Thu Oct 29 12:34:56 2020 -0100
+
+                create test1.txt
+
+            test1.txt
+        "###);
+    }
+
+    {
+        git.run(&["config", "user.name", "Uncreative User Name"])?;
+        git.run(&["config", "user.email", "boring@example.com"])?;
+        git.write_file_txt("test1", "new test1 contents\n")?;
+
+        let (stdout, _stderr) = git.branchless_with_options(
+            "record",
+            &["-m", "empty commit 1", "--new"],
+            &GitRunOptions {
+                time: 2,
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> checkout d4aea9dcdb2ad9ddedc964de9e782aad5a97b864 --
+        M	test1.txt
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show"])?;
+        insta::assert_snapshot!(_stderr+&stdout, @r###"
+        commit d4aea9dcdb2ad9ddedc964de9e782aad5a97b864
+        Author: Uncreative User Name <boring@example.com>
+        Date:   Thu Oct 29 14:34:56 2020 +0000
+
+            empty commit 1
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_record_new_insert() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    git.run(&["switch", "--create", "test"])?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 1)?;
+    git.run(&["checkout", "HEAD^"])?;
+    git.write_file_txt("test1", "new test1 contents\n")?;
+
+    let (stdout, _stderr) = git.branchless_with_options(
+        "record",
+        &["-m", "empty commit", "--new", "--insert"],
+        &GitRunOptions {
+            time: 2,
+            ..Default::default()
+        },
+    )?;
+    insta::assert_snapshot!(stdout, @r###"
+    branchless: running command: <git-executable> checkout 1eee4c0fe5759bd57e95d3b45dd0907fab18b399 --
+    M	test1.txt
+    Attempting rebase in-memory...
+    [1/1] Committed as: b8be95f create test2.txt
+    branchless: processing 1 update: branch test
+    branchless: processing 1 rewritten commit
+    In-memory rebase succeeded.
+    "###);
+
+    let (stdout, _stderr) = git.run(&["show"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    commit 1eee4c0fe5759bd57e95d3b45dd0907fab18b399
+    Author: Testy McTestface <test@example.com>
+    Date:   Thu Oct 29 14:34:56 2020 +0000
+
+        empty commit
+    "###);
+
+    let stdout = git.smartlog()?;
+    insta::assert_snapshot!(stdout, @r###"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    @ 1eee4c0 empty commit
+    |
+    o b8be95f (test) create test2.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn test_record_detach() -> eyre::Result<()> {
     let git = make_git()?;
 


### PR DESCRIPTION
This adds `--new` support to `git record`, to create a new, empty commit. `--insert` works as expected, too.

This required a couple of changes to our tests, too, because this is the first feature in which we create entirely new commits (vs rewriting or modifying existing commits) and I was running into test failures in CI that all focused on time:
- use a correctly formatted RFC2822 date for our deterministic "dummy date" (git parsed and used the existing date format, but the git2 crate rejected it)
- explicitly set timezone to UTC in the test env to avoid git picking up whatever timezone is set locally in a dev environment (eg git was using EST/EDT for me, but CI was using UTC)

<details>
<summary>original description</summary>
This adds `--allow-empty` support to `git record`. This is not very interesting on it's own, but the fun starts when you pass `--insert`, at which point this should behave as a short hand for `git commit --allow-empty -m ... ; git move -s 'siblings(@)'`.

As is, this change will only create an empty commit if there are no changes at all (staged or in the working copy). Eventually, it would be nice to have "real" support for `record --new` to create an empty commit regardless of what changes are currently staged or in the working copy, but I don't intend to tackle that at this time.
</details>