### PR TITLE
feat(move): implement move --reparent like amend --reparent

### DIFF
--- a/git-branchless-lib/src/core/rewrite/plan.rs
+++ b/git-branchless-lib/src/core/rewrite/plan.rs
@@ -1025,7 +1025,9 @@ impl<'a> RebasePlanBuilder<'a> {
         source_oid: NonZeroOid,
         dest_oids: Vec<NonZeroOid>,
     ) -> eyre::Result<()> {
-        assert!(!dest_oids.is_empty());
+        if dest_oids.is_empty() {
+            eyre::bail!("Destination OIDs must not be empty for move_subtree");
+        }
         self.initial_constraints.push(Constraint::MoveSubtree {
             parent_oids: dest_oids,
             child_oid: source_oid,
@@ -1093,7 +1095,9 @@ impl<'a> RebasePlanBuilder<'a> {
         parent_oids: Vec<NonZeroOid>,
         repo: &Repo,
     ) -> eyre::Result<()> {
-        assert!(!parent_oids.is_empty());
+        if parent_oids.is_empty() {
+            eyre::bail!("Parent OIDs must not be empty for reparent_commit");
+        }
 
         // To keep the contents of all descendant commits the same, forcibly
         // replace the child commit, and then rely on normal patch

--- a/git-branchless-lib/src/core/rewrite/plan.rs
+++ b/git-branchless-lib/src/core/rewrite/plan.rs
@@ -4,6 +4,7 @@ use std::ops::Sub;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use bstr::ByteSlice;
 use chashmap::CHashMap;
 use eyre::Context;
 use itertools::Itertools;
@@ -1076,6 +1077,49 @@ impl<'a> RebasePlanBuilder<'a> {
             commit_to_fixup_oid: dest_oid,
             fixup_commit_oid: source_oid,
         });
+        Ok(())
+    }
+
+    /// Instruct the rebase planner to "reparent" the commit at `source_oid`
+    /// onto `parent_oids`, keeping all contents of `source_oid` exactly the same.
+    ///
+    /// Note that in the end the descendant commits of `source_oid` will be
+    /// automatically rebased on top of `source_oid` following normal patch
+    /// application logic, hence the whole subtree of `source_oid` will be
+    /// effectively reparented on top of `parent_oids`.
+    pub fn reparent_commit(
+        &mut self,
+        source_oid: NonZeroOid,
+        parent_oids: Vec<NonZeroOid>,
+        repo: &Repo,
+    ) -> eyre::Result<()> {
+        assert!(!parent_oids.is_empty());
+
+        // To keep the contents of all descendant commits the same, forcibly
+        // replace the child commit, and then rely on normal patch
+        // application for its descendants.
+        let parents: Vec<_> = parent_oids
+            .into_iter()
+            .map(|parent_oid| repo.find_commit_or_fail(parent_oid))
+            .try_collect()?;
+        let source_commit = repo.find_commit_or_fail(source_oid)?;
+        let source_message = source_commit.get_message_raw();
+        let source_message = source_message.to_str().with_context(|| {
+            eyre::eyre!(
+                "Could not decode commit message for source commit: {:?}",
+                source_commit
+            )
+        })?;
+        let reparented_source_oid = repo.create_commit(
+            None,
+            &source_commit.get_author(),
+            &source_commit.get_committer(),
+            source_message,
+            &source_commit.get_tree()?,
+            parents.iter().collect(),
+        )?;
+        self.replace_commit(source_oid, reparented_source_oid)?;
+
         Ok(())
     }
 

--- a/git-branchless-move/src/lib.rs
+++ b/git-branchless-move/src/lib.rs
@@ -269,6 +269,7 @@ pub fn r#move(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
+        reparent,
     } = *move_options;
     let now = SystemTime::now();
     let event_tx_id = event_log_db.make_transaction_id(now, "move")?;

--- a/git-branchless-move/src/lib.rs
+++ b/git-branchless-move/src/lib.rs
@@ -315,6 +315,10 @@ pub fn r#move(
             } else {
                 builder.move_subtree(source_root, vec![dest_oid])?;
             }
+
+            if reparent {
+                builder.reparent_commit(source_root, vec![dest_oid], &repo)?;
+            }
         }
 
         let component_roots: CommitSet = exact_components.keys().cloned().collect();
