### PR TITLE
fix(ci): try another dependabot grouping config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,20 +15,16 @@ updates:
       deps:
         patterns: 
           - "*"
-    ignore:
-      - dependency-name: git2
-      - dependency-name: clap_mangen
-          
-  # flakey or problematic deps are still submitted individually
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "build:"
-    allow:
-      - dependency-name: git2
-      - dependency-name: clap_mangen
+        exclude-patterns:
+          - "git2|clap_mangen"
+           
+      # flakey or problematic deps are still submitted individually
+      git2:
+        patterns:
+          - "git2"
+      clap_mangen:
+        patterns:
+          - "clap_mangen"
 
   # group GH actions deps into a single monthly PR
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Attempting to fix what I broke in #1610.

The previous version turned out to be invalid, with message:

> Update configs must have a unique combination of 'package-ecosystem',
> 'directory', and 'target-branch'. Ecosystem 'cargo' has overlapping
> directories.

This config should accomplish the same thing, but does so by creating 3 separate dep groups for cargo: 1 for most deps, and 2 more for known troublesome deps. The latter are explicitly excluded from the former, or so I hope. We'll see what happens after merge.

Refs:
- 758268e568ebbf40e952ff04dfa048ab39c642f5
- https://github.com/arxanas/git-branchless/pull/1610#issuecomment-3829507119
- https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates