### PR TITLE
fix: add '--' separator to Git commands to disambiguate refs from paths

### DIFF
--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -147,7 +147,11 @@ pub fn check_out_commit(
 
     if *reset {
         if let Some(target) = &target {
-            try_exit_code!(git_run_info.run(effects, Some(event_tx_id), &["reset", target])?);
+            try_exit_code!(git_run_info.run(
+                effects,
+                Some(event_tx_id),
+                &["reset", target, "--"]
+            )?);
         }
     } else {
         let checkout_args = {
@@ -156,6 +160,7 @@ pub fn check_out_commit(
                 args.push(OsStr::new(target.as_str()));
             }
             args.extend(additional_args.iter().map(OsStr::new));
+            args.push(OsStr::new("--"));
             args
         };
         match git_run_info.run(effects, Some(event_tx_id), checkout_args.as_slice())? {
@@ -258,7 +263,11 @@ pub fn restore_snapshot(
     // Discard any working copy changes. The caller is responsible for having
     // snapshotted them if necessary.
     try_exit_code!(git_run_info
-        .run(effects, Some(event_tx_id), &["reset", "--hard", "HEAD"])
+        .run(
+            effects,
+            Some(event_tx_id),
+            &["reset", "--hard", "HEAD", "--"]
+        )
         .wrap_err("Discarding working copy changes")?);
 
     // Check out the unstaged changes. Note that we don't call `git reset --hard
@@ -271,7 +280,11 @@ pub fn restore_snapshot(
         .run(
             effects,
             Some(event_tx_id),
-            &["checkout", &snapshot.commit_unstaged.get_oid().to_string()],
+            &[
+                "checkout",
+                &snapshot.commit_unstaged.get_oid().to_string(),
+                "--"
+            ],
         )
         .wrap_err("Checking out unstaged changes (fail if conflict)")?);
 
@@ -283,7 +296,7 @@ pub fn restore_snapshot(
                 .run(
                     effects,
                     Some(event_tx_id),
-                    &["reset", &head_commit.get_oid().to_string()],
+                    &["reset", &head_commit.get_oid().to_string(), "--"],
                 )
                 .wrap_err("Update HEAD for unstaged changes")?);
         }

--- a/git-branchless-record/tests/test_record.rs
+++ b/git-branchless-record/tests/test_record.rs
@@ -299,7 +299,7 @@ fn test_record_stash() -> eyre::Result<()> {
          1 file changed, 1 insertion(+)
          create mode 100644 test1.txt
         branchless: running command: <git-executable> branch -f master f777ecc9b0db5ed372b2615695191a8a17f79f24
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         "###);
     }
 
@@ -322,7 +322,7 @@ fn test_record_stash() -> eyre::Result<()> {
         [master 9b6164c] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> branch -f master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         "###);
     }
 
@@ -371,7 +371,7 @@ fn test_record_stash_detached_head() -> eyre::Result<()> {
         insta::assert_snapshot!(stdout, @r###"
         [detached HEAD 9b6164c] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         "###);
     }
 
@@ -408,7 +408,7 @@ fn test_record_stash_default_message() -> eyre::Result<()> {
         [master fd2ffa4] stash: test1.txt (+1/-1)
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> branch -f master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         "###);
     }
 
@@ -435,7 +435,7 @@ fn test_record_create_branch() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("record", &["-c", "foo", "-m", "Update"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master -b foo
+        branchless: running command: <git-executable> checkout master -b foo --
         M	test1.txt
         [foo 836023f] Update
          1 file changed, 1 insertion(+), 1 deletion(-)

--- a/git-branchless-submit/tests/test_github_forge.rs
+++ b/git-branchless-submit/tests/test_github_forge.rs
@@ -330,7 +330,7 @@ fn test_github_forge_mock_client_closes_pull_requests() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/2] Skipped commit (was already applied upstream): 62fc20d create test1.txt
         [2/2] Committed as: fa46633 create test2.txt
-        branchless: running command: <git-executable> checkout mock-github-username/create-test2-txt
+        branchless: running command: <git-executable> checkout mock-github-username/create-test2-txt --
         Your branch and 'origin/mock-github-username/create-test2-txt' have diverged,
         and have 2 and 2 different commits each, respectively.
         In-memory rebase succeeded.

--- a/git-branchless-submit/tests/test_phabricator_forge.rs
+++ b/git-branchless-submit/tests/test_phabricator_forge.rs
@@ -66,7 +66,7 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
         [1/2] Committed as: 55af3db create test1.txt
         [2/2] Committed as: ccb7fd5 create test2.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3
+        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3 --
         In-memory rebase succeeded.
         Setting D0002 as stack root (no dependencies)
         Stacking D0003 on top of D0002
@@ -144,7 +144,7 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
         [1/2] Committed as: 55af3db create test1.txt
         [2/2] Committed as: ccb7fd5 create test2.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3
+        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3 --
         In-memory rebase succeeded.
         Setting D0002 as stack root (no dependencies)
         Stacking D0003 on top of D0002
@@ -195,7 +195,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
         [1/2] Committed as: 55af3db create test1.txt
         [2/2] Committed as: ccb7fd5 create test2.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3
+        branchless: running command: <git-executable> checkout ccb7fd5d90c1888bea906a41c197e9215d6b9bb3 --
         In-memory rebase succeeded.
         Setting D0002 as stack root (no dependencies)
         Stacking D0003 on top of D0002

--- a/git-branchless-test/tests/test_test.rs
+++ b/git-branchless-test/tests/test_test.rs
@@ -867,7 +867,7 @@ done
         [2/3] Committed as: 2ee3aea create test2.txt
         [3/3] Committed as: 6f48e0a create test3.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout 6f48e0a628753731739619f27107c57f5d0cc1e0
+        branchless: running command: <git-executable> checkout 6f48e0a628753731739619f27107c57f5d0cc1e0 --
         In-memory rebase succeeded.
         Fixed 3 commits with bash test.sh:
         62fc20d -> 300cb54 create test1.txt
@@ -1130,7 +1130,7 @@ done
         [1/2] Committed as: 300cb54 create test1.txt
         [2/2] Committed as: f15b423 descendant commit
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout f15b423404bbebfe4b09e305e074b525d008f44a
+        branchless: running command: <git-executable> checkout f15b423404bbebfe4b09e305e074b525d008f44a --
         In-memory rebase succeeded.
         Fixed 2 commits with bash test.sh:
         62fc20d -> 300cb54 create test1.txt

--- a/git-branchless/tests/test_amend.rs
+++ b/git-branchless/tests/test_amend.rs
@@ -27,7 +27,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
         branchless: processing 1 update: ref HEAD
         "###);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 7ac317b9d1dd1bbdf46e8ee692b9b9e280f28a50
+        branchless: running command: <git-executable> reset 7ac317b9d1dd1bbdf46e8ee692b9b9e280f28a50 --
         Attempting rebase in-memory...
         [1/1] Committed as: b51f01b create test3.txt
         branchless: processing 1 rewritten commit
@@ -65,7 +65,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.branchless("amend", &[])?;
             insta::assert_snapshot!(stdout, @r###"
-            branchless: running command: <git-executable> reset 7c5e8578f402b6b77afa143283b65fcdc9614233
+            branchless: running command: <git-executable> reset 7c5e8578f402b6b77afa143283b65fcdc9614233 --
             Attempting rebase in-memory...
             This operation would cause a merge conflict:
             - (1 conflicting file) b51f01b create test3.txt
@@ -118,7 +118,7 @@ fn test_amend_rename() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset f6b255388219264f4bcd258a3020d262c2d7b03e
+        branchless: running command: <git-executable> reset f6b255388219264f4bcd258a3020d262c2d7b03e --
         Amended with 2 staged changes.
         "###);
     }
@@ -157,7 +157,7 @@ fn test_amend_delete() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe
+        branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -196,7 +196,7 @@ fn test_amend_delete_only_in_index() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe
+        branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe --
         Amended with 1 staged change.
         "###);
     }
@@ -282,7 +282,7 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset f8e4ba1be5cefcf22e831f51b1525b0be8215a31
+        branchless: running command: <git-executable> reset f8e4ba1be5cefcf22e831f51b1525b0be8215a31 --
         Unstaged changes after reset:
         M	test2.txt
         Amended with 1 staged change. (Some uncommitted changes were not amended.)
@@ -326,7 +326,7 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 2e69581cb466962fa85e5918f29af6d2925fdd6f
+        branchless: running command: <git-executable> reset 2e69581cb466962fa85e5918f29af6d2925fdd6f --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -369,7 +369,7 @@ fn test_amend_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 3b98a960e6ebde39a933c25413b43bce8c0fd128
+        branchless: running command: <git-executable> reset 3b98a960e6ebde39a933c25413b43bce8c0fd128 --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -395,7 +395,7 @@ fn test_amend_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 685ef311b070a460b7c86a9aed068be563978021
+        branchless: running command: <git-executable> reset 685ef311b070a460b7c86a9aed068be563978021 --
         Amended with 1 staged change.
         "###);
     }
@@ -428,7 +428,7 @@ fn test_amend_head_with_file_with_space() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 5ccdda3c1e0dca9aa58634b37cfa9cac09e3975b
+        branchless: running command: <git-executable> reset 5ccdda3c1e0dca9aa58634b37cfa9cac09e3975b --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -465,7 +465,7 @@ fn test_amend_executable() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset f00ec4b5a81438f4e792ca5576a290b16fed8fdb
+        branchless: running command: <git-executable> reset f00ec4b5a81438f4e792ca5576a290b16fed8fdb --
         Amended with 1 staged change.
         "###);
     }
@@ -567,7 +567,7 @@ fn test_amend_undo() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: processing 1 update: branch foo
-        branchless: running command: <git-executable> reset foo
+        branchless: running command: <git-executable> reset foo --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -608,11 +608,11 @@ fn test_amend_undo() -> eyre::Result<()> {
         6. Restore snapshot for branch foo
                     pointing to c0bdfb5 create file1.txt
                 backed up using a293e0b branchless: automated working copy snapshot
-        branchless: running command: <git-executable> checkout a293e0b4502882ced673f83b6742539ee06cbc74 -B foo
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> checkout a293e0b4502882ced673f83b6742539ee06cbc74 -B foo --
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at a293e0b branchless: automated working copy snapshot
-        branchless: running command: <git-executable> checkout 7b6d0f10f68cf5df3de91f062c565e45f1b28006
-        branchless: running command: <git-executable> reset c0bdfb5ba33c02bba2aa451efe2f220f12232408
+        branchless: running command: <git-executable> checkout 7b6d0f10f68cf5df3de91f062c565e45f1b28006 --
+        branchless: running command: <git-executable> reset c0bdfb5ba33c02bba2aa451efe2f220f12232408 --
         Unstaged changes after reset:
         M	file1.txt
         branchless: running command: <git-executable> update-ref refs/heads/foo c0bdfb5ba33c02bba2aa451efe2f220f12232408
@@ -674,7 +674,7 @@ fn test_amend_undo_detached_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 94b10776514a5a182d920265fc3c42f2147b1201
+        branchless: running command: <git-executable> reset 94b10776514a5a182d920265fc3c42f2147b1201 --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -700,11 +700,11 @@ fn test_amend_undo_detached_head() -> eyre::Result<()> {
                       as c0bdfb5 create file1.txt
         4. Restore snapshot for c0bdfb5 create file1.txt
                 backed up using 55e9304 branchless: automated working copy snapshot
-        branchless: running command: <git-executable> checkout 55e9304c975103af25622dca880679182506f49f
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> checkout 55e9304c975103af25622dca880679182506f49f --
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 55e9304 branchless: automated working copy snapshot
-        branchless: running command: <git-executable> checkout 7b6d0f10f68cf5df3de91f062c565e45f1b28006
-        branchless: running command: <git-executable> reset c0bdfb5ba33c02bba2aa451efe2f220f12232408
+        branchless: running command: <git-executable> checkout 7b6d0f10f68cf5df3de91f062c565e45f1b28006 --
+        branchless: running command: <git-executable> reset c0bdfb5ba33c02bba2aa451efe2f220f12232408 --
         Unstaged changes after reset:
         M	file1.txt
         O f777ecc (master) create initial.txt
@@ -749,7 +749,7 @@ fn test_amend_reparent() -> eyre::Result<()> {
             ],
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526
+        branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526 --
         Rebase constraints before adding descendants: [
             (
                 NonZeroOid(3d8543b87d55c5b7995935e18e05cb6c399fb526),
@@ -922,7 +922,7 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         let (stdout, _stderr) =
             git.branchless("amend", &["--reparent", "--debug-dump-rebase-plan"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset d517a648915434edf38114da4efd820ec6f513cf
+        branchless: running command: <git-executable> reset d517a648915434edf38114da4efd820ec6f513cf --
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(7ec39c7da50fc25deeea3318d937e1005de2a047),
@@ -1050,12 +1050,12 @@ fn test_amend_no_detach_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: processing 1 update: branch foo
-        branchless: running command: <git-executable> reset foo
+        branchless: running command: <git-executable> reset foo --
         Attempting rebase in-memory...
         [1/1] Committed as: fc597fa create test2.txt
         branchless: processing 1 update: branch bar
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         In-memory rebase succeeded.
         Restacked 1 commit.
         Amended with 1 uncommitted change.
@@ -1104,7 +1104,7 @@ fn test_amend_merge() -> eyre::Result<()> {
         )?;
         let stdout = remove_rebase_lines(stdout);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526
+        branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526 --
         Attempting rebase in-memory...
         Failed to merge in-memory, trying again on-disk...
         branchless: running command: <git-executable> diff --quiet
@@ -1166,7 +1166,7 @@ fn test_amend_move_detached_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
         branchless: processing 1 update: branch foo
-        branchless: running command: <git-executable> reset 7143ebcc44407b0553d9f50eaf29e0e4f0f0d6c0
+        branchless: running command: <git-executable> reset 7143ebcc44407b0553d9f50eaf29e0e4f0f0d6c0 --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -1201,7 +1201,7 @@ fn test_amend_merge_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset 3ebbc8fdaff7b5d5d0f1101feb3640d06b0297a2
+        branchless: running command: <git-executable> reset 3ebbc8fdaff7b5d5d0f1101feb3640d06b0297a2 --
         Amended with 1 uncommitted change.
         "###);
     }
@@ -1240,6 +1240,50 @@ fn test_amend_merge_commit() -> eyre::Result<()> {
         @@@ -1,0 -1,1 +1,1 @@@
          -test1 contents
         ++new test1 contents
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_with_branch_name_matching_file() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    git.init_repo()?;
+
+    // Create a branch named 'foo'
+    git.run(&["checkout", "-b", "foo"])?;
+    git.commit_file("test1", 1)?;
+
+    // Create a file with the same name as the branch
+    git.write_file("foo", "some file content\n")?;
+
+    // Try to amend - this should work despite the file name matching the branch name
+    {
+        let (stdout, _stderr) = git.branchless("amend", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        There are no uncommitted or staged changes. Nothing to amend.
+        "###);
+    }
+
+    // Now modify test1 and amend - this should also work
+    git.write_file_txt("test1", "modified contents\n")?;
+    {
+        let (stdout, _stderr) = git.branchless("amend", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: processing 1 update: branch foo
+        branchless: running command: <git-executable> reset foo --
+        Amended with 1 uncommitted change.
+        "###);
+    }
+
+    {
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        @ d408d49 (> foo) create test1.txt
         "###);
     }
 

--- a/git-branchless/tests/test_branchless.rs
+++ b/git-branchless/tests/test_branchless.rs
@@ -41,7 +41,7 @@ fn test_commands() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         @ 3df4b93 (> master) create test.txt
         |
@@ -52,7 +52,7 @@ fn test_commands() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 73b746ca864a21fc0c3dedbc937eaa9e279b73eb
+        branchless: running command: <git-executable> checkout 73b746ca864a21fc0c3dedbc937eaa9e279b73eb --
         :
         O 3df4b93 (master) create test.txt
         |
@@ -158,7 +158,7 @@ fn test_index_version_4() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("switch", &["HEAD"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout HEAD
+        branchless: running command: <git-executable> checkout HEAD --
         @ f777ecc (> master) create initial.txt
         "###);
     }

--- a/git-branchless/tests/test_move.rs
+++ b/git-branchless/tests/test_move.rs
@@ -96,7 +96,7 @@ fn test_move_stick() -> eyre::Result<()> {
         [1/2] Committed as: 4838e49 create test3.txt
         [2/2] Committed as: a248207 create test4.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b
+        branchless: running command: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b --
         :
         O 62fc20d create test1.txt
         |\
@@ -241,7 +241,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
         [2/3] Committed as: a248207 create test4.txt
         [3/3] Committed as: 5a436ed create test2.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b
+        branchless: running command: <git-executable> checkout a248207402822b7396cabe0f1011d8a7ce7daf1b --
         :
         O 62fc20d (master) create test1.txt
         |
@@ -2316,7 +2316,7 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
             [2/2] Committed as: a248207 create test4.txt
             branchless: processing 1 update: branch master
             branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout master
+            branchless: running command: <git-executable> checkout master --
             :
             O 62fc20d create test1.txt
             |\
@@ -2501,7 +2501,7 @@ fn test_move_base() -> eyre::Result<()> {
         [1/2] Committed as: 44352d0 create test2.txt
         [2/2] Committed as: cf5eb24 create test3.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         @ bf0d52a (> master) create test4.txt
         |
@@ -2560,7 +2560,7 @@ fn test_move_base_shared() -> eyre::Result<()> {
         [1/2] Committed as: 70deb1e create test3.txt
         [2/2] Committed as: 355e173 create test4.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout 355e173bf9c5d2efac2e451da0cdad3fb82b869a
+        branchless: running command: <git-executable> checkout 355e173bf9c5d2efac2e451da0cdad3fb82b869a --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -2631,7 +2631,7 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --
         :
         O 62fc20d (master) create test1.txt
         |
@@ -2708,7 +2708,7 @@ fn test_move_branch() -> eyre::Result<()> {
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 update: branch master
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         @ 70deb1e (> master) create test3.txt
         In-memory rebase succeeded.
@@ -3020,7 +3020,7 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: fe65c1f create test2.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout fe65c1fe15584744e649b2c79d4cf9b0d878f92e
+        branchless: running command: <git-executable> checkout fe65c1fe15584744e649b2c79d4cf9b0d878f92e --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -3095,7 +3095,7 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
         [3/3] Committed as: 566e434 create test5.txt
         branchless: processing 1 update: branch master
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         O 62fc20d create test1.txt
         |\
@@ -3270,7 +3270,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             [3/3] Committed as: 566e434 create test5.txt
             branchless: processing 2 updates: branch bar, branch foo
             branchless: processing 3 rewritten commits
-            branchless: running command: <git-executable> checkout bar
+            branchless: running command: <git-executable> checkout bar --
             :
             O 62fc20d create test1.txt
             |\
@@ -3396,7 +3396,7 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
             [2/2] Committed as: fa46633 create test2.txt
             branchless: processing 1 update: branch should-be-deleted
             branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout fa46633239bfa767036e41a77b67258286e4ddb9
+            branchless: running command: <git-executable> checkout fa46633239bfa767036e41a77b67258286e4ddb9 --
             :
             O 047b7ad (master) create test1.txt
             |
@@ -3473,7 +3473,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             Executing: git branchless hook-register-extra-post-rewrite-hook
             branchless: processing 4 rewritten commits
             branchless: creating working copy snapshot
-            branchless: running command: <git-executable> checkout master
+            branchless: running command: <git-executable> checkout master --
             Switched to branch 'master'
             branchless: processing checkout
             :
@@ -3537,7 +3537,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             [1/2] Skipped now-empty commit: e7bcdd6 create test1.txt
             [2/2] Skipped now-empty commit: 12d361a create test2.txt
             branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout master
+            branchless: running command: <git-executable> checkout master --
             :
             @ de4a1fe (> master) squashed test1 and test2
             In-memory rebase succeeded.
@@ -3610,7 +3610,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             branchless: processing 3 rewritten commits
             branchless: processing 2 updates: branch more-work, branch work
             branchless: creating working copy snapshot
-            branchless: running command: <git-executable> checkout master
+            branchless: running command: <git-executable> checkout master --
             Previous HEAD position was 012efd6 create test3.txt
             Switched to branch 'master'
             branchless: processing checkout
@@ -3658,7 +3658,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             [3/3] Committed as: 012efd6 create test3.txt
             branchless: processing 2 updates: branch more-work, branch work
             branchless: processing 3 rewritten commits
-            branchless: running command: <git-executable> checkout master
+            branchless: running command: <git-executable> checkout master --
             :
             @ 91c5ce6 (> master) create test2.txt
             |
@@ -4346,7 +4346,7 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             branchless: processing 3 rewritten commits
             branchless: processing 1 update: branch new-root
             branchless: creating working copy snapshot
-            branchless: running command: <git-executable> checkout new-root
+            branchless: running command: <git-executable> checkout new-root --
             Switched to branch 'new-root'
             branchless: processing checkout
             :
@@ -4395,7 +4395,7 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             [2/2] Committed as: 70deb1e create test3.txt
             branchless: processing 1 update: branch new-root
             branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout new-root
+            branchless: running command: <git-executable> checkout new-root --
             :
             O 96d1c37 (master) create test2.txt
             |
@@ -4487,7 +4487,7 @@ fn test_move_dest_not_in_dag() -> eyre::Result<()> {
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 update: branch other-branch
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout other-branch
+        branchless: running command: <git-executable> checkout other-branch --
         Your branch and 'origin/other-branch' have diverged,
         and have 2 and 1 different commits each, respectively.
         :
@@ -4652,7 +4652,7 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
         Executing: git branchless hook-register-extra-post-rewrite-hook
         branchless: processing 1 rewritten commit
         branchless: creating working copy snapshot
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         Previous HEAD position was 3632ef4 create test1.txt
         Switched to branch 'master'
         branchless: processing checkout
@@ -4718,7 +4718,7 @@ fn test_move_revset() -> eyre::Result<()> {
         [2/3] Committed as: f387c23 create test3.txt
         [3/3] Committed as: 9cb6a30 create test4.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         @ ea7aa06 (> master) create test5.txt
         |\
@@ -4760,7 +4760,7 @@ fn test_move_revset_non_continguous() -> eyre::Result<()> {
         [2/3] Committed as: fe65c1f create test2.txt
         [3/3] Committed as: 0206717 create test3.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout 8f7aef57d66466a6e0737ae10f67cd98ddecdc66
+        branchless: running command: <git-executable> checkout 8f7aef57d66466a6e0737ae10f67cd98ddecdc66 --
         O f777ecc create initial.txt
         |\
         | o fe65c1f create test2.txt
@@ -4819,7 +4819,7 @@ fn test_move_hint() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 62fc20d (master) create test1.txt
         |
@@ -4855,7 +4855,7 @@ fn test_move_hint() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 62fc20d (master) create test1.txt
         |
@@ -4906,7 +4906,7 @@ fn test_move_public_commit() -> eyre::Result<()> {
         [2/2] Committed as: 0770943 create test1.txt
         branchless: processing 1 update: branch master
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         :
         @ fe65c1f (> master) create test2.txt
         |
@@ -4945,7 +4945,7 @@ fn test_move_delete_branch_config_entry() -> eyre::Result<()> {
         [1/1] Skipped commit (was already applied upstream): 047b7ad create test1.txt
         branchless: processing 1 update: branch bar
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -5021,7 +5021,7 @@ fn test_move_fixup_head_into_parent() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 8c3aa56 update 2 test.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout 8c3aa56b40afc7aa8b61ac5d6f6bff9fd8407896
+        branchless: running command: <git-executable> checkout 8c3aa56b40afc7aa8b61ac5d6f6bff9fd8407896 --
         O f777ecc (master) create initial.txt
         |
         o 307a04c create test.txt
@@ -5091,7 +5091,7 @@ fn test_move_fixup_parent_into_head() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: ff6183f update 3 test.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout ff6183fc6b71c3fcf6f26247162bde4e34bc5193
+        branchless: running command: <git-executable> checkout ff6183fc6b71c3fcf6f26247162bde4e34bc5193 --
         O f777ecc (master) create initial.txt
         |
         o 307a04c create test.txt
@@ -5171,7 +5171,7 @@ fn test_move_fixup_head_into_ancestor() -> eyre::Result<()> {
         [2/2] Committed as: b9da1e0 update 2 test.txt
         branchless: processing 1 update: branch test
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout 963fb93e7a4b7c53a1feb565106a1a4e5a298bf4
+        branchless: running command: <git-executable> checkout 963fb93e7a4b7c53a1feb565106a1a4e5a298bf4 --
         O f777ecc (master) create initial.txt
         |
         @ 963fb93 create test.txt
@@ -5258,7 +5258,7 @@ fn test_move_fixup_ancestor_into_head() -> eyre::Result<()> {
         [1/2] Committed as: dbcd17a update 3 test.txt
         [2/2] Committed as: 2b97091 update 4 test.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout 2b970915e7142b451375b5df3dc7a02db6022357
+        branchless: running command: <git-executable> checkout 2b970915e7142b451375b5df3dc7a02db6022357 --
         O f777ecc (master) create initial.txt
         |
         o 307a04c create test.txt
@@ -5336,7 +5336,7 @@ fn test_move_fixup_multiple_into_head() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: c4f6746 update 3 test.txt
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout c4f67465a26371b485ddd7eacfe61d0b962f92a6
+        branchless: running command: <git-executable> checkout c4f67465a26371b485ddd7eacfe61d0b962f92a6 --
         O f777ecc (master) create initial.txt
         |
         @ c4f6746 update 3 test.txt
@@ -5428,7 +5428,7 @@ fn test_move_fixup_multiple_into_ancestor_with_unmoved_head() -> eyre::Result<()
         [1/2] Committed as: 23d4bdd create test.txt
         [2/2] Committed as: 797ef91 update 4 test.txt
         branchless: processing 4 rewritten commits
-        branchless: running command: <git-executable> checkout 797ef91eb97d58cc1898de8ddcdfc31388a8893e
+        branchless: running command: <git-executable> checkout 797ef91eb97d58cc1898de8ddcdfc31388a8893e --
         O f777ecc (master) create initial.txt
         |
         o 23d4bdd create test.txt
@@ -5611,7 +5611,7 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
         [4/4] Committed as: 472b70b update 6 test.txt
         branchless: processing 1 update: branch test
         branchless: processing 6 rewritten commits
-        branchless: running command: <git-executable> checkout 472b70be50d5c91210b3f2a089dbbb6af3a6bb71
+        branchless: running command: <git-executable> checkout 472b70be50d5c91210b3f2a089dbbb6af3a6bb71 --
         O f777ecc (master) create initial.txt
         |
         o 38caaaf (test) create test.txt
@@ -5803,7 +5803,7 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
         [2/2] Committed as: 237b381 update 6 test.txt
         branchless: processing 1 update: branch test
         branchless: processing 4 rewritten commits
-        branchless: running command: <git-executable> checkout 237b381bee4b7d2fdb4a300affdf9f5aa3e78a0c
+        branchless: running command: <git-executable> checkout 237b381bee4b7d2fdb4a300affdf9f5aa3e78a0c --
         O f777ecc (master) create initial.txt
         |
         o 64eb9bf create test.txt
@@ -5920,7 +5920,7 @@ fn test_move_fixup_squash_branch() -> eyre::Result<()> {
         [1/1] Committed as: c513440 create test.txt
         branchless: processing 1 update: branch test
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout test
+        branchless: running command: <git-executable> checkout test --
         O f777ecc (master) create initial.txt
         |
         @ c513440 (> test) create test.txt
@@ -6028,7 +6028,7 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
         [2/2] Committed as: 2746e2a update 2 test.txt
         branchless: processing 3 updates: branch test-1, branch test-2, branch test-3
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout test-3
+        branchless: running command: <git-executable> checkout test-3 --
         O f777ecc (master) create initial.txt
         |
         @ f4321df (> test-3, test-1) create test.txt
@@ -6218,7 +6218,7 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
         [3/3] Committed as: 1e7fdb8 update 5 test.txt
         branchless: processing 1 update: branch test
         branchless: processing 5 rewritten commits
-        branchless: running command: <git-executable> checkout 5e6d3e476b7c3dfb2e1344d8b13ef12523fc07af
+        branchless: running command: <git-executable> checkout 5e6d3e476b7c3dfb2e1344d8b13ef12523fc07af --
         O f777ecc (master) create initial.txt
         |
         o 64eb9bf create test.txt
@@ -6312,7 +6312,7 @@ fn test_move_fixup_added_files() -> eyre::Result<()> {
     Attempting rebase in-memory...
     [1/1] Committed as: e9f8a2b create test1.txt
     branchless: processing 2 rewritten commits
-    branchless: running command: <git-executable> checkout e9f8a2b1e4c72b2ca31c5f2feffabc947e2f1b5a
+    branchless: running command: <git-executable> checkout e9f8a2b1e4c72b2ca31c5f2feffabc947e2f1b5a --
     O f777ecc (master) create initial.txt
     |
     @ e9f8a2b create test1.txt
@@ -6373,7 +6373,7 @@ fn test_worktree_rebase_in_memory() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 4838e49 create test3.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 4838e49b08954becdd17c0900c1179c2c654c627
+        branchless: running command: <git-executable> checkout 4838e49b08954becdd17c0900c1179c2c654c627 --
         :
         O 62fc20d (master) create test1.txt
         |\

--- a/git-branchless/tests/test_navigation.rs
+++ b/git-branchless/tests/test_navigation.rs
@@ -14,7 +14,7 @@ fn test_prev() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24
+        branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
         @ f777ecc create initial.txt
         |
         O 62fc20d (master) create test1.txt
@@ -58,7 +58,7 @@ fn test_prev_multiple() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24
+        branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
         @ f777ecc create initial.txt
         :
         O 96d1c37 (master) create test2.txt
@@ -81,7 +81,7 @@ fn test_next_multiple() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -129,7 +129,7 @@ fn test_next_ambiguous() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["--oldest"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |\
         | @ 62fc20d create test1.txt
@@ -144,7 +144,7 @@ fn test_next_ambiguous() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["--newest"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 98b9119d16974f372e76cb64a3b77c528fc0b18b
+        branchless: running command: <git-executable> checkout 98b9119d16974f372e76cb64a3b77c528fc0b18b --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -217,7 +217,7 @@ fn test_next_on_master() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 96d1c37 (master) create test2.txt
         |
@@ -242,7 +242,7 @@ fn test_next_on_master2() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 62fc20d (master) create test1.txt
         |
@@ -270,7 +270,7 @@ fn test_next_no_more_children() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("next", &["3"])?;
         insta::assert_snapshot!(stdout, @r###"
         No more child commits to go to after traversing 2 children.
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 96d1c37 (master) create test2.txt
         |
@@ -394,7 +394,7 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["-a"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
@@ -408,7 +408,7 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["-a"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f
+        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -439,7 +439,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["-b", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -455,7 +455,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("prev", &["-a", "-b"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -471,7 +471,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("prev", &["-b"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -489,7 +489,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["-b", "2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout bar
+        branchless: running command: <git-executable> checkout bar --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -507,7 +507,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("next", &["-a", "-b"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout bar
+        branchless: running command: <git-executable> checkout bar --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -539,7 +539,7 @@ fn test_traverse_branches_ambiguous() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["--all", "--branch"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d (bar, foo) create test1.txt
@@ -573,7 +573,7 @@ fn test_navigation_failed_to_check_out_commit() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
         "###);
     }
@@ -672,7 +672,7 @@ fn test_navigation_merge() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5
+        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --
         Failed to check out commit: 25497cb08387d7d20aa741398b73ce7f924afdb5
         "###);
         insta::assert_snapshot!(stderr, @r###"
@@ -687,7 +687,7 @@ fn test_navigation_merge() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["--merge"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --merge
+        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --merge --
         M	conflicting.txt
         O f777ecc (master) create initial.txt
         |
@@ -737,7 +737,7 @@ fn test_navigation_force() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5
+        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --
         Failed to check out commit: 25497cb08387d7d20aa741398b73ce7f924afdb5
         "###);
         insta::assert_snapshot!(stderr, @r###"
@@ -752,7 +752,7 @@ fn test_navigation_force() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("prev", &["--force"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --force
+        branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --force --
         O f777ecc (master) create initial.txt
         |
         @ 25497cb create conflicting.txt
@@ -782,7 +782,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.branchless("switch", &["-c", "foo", "HEAD^"])?;
             insta::assert_snapshot!(stdout, @r###"
-            branchless: running command: <git-executable> checkout HEAD^ -b foo
+            branchless: running command: <git-executable> checkout HEAD^ -b foo --
             :
             @ 62fc20d (> foo) create test1.txt
             |
@@ -793,7 +793,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         {
             let (stdout, _stderr) = git.branchless("switch", &["-c", "bar"])?;
             insta::assert_snapshot!(stdout, @r###"
-            branchless: running command: <git-executable> checkout foo -b bar
+            branchless: running command: <git-executable> checkout foo -b bar --
             :
             @ 62fc20d (> bar, foo) create test1.txt
             |
@@ -809,7 +809,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
             git.write_file_txt("test1", "conflicting\n")?;
             let (stdout, _stderr) = git.branchless("switch", &["-f", "HEAD~2"])?;
             insta::assert_snapshot!(stdout, @r###"
-            branchless: running command: <git-executable> checkout HEAD~2 --force
+            branchless: running command: <git-executable> checkout HEAD~2 --force --
             :
             @ 62fc20d create test1.txt
             :
@@ -823,7 +823,7 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         git.write_file_txt("test1", "conflicting\n")?;
         let (stdout, _stderr) = git.branchless("switch", &["-m", "HEAD~2"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout HEAD~2 --merge
+        branchless: running command: <git-executable> checkout HEAD~2 --merge --
         M	test1.txt
         :
         @ 62fc20d create test1.txt
@@ -843,7 +843,7 @@ fn test_navigation_switch_target_only() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("switch", &["master"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
         "###);
     }
@@ -872,7 +872,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("switch", &["descendants(master)"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
@@ -913,7 +913,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
         // switching back to "last checkout"
         let (stdout, _stderr) = git.branchless("switch", &["@{-1}"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout @{-1}
+        branchless: running command: <git-executable> checkout @{-1} --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -926,7 +926,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
         // switching back to "last checkout"
         let (stdout, _stderr) = git.branchless("switch", &["-"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout -
+        branchless: running command: <git-executable> checkout - --
         @ f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -941,7 +941,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("switch", &["master"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -951,7 +951,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("switch", &["@{-2}"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout @{-2}
+        branchless: running command: <git-executable> checkout @{-2} --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -961,7 +961,7 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.branchless("switch", &["-"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout -
+        branchless: running command: <git-executable> checkout - --
         @ f777ecc (> master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -1066,7 +1066,7 @@ fn test_switch_detach() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("switch", &["-d"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout master --detach
+        branchless: running command: <git-executable> checkout master --detach --
         :
         O 62fc20d (foo) create test1.txt
         |
@@ -1077,7 +1077,7 @@ fn test_switch_detach() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("switch", &["-d", "foo"])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout foo --detach
+        branchless: running command: <git-executable> checkout foo --detach --
         :
         @ 62fc20d (foo) create test1.txt
         |
@@ -1088,7 +1088,7 @@ fn test_switch_detach() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("switch", &[])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         :
         @ 62fc20d (> foo) create test1.txt
         |

--- a/git-branchless/tests/test_restack.rs
+++ b/git-branchless/tests/test_restack.rs
@@ -361,7 +361,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         Executing: git branchless hook-register-extra-post-rewrite-hook
         branchless: processing 1 rewritten commit
         branchless: creating working copy snapshot
-        branchless: running command: <git-executable> checkout 3bd716d57489779ab1daf446f80e66e90b56ead7
+        branchless: running command: <git-executable> checkout 3bd716d57489779ab1daf446f80e66e90b56ead7 --
         Previous HEAD position was 944f78d create test3.txt
         branchless: processing 1 update: ref HEAD
         HEAD is now at 3bd716d updated test4
@@ -488,7 +488,7 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
         [1/1] Committed as: 59e7581 create test2.txt
         branchless: processing 2 updates: branch foo, branch master
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         In-memory rebase succeeded.
         Finished restacking commits.
         No abandoned branches to restack.
@@ -521,7 +521,7 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
         [1/1] Committed as: 59e7581 create test2.txt
         branchless: processing 2 updates: branch foo, branch master
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout foo
+        branchless: running command: <git-executable> checkout foo --
         In-memory rebase succeeded.
         Finished restacking commits.
         No abandoned branches to restack.

--- a/git-branchless/tests/test_reword.rs
+++ b/git-branchless/tests/test_reword.rs
@@ -561,7 +561,7 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 2fc54bd new message
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 2fc54bd59c79078e6d9012df241bcc90f0199596
+        branchless: running command: <git-executable> checkout 2fc54bd59c79078e6d9012df241bcc90f0199596 --
         In-memory rebase succeeded.
         Reworded commit a4dd9b0 as 2fc54bd new message
         "###);
@@ -612,7 +612,7 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         [2/3] Committed as: 800dd6c new message 2
         [3/3] Committed as: 930244c new message 2
         branchless: processing 3 rewritten commits
-        branchless: running command: <git-executable> checkout 930244cad08ebb6278b3b606c45a6848dcc5cc74
+        branchless: running command: <git-executable> checkout 930244cad08ebb6278b3b606c45a6848dcc5cc74 --
         In-memory rebase succeeded.
         Reworded commit 96d1c37 as 800dd6c new message 2
         Reworded commit 4838e49 as 11f31c5 new message 2

--- a/git-branchless/tests/test_snapshot.rs
+++ b/git-branchless/tests/test_snapshot.rs
@@ -92,10 +92,10 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
         branchless: processing 1 update: branch master
         "###);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 96d1c37 create test2.txt
-        branchless: running command: <git-executable> checkout f7ec40d081d7fa358f5e283ebf42f06a1508084c
-        branchless: running command: <git-executable> reset 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: running command: <git-executable> checkout f7ec40d081d7fa358f5e283ebf42f06a1508084c --
+        branchless: running command: <git-executable> reset 96d1c37a3d4363611c49f7e52186e189a04c531f --
         Unstaged changes after reset:
         M	test1.txt
         M	test2.txt
@@ -202,10 +202,10 @@ fn test_restore_snapshot_deleted_files() -> eyre::Result<()> {
         branchless: processing 1 update: branch master
         "###);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 96d1c37 create test2.txt
-        branchless: running command: <git-executable> checkout 1935fedb3b0232849e52e44225b2e5bbe9de0ff7
-        branchless: running command: <git-executable> reset 96d1c37a3d4363611c49f7e52186e189a04c531f
+        branchless: running command: <git-executable> checkout 1935fedb3b0232849e52e44225b2e5bbe9de0ff7 --
+        branchless: running command: <git-executable> reset 96d1c37a3d4363611c49f7e52186e189a04c531f --
         Unstaged changes after reset:
         D	test1.txt
         D	test2.txt
@@ -275,10 +275,10 @@ fn test_restore_snapshot_delete_file_only_in_index() -> eyre::Result<()> {
         branchless: processing 1 update: branch master
         "###);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 62fc20d create test1.txt
-        branchless: running command: <git-executable> checkout eb8b9eecf747c1aa08bb9dd0cbda15b9a90082af
-        branchless: running command: <git-executable> reset 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
+        branchless: running command: <git-executable> checkout eb8b9eecf747c1aa08bb9dd0cbda15b9a90082af --
+        branchless: running command: <git-executable> reset 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         Unstaged changes after reset:
         D	test1.txt
         branchless: running command: <git-executable> update-ref refs/heads/master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
@@ -344,9 +344,9 @@ fn test_restore_snapshot_respect_untracked_changes() -> eyre::Result<()> {
         Aborting
         "###);
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at f777ecc create initial.txt
-        branchless: running command: <git-executable> checkout cd8605eef8b78e22427fa3846f1a23f95e88aa7e
+        branchless: running command: <git-executable> checkout cd8605eef8b78e22427fa3846f1a23f95e88aa7e --
         "###);
     }
 
@@ -419,10 +419,10 @@ fn test_snapshot_merge_conflict() -> eyre::Result<()> {
         let (stdout, _stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 588fac3 delete test2.txt
-        branchless: running command: <git-executable> checkout 1ea5d7118ef363f3e4ed0ed6c250dd01b91bff2a
-        branchless: running command: <git-executable> reset 588fac31cba846f7278a95e1361c45118be90c6c
+        branchless: running command: <git-executable> checkout 1ea5d7118ef363f3e4ed0ed6c250dd01b91bff2a --
+        branchless: running command: <git-executable> reset 588fac31cba846f7278a95e1361c45118be90c6c --
         branchless: running command: <git-executable> update-ref refs/heads/change 588fac31cba846f7278a95e1361c45118be90c6c
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/change
         "###);
@@ -489,9 +489,9 @@ fn test_snapshot_restore_unborn_head() -> eyre::Result<()> {
         let (stdout, _stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
         insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> reset --hard HEAD
+        branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 6118a39 create test1.txt
-        branchless: running command: <git-executable> checkout 20939f1f30f51ffaa6569d218cd7a50f24c956cf
+        branchless: running command: <git-executable> checkout 20939f1f30f51ffaa6569d218cd7a50f24c956cf --
         branchless: running command: <git-executable> update-ref refs/heads/master 0000000000000000000000000000000000000000
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/master
         "###);

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -26,7 +26,7 @@ fn test_split_detached_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471
+            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -83,7 +83,7 @@ fn test_split_added_file() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 2f9e232b389b1bc8035f4e5bde79f262c0af020c
+            branchless: running command: <git-executable> checkout 2f9e232b389b1bc8035f4e5bde79f262c0af020c --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -140,7 +140,7 @@ fn test_split_modified_file() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00
+            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -207,7 +207,7 @@ fn test_split_deleted_file() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00
+            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -262,7 +262,7 @@ fn test_split_multiple_files() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "test3.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 8e5c74b7a1f09fc7ee1754763c810e3f00fe9b05
+            branchless: running command: <git-executable> checkout 8e5c74b7a1f09fc7ee1754763c810e3f00fe9b05 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -318,7 +318,7 @@ fn test_split_detached_branch() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
         insta::assert_snapshot!(&stdout, @r###"
             branchless: processing 1 update: branch branch-name
-            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471
+            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -409,7 +409,7 @@ fn test_split_restacks_descendents() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: a629a22 create test3.txt
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1
+            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -470,7 +470,7 @@ fn test_split_detach() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: f88fbe5 create test3.txt
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout f88fbe5901493ffe1c669cdb8aa5f056dc0bb605
+            branchless: running command: <git-executable> checkout f88fbe5901493ffe1c669cdb8aa5f056dc0bb605 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -553,7 +553,7 @@ fn test_split_discard() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: 6e23d3d second commit
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 6e23d3dfe1baeb366ebc31a61c32a19ca6a4ab63
+            branchless: running command: <git-executable> checkout 6e23d3dfe1baeb366ebc31a61c32a19ca6a4ab63 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -583,7 +583,7 @@ fn test_split_discard() -> eyre::Result<()> {
         let (stdout, _stderr) =
             git.branchless("split", &["HEAD", "test3.txt", "test4.txt", "--discard"])?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 6128a569e64c77d8a847293b81ae8c96357b751c
+            branchless: running command: <git-executable> checkout 6128a569e64c77d8a847293b81ae8c96357b751c --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -673,7 +673,7 @@ fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
             [1/1] Committed as: 6e23d3d second commit
             branchless: processing 1 update: branch my-branch
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout my-branch
+            branchless: running command: <git-executable> checkout my-branch --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -786,7 +786,7 @@ fn test_split_insert_before_added_file() -> eyre::Result<()> {
             [1/2] Committed as: 7014c04 first commit
             [2/2] Committed as: 22bd240 create test3.txt
             branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout 22bd2405a4660938b88615fb2b1283bfa2a52f8e
+            branchless: running command: <git-executable> checkout 22bd2405a4660938b88615fb2b1283bfa2a52f8e --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -865,7 +865,7 @@ fn test_split_insert_before_modified_file() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: 38fe8b7 second commit
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 38fe8b76f889772efd0dd5cc1acb6ac02c85f9fb
+            branchless: running command: <git-executable> checkout 38fe8b76f889772efd0dd5cc1acb6ac02c85f9fb --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -943,7 +943,7 @@ fn test_split_insert_before_deleted_file() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: f8502a2 second commit
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout f8502a26000b8f90597f6861d7f3c0330fdf4351
+            branchless: running command: <git-executable> checkout f8502a26000b8f90597f6861d7f3c0330fdf4351 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -1005,7 +1005,7 @@ fn test_split_insert_before_attached_branch() -> eyre::Result<()> {
             [1/1] Committed as: c678b65 first commit
             branchless: processing 1 update: branch branch-name
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout branch-name
+            branchless: running command: <git-executable> checkout branch-name --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -1065,7 +1065,7 @@ fn test_split_insert_before_detached_branch() -> eyre::Result<()> {
             [1/1] Committed as: c678b65 first commit
             branchless: processing 1 update: branch branch-name
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout c678b6529d8f33a6903e25f70327464bd77f1ca1
+            branchless: running command: <git-executable> checkout c678b6529d8f33a6903e25f70327464bd77f1ca1 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -1121,7 +1121,7 @@ fn test_split_undo_works() -> eyre::Result<()> {
             Attempting rebase in-memory...
             [1/1] Committed as: a629a22 create test3.txt
             branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1
+            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
             In-memory rebase succeeded.
             O f777ecc (master) create initial.txt
             |
@@ -1206,7 +1206,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             },
         )?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout d9d41a308e25a71884831c865c356da43cc5294e
+            branchless: running command: <git-executable> checkout d9d41a308e25a71884831c865c356da43cc5294e --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -1238,7 +1238,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             },
         )?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 0cb81546d386a2064603c05ce7dc9759591f5a93
+            branchless: running command: <git-executable> checkout 0cb81546d386a2064603c05ce7dc9759591f5a93 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -1270,7 +1270,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             },
         )?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 912204674dfda3ab5fe089dddd1c9bf17b3c2965
+            branchless: running command: <git-executable> checkout 912204674dfda3ab5fe089dddd1c9bf17b3c2965 --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |
@@ -1302,7 +1302,7 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
             },
         )?;
         insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 6d0cd9b8fb1938e50250f30427a0d4865b351f2f
+            branchless: running command: <git-executable> checkout 6d0cd9b8fb1938e50250f30427a0d4865b351f2f --
             Nothing to restack.
             O f777ecc (master) create initial.txt
             |

--- a/git-branchless/tests/test_sync.rs
+++ b/git-branchless/tests/test_sync.rs
@@ -57,12 +57,12 @@ fn test_sync_basic() -> eyre::Result<()> {
         [1/2] Committed as: 87c7a36 create test1.txt
         [2/2] Committed as: 8ee4f26 create test2.txt
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         In-memory rebase succeeded.
         Attempting rebase in-memory...
         [1/1] Committed as: d7e7e6c create test4.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         In-memory rebase succeeded.
         Synced 62fc20d create test1.txt
         Synced 2b633ed create test4.txt
@@ -163,7 +163,7 @@ fn test_sync_pull() -> eyre::Result<()> {
         Attempting rebase in-memory...
         [1/1] Committed as: 2831fb5 create test6.txt
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 2831fb5864ee099dc3e448a38dcb3c8527149510
+        branchless: running command: <git-executable> checkout 2831fb5864ee099dc3e448a38dcb3c8527149510 --
         In-memory rebase succeeded.
         Synced 6ac5566 create test6.txt
         "###);
@@ -235,7 +235,7 @@ fn test_sync_stack_from_commit() -> eyre::Result<()> {
         [2/2] Committed as: 11bfd99 create test3-1.txt
         branchless: processing 1 update: branch foo
         branchless: processing 2 rewritten commits
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         In-memory rebase succeeded.
         Synced 70deb1e create test3.txt
         "###);
@@ -303,7 +303,7 @@ fn test_sync_divergent_main_branch() -> eyre::Result<()> {
         [1/1] Committed as: f81d55c create test5.txt
         branchless: processing 1 update: branch master
         branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         Your branch is ahead of 'origin/master' by 1 commit.
           (use "git push" to publish your local commits)
         In-memory rebase succeeded.
@@ -364,7 +364,7 @@ fn test_sync_no_delete_main_branch() -> eyre::Result<()> {
         branchless: processing 1 rewritten commit
         branchless: processing 2 updates: branch master, branch should-be-deleted
         branchless: creating working copy snapshot
-        branchless: running command: <git-executable> checkout master
+        branchless: running command: <git-executable> checkout master --
         branchless: processing checkout
         :
         @ 96d1c37 (> master) create test2.txt

--- a/git-branchless/tests/test_undo.rs
+++ b/git-branchless/tests/test_undo.rs
@@ -412,7 +412,7 @@ fn test_undo_move_refs() -> eyre::Result<()> {
                                 to 62fc20d create test1.txt
         3. Check out from 96d1c37 create test2.txt
                        to 62fc20d create test1.txt
-        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach
+        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         Applied 3 inverse events.
         "###);
         assert_eq!(exit_code, 0);
@@ -642,7 +642,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
                        to f777ecc create initial.txt
         5. Delete branch foo at f777ecc create initial.txt
 
-        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach
+        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         Applied 5 inverse events.
         "###);
         assert_eq!(exit_code, 0);
@@ -805,7 +805,7 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
                                 to 62fc20d create test1.txt
         3. Check out from 62fc20d create test1.txt
                        to <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>
-        Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach
+        Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach --
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
         "###);
         assert!(exit_code > 0);
@@ -880,7 +880,7 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
                                 to 96d1c37 create test2.txt
         4. Check out from 9ed8f9a bad message
                        to 96d1c37 create test2.txt
-        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach
+        Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         :
         @ 96d1c37 (master) create test2.txt
         Applied 4 inverse events.


### PR DESCRIPTION
## Problem

When a branch name matches a filename in the working directory, Git commands like `git checkout` and `git reset` become ambiguous about whether arguments are refs or paths. This causes git-branchless commands (like `git branchless amend`) to fail when operating on branches that have the same name as files in the current directory.

Example scenario:
```bash
$ git checkout -b foo
$ touch foo
$ git branchless amend
# Error: pathspec 'foo' did not match any files
```

## Solution

This PR adds the standard Git `--` separator to all checkout and reset operations in the `check_out` module to explicitly separate refs from paths, preventing such ambiguity.

### Changes

**Core fix (check_out.rs):** Added `--` separator to 5 git command invocations:
- Line 150: `git reset <target> --`
- Line 159: `git checkout <target> --`
- Line 261: `git reset --hard HEAD --`
- Line 274: `git checkout <oid> --`
- Line 286: `git reset <oid> --`

**Tests:**
- Updated 220+ test snapshots across 15 test files to match the new command output format with `--` separator
- Added new test `test_amend_with_branch_name_matching_file()` in test_amend.rs to verify the fix works when branch names match filenames

The `--` separator is a standard Git convention that tells Git to treat everything before it as refs/options and everything after it as paths. This ensures unambiguous command parsing even when branch names and filenames collide.

### Test Results

All affected test suites passing:
- ✅ test_amend (18 tests)
- ✅ test_navigation (24 tests)
- ✅ test_move (70 tests)
- ✅ test_snapshot (6 tests)
- ✅ test_split (20 tests)
- ✅ test_record (16 tests)
- ✅ test_sync, test_restack, test_reword, test_branchless
- ✅ test_github_forge, test_phabricator_forge