@@ -419,6 +423,10 @@ pub fn r#move(
             } else {
                 builder.move_subtree(component_root, vec![component_dest_oid])?;
             }
+
+            if reparent {
+                builder.reparent_commit(component_root, vec![component_dest_oid], &repo)?;
+            }
         }
 
         if insert {
@@ -477,6 +485,9 @@ pub fn r#move(
 
             for dest_child in dag.commit_set_to_vec(&dest_children)? {
                 builder.move_subtree(dest_child, vec![source_head])?;
+                if reparent {
+                    builder.reparent_commit(dest_child, vec![source_head], &repo)?;
+                }
             }
         }
         builder.build(effects, &pool, &repo_pool)?

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -86,6 +86,13 @@ pub struct MoveOptions {
     #[clap(action, name = "merge", short = 'm', long = "merge")]
     pub resolve_merge_conflicts: bool,
 
+    /// Keep all contents of descendant commits exactly the same (i.e. "reparent" them).
+    /// This can be useful when applying formatting or refactoring changes.
+    /// Use with care if the descendants are moved from a far-away branch, as it may
+    /// carry along a lot of unintended changes onto the destination.
+    #[clap(long, conflicts_with = "merge")]
+    pub reparent: bool,
+
     /// Debugging option. Print the constraints used to create the rebase
     /// plan before executing it.
     #[clap(action, long = "debug-dump-rebase-constraints")]
@@ -460,12 +467,6 @@ pub enum Command {
         /// Options for moving commits.
         #[clap(flatten)]
         move_options: MoveOptions,
-
-        /// Modify the contents of the current HEAD commit, but keep all contents of descendant
-        /// commits exactly the same (i.e. "reparent" them). This can be useful when applying
-        /// formatting or refactoring changes.
-        #[clap(long)]
-        reparent: bool,
 
         /// How should newly encountered, untracked files be handled?
         #[clap(action, long = "untracked")]
@@ -957,7 +958,10 @@ pub enum TestSubcommand {
         verbosity: u8,
     },
 
-    /// Run a given command on a set of commits and present the successes and failures.
+    /// Rewrites a set of commits one by one, by running a given command on each commit
+    ///
+    /// The descendants are "reparented" onto the rewritten commits without changing their
+    /// contents. This avoids the possibility of merge conflicts in descendants.
     Fix {
         /// An ad-hoc command to execute on each commit.
         #[clap(value_parser, short = 'x', long = "exec")]

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -566,7 +566,7 @@ pub enum Command {
         move_options: MoveOptions,
 
         /// Combine the moved commits and squash them into the destination commit.
-        #[clap(action, short = 'F', long = "fixup", conflicts_with = "insert")]
+        #[clap(action, short = 'F', long = "fixup", conflicts_with_all(&["insert", "reparent"]))]
         fixup: bool,
 
         /// Insert the subtree between the destination and it's children, if any.

--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -393,6 +393,7 @@ BUG: Expected resolved_interactive ({resolved_interactive:?}) to match interacti
                 resolve_merge_conflicts,
                 dump_rebase_constraints,
                 dump_rebase_plan,
+                reparent: _, // always implied
             } = move_options;
 
             let force_in_memory = true;

--- a/git-branchless-test/src/lib.rs
+++ b/git-branchless-test/src/lib.rs
@@ -396,6 +396,13 @@ BUG: Expected resolved_interactive ({resolved_interactive:?}) to match interacti
                 reparent: _, // always implied
             } = move_options;
 
+            if *resolve_merge_conflicts {
+                writeln!(
+                    effects.get_output_stream(),
+                    "Ignoring --merge since --reparent is always implied when fixing commits."
+                )?;
+            }
+
             let force_in_memory = true;
             if *force_on_disk {
                 writeln!(

--- a/git-branchless/src/commands/amend.rs
+++ b/git-branchless/src/commands/amend.rs
@@ -9,8 +9,6 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bstr::ByteSlice;
-
 use eyre::Context;
 use git_branchless_opts::{MoveOptions, ResolveRevsetOptions};
 use itertools::Itertools;
@@ -268,30 +266,8 @@ pub fn amend(
                 .collect();
             builder.move_subtree(descendant_oid, parent_oids.clone())?;
 
-            // To keep the contents of all descendant commits the same, forcibly
-            // replace the children commits, and then rely on normal patch
-            // application to apply the rest.
             if reparent {
-                let parents: Vec<_> = parent_oids
-                    .into_iter()
-                    .map(|parent_oid| repo.find_commit_or_fail(parent_oid))
-                    .try_collect()?;
-                let descendant_message = descendant_commit.get_message_raw();
-                let descendant_message = descendant_message.to_str().with_context(|| {
-                    eyre::eyre!(
-                        "Could not decode commit message for descendant commit: {:?}",
-                        descendant_commit
-                    )
-                })?;
-                let reparented_descendant_oid = repo.create_commit(
-                    None,
-                    &descendant_commit.get_author(),
-                    &descendant_commit.get_committer(),
-                    descendant_message,
-                    &descendant_commit.get_tree()?,
-                    parents.iter().collect(),
-                )?;
-                builder.replace_commit(descendant_oid, reparented_descendant_oid)?;
+                builder.reparent_subtree(descendant_oid, parent_oids, &repo)?;
             }
         }
 

--- a/git-branchless/src/commands/amend.rs
+++ b/git-branchless/src/commands/amend.rs
@@ -40,7 +40,6 @@ pub fn amend(
     git_run_info: &GitRunInfo,
     resolve_revset_options: &ResolveRevsetOptions,
     move_options: &MoveOptions,
-    reparent: bool,
     untracked_file_strategy: Option<UntrackedFileStrategy>,
 ) -> EyreExitOr<()> {
     let now = SystemTime::now();
@@ -266,8 +265,8 @@ pub fn amend(
                 .collect();
             builder.move_subtree(descendant_oid, parent_oids.clone())?;
 
-            if reparent {
-                builder.reparent_subtree(descendant_oid, parent_oids, &repo)?;
+            if move_options.reparent {
+                builder.reparent_commit(descendant_oid, parent_oids, &repo)?;
             }
         }
 

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -35,14 +35,12 @@ fn command_main(ctx: CommandContext, opts: Opts) -> EyreExitOr<()> {
     let exit_code = match command {
         Command::Amend {
             move_options,
-            reparent,
             untracked_file_strategy,
         } => amend::amend(
             &effects,
             &git_run_info,
             &ResolveRevsetOptions::default(),
             &move_options,
-            reparent,
             untracked_file_strategy,
         )?,
 

--- a/git-branchless/src/commands/restack.rs
+++ b/git-branchless/src/commands/restack.rs
@@ -314,6 +314,7 @@ pub fn restack(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
+        reparent: _, // not yet implemented
     } = *move_options;
     let build_options = BuildRebasePlanOptions {
         force_rewrite_public_commits,

--- a/git-branchless/src/commands/restack.rs
+++ b/git-branchless/src/commands/restack.rs
@@ -91,6 +91,7 @@ fn restack_commits(
     event_cursor: EventCursor,
     git_run_info: &GitRunInfo,
     commits: Option<impl IntoIterator<Item = NonZeroOid>>,
+    reparent: bool,
     build_options: BuildRebasePlanOptions,
     execute_options: &ExecuteRebasePlanOptions,
     merge_conflict_remediation: MergeConflictRemediation,
@@ -151,6 +152,9 @@ fn restack_commits(
         {
             for child_oid in abandoned_child_oids {
                 builder.move_subtree(child_oid, vec![dest_oid])?;
+                if reparent {
+                    builder.reparent_commit(child_oid, vec![dest_oid], &repo)?;
+                }
             }
         }
         match builder.build(effects, thread_pool, repo_pool)? {
@@ -314,7 +318,7 @@ pub fn restack(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
-        reparent: _, // not yet implemented
+        reparent,
     } = *move_options;
     let build_options = BuildRebasePlanOptions {
         force_rewrite_public_commits,
@@ -350,6 +354,7 @@ pub fn restack(
         event_cursor,
         git_run_info,
         commits,
+        reparent,
         build_options,
         &execute_options,
         merge_conflict_remediation,

--- a/git-branchless/src/commands/split.rs
+++ b/git-branchless/src/commands/split.rs
@@ -80,6 +80,7 @@ pub fn split(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
+        reparent: _, // not yet implemented
     } = *move_options;
 
     let target_oid: NonZeroOid = match resolve_commits(

--- a/git-branchless/src/commands/split.rs
+++ b/git-branchless/src/commands/split.rs
@@ -80,8 +80,12 @@ pub fn split(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
-        reparent: _, // not yet implemented
+        reparent,
     } = *move_options;
+
+    // reparenting is only relevant for non-Insert* modes
+    let should_reparent =
+        reparent && !matches!(split_mode, SplitMode::InsertAfter | SplitMode::InsertBefore);
 
     let target_oid: NonZeroOid = match resolve_commits(
         effects,
@@ -535,10 +539,16 @@ pub fn split(
         for child in dag.commit_set_to_vec(&children)? {
             match (&split_mode, extracted_commit_oid) {
                 (_, None) | (SplitMode::DetachAfter, Some(_)) => {
-                    builder.move_subtree(child, vec![remainder_commit_oid])?
+                    builder.move_subtree(child, vec![remainder_commit_oid])?;
+                    if should_reparent {
+                        builder.reparent_commit(child, vec![remainder_commit_oid], &repo)?;
+                    }
                 }
                 (_, Some(extracted_commit_oid)) => {
-                    builder.move_subtree(child, vec![extracted_commit_oid])?
+                    builder.move_subtree(child, vec![extracted_commit_oid])?;
+                    if should_reparent {
+                        builder.reparent_commit(child, vec![extracted_commit_oid], &repo)?;
+                    }
                 }
             }
         }

--- a/git-branchless/src/commands/sync.rs
+++ b/git-branchless/src/commands/sync.rs
@@ -76,6 +76,7 @@ pub fn sync(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
+        reparent: _, // not yet implemented
     } = *move_options;
     let build_options = BuildRebasePlanOptions {
         force_rewrite_public_commits,

--- a/git-branchless/src/commands/sync.rs
+++ b/git-branchless/src/commands/sync.rs
@@ -76,7 +76,7 @@ pub fn sync(
         resolve_merge_conflicts,
         dump_rebase_constraints,
         dump_rebase_plan,
-        reparent: _, // not yet implemented
+        reparent,
     } = *move_options;
     let build_options = BuildRebasePlanOptions {
         force_rewrite_public_commits,
@@ -111,6 +111,7 @@ pub fn sync(
             git_run_info,
             &repo,
             &event_log_db,
+            reparent,
             &build_options,
             &execute_options,
             &thread_pool,
@@ -126,6 +127,7 @@ pub fn sync(
         git_run_info,
         &repo,
         &event_log_db,
+        reparent,
         build_options,
         &execute_options,
         &thread_pool,
@@ -140,6 +142,7 @@ fn execute_main_branch_sync_plan(
     git_run_info: &GitRunInfo,
     repo: &Repo,
     event_log_db: &EventLogDb,
+    reparent: bool,
     build_options: &BuildRebasePlanOptions,
     execute_options: &ExecuteRebasePlanOptions,
     thread_pool: &ThreadPool,
@@ -275,6 +278,9 @@ fn execute_main_branch_sync_plan(
         Err(_) => return Ok(Ok(())),
     };
     builder.move_subtree(root_commit_oid, vec![upstream_main_branch_oid])?;
+    if reparent {
+        builder.reparent_commit(root_commit_oid, vec![upstream_main_branch_oid], repo)?;
+    }
     let rebase_plan = match builder.build(effects, thread_pool, repo_pool)? {
         Ok(rebase_plan) => rebase_plan,
         Err(err) => {
@@ -302,6 +308,7 @@ fn execute_sync_plans(
     git_run_info: &GitRunInfo,
     repo: &Repo,
     event_log_db: &EventLogDb,
+    reparent: bool,
     build_options: BuildRebasePlanOptions,
     execute_options: &ExecuteRebasePlanOptions,
     thread_pool: &ThreadPool,
@@ -365,6 +372,13 @@ fn execute_sync_plans(
                     }
 
                     builder.move_subtree(root_commit.get_oid(), vec![main_branch_oid])?;
+                    if reparent {
+                        builder.reparent_commit(
+                            root_commit.get_oid(),
+                            vec![main_branch_oid],
+                            &repo,
+                        )?;
+                    }
                     let rebase_plan = builder.build(effects, thread_pool, repo_pool)?;
                     Ok(rebase_plan.map(|rebase_plan| (root_commit_oid, rebase_plan)))
                 },

--- a/git-branchless/tests/test_move.rs
+++ b/git-branchless/tests/test_move.rs
@@ -6330,6 +6330,165 @@ fn test_move_fixup_added_files() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_move_reparent() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+
+    git.detach_head()?;
+    let test1_branch = "test1-branch";
+    let test2_branch = "test2-branch";
+    let test3_branch = "test3-branch";
+    git.commit_file("test1", 1)?;
+    git.run(&["branch", test1_branch])?;
+    git.commit_file("test2_will_also_contain_test1_when_reparented", 2)?;
+    git.run(&["branch", test2_branch])?;
+    git.commit_file("test3_will_also_contain_test2_when_reparented", 3)?;
+    git.run(&["branch", test3_branch])?;
+    {
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r"
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d (test1-branch) create test1.txt
+        |
+        o 06309ac (test2-branch) create test2_will_also_contain_test1_when_reparented.txt
+        |
+        @ f41e0bb (test3-branch) create test3_will_also_contain_test2_when_reparented.txt
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.branchless(
+            "move",
+            &["--source", test2_branch, "--dest", "master", "--reparent"],
+        )?;
+        insta::assert_snapshot!(stdout, @r"
+        Attempting rebase in-memory...
+        [1/2] Committed as: 40ca381 create test2_will_also_contain_test1_when_reparented.txt
+        [2/2] Committed as: e4eeed5 create test3_will_also_contain_test2_when_reparented.txt
+        branchless: processing 2 updates: branch test2-branch, branch test3-branch
+        branchless: processing 2 rewritten commits
+        branchless: running command: <git-executable> checkout test3-branch --
+        O f777ecc (master) create initial.txt
+        |\
+        | o 62fc20d (test1-branch) create test1.txt
+        |
+        o 40ca381 (test2-branch) create test2_will_also_contain_test1_when_reparented.txt
+        |
+        @ e4eeed5 (> test3-branch) create test3_will_also_contain_test2_when_reparented.txt
+        In-memory rebase succeeded.
+        ");
+    }
+
+    git.branchless("prev", &[])?;
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(stdout, @r"
+        test1.txt                                         | 1 +
+        test2_will_also_contain_test1_when_reparented.txt | 1 +
+        2 files changed, 2 insertions(+)
+        ");
+    }
+
+    // test --reparent with --insert
+    {
+        let (stdout, _stderr) = git.branchless(
+            "move",
+            &[
+                "--source",
+                test3_branch,
+                "--dest",
+                "master",
+                "--reparent",
+                "--insert",
+            ],
+        )?;
+        insta::assert_snapshot!(stdout, @r"
+        Attempting rebase in-memory...
+        [1/3] Committed as: 3f0558d create test3_will_also_contain_test2_when_reparented.txt
+        [2/3] Committed as: e1e0b99 create test2_will_also_contain_test1_when_reparented.txt
+        [3/3] Committed as: fee6ba0 create test1.txt
+        branchless: processing 3 updates: branch test1-branch, branch test2-branch, branch test3-branch
+        branchless: processing 3 rewritten commits
+        branchless: running command: <git-executable> checkout test2-branch --
+        O f777ecc (master) create initial.txt
+        |
+        o 3f0558d (test3-branch) create test3_will_also_contain_test2_when_reparented.txt
+        |\
+        | o fee6ba0 (test1-branch) create test1.txt
+        |
+        @ e1e0b99 (> test2-branch) create test2_will_also_contain_test1_when_reparented.txt
+        In-memory rebase succeeded.
+        ");
+    }
+
+    // the reparented test3 contains everything, including test1 and test2
+    git.branchless("prev", &[])?;
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(stdout, @r"
+        test1.txt                                         | 1 +
+        test2_will_also_contain_test1_when_reparented.txt | 1 +
+        test3_will_also_contain_test2_when_reparented.txt | 1 +
+        3 files changed, 3 insertions(+)
+        ");
+    }
+
+    // the descendant test2 should come without test3 like before
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test2_branch])?;
+        insta::assert_snapshot!(stdout, @r"
+        test3_will_also_contain_test2_when_reparented.txt | 1 -
+        1 file changed, 1 deletion(-)
+        ");
+    }
+
+    // similarly the descendant test1 should come without test1 and test2
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test1_branch])?;
+        insta::assert_snapshot!(stdout, @r"
+        test2_will_also_contain_test1_when_reparented.txt | 1 -
+        test3_will_also_contain_test2_when_reparented.txt | 1 -
+        2 files changed, 2 deletions(-)
+        ");
+    }
+
+    // test --reparent with --exact
+    {
+        let (stdout, _stderr) = git.branchless(
+            "move",
+            &["--exact", test2_branch, "--dest", "master", "--reparent"],
+        )?;
+        insta::assert_snapshot!(stdout, @r"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 40ca381 create test2_will_also_contain_test1_when_reparented.txt
+        branchless: processing 1 update: branch test2-branch
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout test3-branch --
+        O f777ecc (master) create initial.txt
+        |\
+        | o 40ca381 (test2-branch) create test2_will_also_contain_test1_when_reparented.txt
+        |
+        @ 3f0558d (> test3-branch) create test3_will_also_contain_test2_when_reparented.txt
+        |
+        o fee6ba0 (test1-branch) create test1.txt
+        In-memory rebase succeeded.
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test2_branch])?;
+        insta::assert_snapshot!(stdout, @r"
+        test1.txt                                         | 1 +
+        test2_will_also_contain_test1_when_reparented.txt | 1 +
+        2 files changed, 2 insertions(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_worktree_rebase_in_memory() -> eyre::Result<()> {
     let git = make_git()?;
 

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -616,6 +616,136 @@ fn test_split_discard() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_split_reparent() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+
+    git.write_file_txt("test1", "contents1")?;
+    git.write_file_txt("test2", "contents2")?;
+    git.write_file_txt("test3", "contents3")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "first commit"])?;
+
+    git.write_file_txt("test3", "updated contents3")?;
+    git.write_file_txt("test4", "contents4")?;
+    git.write_file_txt("test5", "contents5")?;
+    git.run(&["add", "."])?;
+    git.run(&["commit", "-m", "second commit"])?;
+
+    {
+        let (stdout, _stderr) = git.branchless("smartlog", &[])?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 8c3edf7 second commit
+        "###);
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 1 +
+            3 files changed, 3 insertions(+)
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test3.txt | 2 +-
+            test4.txt | 1 +
+            test5.txt | 1 +
+            3 files changed, 3 insertions(+), 1 deletion(-)
+        ");
+    }
+
+    {
+        let (stdout, _stderr) =
+            git.branchless("split", &["HEAD~", "test2.txt", "--discard", "--reparent"])?;
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 3aec2d3 second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout 3aec2d3c59e90647cef2f4bbb49a4e09790611c6 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 3aec2d3 second commit
+        ");
+
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @"
+            test1.txt | 1 +
+            test3.txt | 1 +
+            2 files changed, 2 insertions(+)
+        ");
+
+        // the discarded test2 is effectively squashed into the second commit
+        // due to --reparent
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @r"
+            test2.txt | 1 +
+            test3.txt | 2 +-
+            test4.txt | 1 +
+            test5.txt | 1 +
+            4 files changed, 4 insertions(+), 1 deletion(-)
+        ");
+    }
+
+    // similarly for --detach
+    {
+        let (stdout, _stderr) =
+            git.branchless("split", &["HEAD~", "test1.txt", "--detach", "--reparent"])?;
+        insta::assert_snapshot!(&stdout, @r"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 6249d09 second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout 6249d093020c9d764e62b8bf8e67228a4445b4f0 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 52618ab first commit
+        |\
+        | o 4271e93 temp(split): test1.txt (+1)
+        |
+        @ 6249d09 second commit
+        ");
+    }
+
+    {
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
+        insta::assert_snapshot!(&stdout, @r"
+            test3.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+
+        // the detached test1 is effectively squashed into the second commit
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
+        insta::assert_snapshot!(&stdout, @r"
+            test1.txt | 1 +
+            test2.txt | 1 +
+            test3.txt | 2 +-
+            test4.txt | 1 +
+            test5.txt | 1 +
+            5 files changed, 5 insertions(+), 1 deletion(-)
+        ");
+
+        let (split_commit, _stderr) = git.run(&["query", "--raw", "exactly(siblings(HEAD), 1)"])?;
+        let (stdout, _stderr) =
+            git.run(&["show", "--pretty=format:", "--stat", split_commit.trim()])?;
+        insta::assert_snapshot!(&stdout, @r"
+            test1.txt | 1 +
+            1 file changed, 1 insertion(+)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
     let git = make_git()?;
     git.init_repo()?;

--- a/git-branchless/tests/test_sync.rs
+++ b/git-branchless/tests/test_sync.rs
@@ -193,6 +193,108 @@ fn test_sync_pull() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_sync_reparent() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test3", 3)?;
+
+    git.detach_head()?;
+    git.commit_file("test4", 4)?;
+
+    git.run(&["checkout", "master"])?;
+    git.commit_file("test5", 5)?;
+
+    {
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r###"
+        O f777ecc create initial.txt
+        |\
+        | o 62fc20d create test1.txt
+        | |
+        | o 96d1c37 create test2.txt
+        |
+        O 98b9119 create test3.txt
+        |\
+        | o 2b633ed create test4.txt
+        |
+        @ 117e086 (> master) create test5.txt
+        "###);
+    }
+
+    {
+        let (stdout, stderr) = git.branchless("sync", &["--reparent"])?;
+        insta::assert_snapshot!(stderr, @r###"
+        branchless: creating working copy snapshot
+        Switched to branch 'master'
+        branchless: processing checkout
+        branchless: creating working copy snapshot
+        Switched to branch 'master'
+        branchless: processing checkout
+        "###);
+        insta::assert_snapshot!(stdout, @"
+        Attempting rebase in-memory...
+        [1/2] Committed as: 9343a7d create test1.txt
+        [2/2] Committed as: e14bee9 create test2.txt
+        branchless: processing 2 rewritten commits
+        branchless: running command: <git-executable> checkout master --
+        In-memory rebase succeeded.
+        Attempting rebase in-memory...
+        [1/1] Committed as: e8f8c47 create test4.txt
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout master --
+        In-memory rebase succeeded.
+        Synced 62fc20d create test1.txt
+        Synced 2b633ed create test4.txt
+        ");
+    }
+
+    {
+        let stdout = git.smartlog()?;
+        insta::assert_snapshot!(stdout, @r"
+        :
+        @ 117e086 (> master) create test5.txt
+        |\
+        | o 9343a7d create test1.txt
+        | |
+        | o e14bee9 create test2.txt
+        |
+        o e8f8c47 create test4.txt
+        ");
+    }
+
+    {
+        // the reparented test1 will effectively undo test3 & test5
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "9343a7d"])?;
+        insta::assert_snapshot!(&stdout, @r"
+        test1.txt | 1 +
+        test3.txt | 1 -
+        test5.txt | 1 -
+        3 files changed, 1 insertion(+), 2 deletions(-)
+        ");
+
+        // similar the reparented test4 will effectively undo test5
+        let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "e8f8c47"])?;
+        insta::assert_snapshot!(&stdout, @r"
+        test4.txt | 1 +
+        test5.txt | 1 -
+        2 files changed, 1 insertion(+), 1 deletion(-)
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_sync_stack_from_commit() -> eyre::Result<()> {
     let git = make_git()?;
 


### PR DESCRIPTION
Closes #1537. This is done in the following commits:
1. refactor out the `amend --reparent` logic into a `.reparent_subtree` method for the `RebasePlanBuilder`
2. move the --reparent flag into MoveOptions which may be generalized for `move` and possibly `restack`, `split` etc ~~in the future (currently not implemented and would be a no-op)~~ (now implemented, see below)
3. actually implement --reparent for the `move` command with a few `builder.reparent_subtree` calls. Currently `--reparent` conflicts with `--fixup` since ~~I am not yet sure how it should be implemented (help wanted)~~ the behavior for `--fixup --parent` may be ambiguous or confusing for users
4. add tests for `move --reparent` and showcase its intended behavior.
5. refactor: use eyre::bail! instead of assert!
6. implement `restack --reparent`
7. implement `split --reparent` (for --stack or --detach)
8. implement `sync --reparent`

I would like to test this more in real life and see if it's actually working, but I think it would be good to post it here early to gather some feedback: is this feature desired? Would this be the correct way to implement it? I have very limited knowledge on the codebase so all feedbacks are much welcomed. Thank you!