### PR TITLE
fix(render): only apply real effects

### DIFF
--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Display;
 
-use cursive::theme::{Effect, Style};
+use cursive::theme::{ConcreteEffects, Effect, Style};
 use cursive::utils::markup::StyledString;
 use cursive::utils::span::Span;
 
@@ -404,14 +404,14 @@ fn render_style_as_ansi(content: &str, style: Style) -> eyre::Result<String> {
 
     let output = {
         let mut output = output;
-        for (effect, _status) in effects.statuses.iter() {
+        for effect in effects.resolve(ConcreteEffects::empty()) {
             output = match effect {
                 Effect::Simple => output,
                 Effect::Dim => output.dim(),
                 Effect::Reverse => output.reverse(),
                 Effect::Bold => output.bold(),
                 Effect::Italic => output.italic(),
-                Effect::Strikethrough => output, // Not supported by console crate, skip it
+                Effect::Strikethrough => eyre::bail!("Not implemented: Effect::Strikethrough"),
                 Effect::Underline => output.underlined(),
                 Effect::Blink => output.blink(),
             };


### PR DESCRIPTION
I didn't review the AI generated changes in ed946a9 and f6a7008 carefully enough. In particular, the AI slapped a bandaid over the Effect/EffectStatus API change in cursive 0.4 that compiled and passed tests, but which was nevertheless incorrect because the rendered ANSI codes were all wrong. As I understand it, the API change passes *all effects* but each effect has a corresponding status to indicate if it should be applied or not. So the previous version of this code was just applying all effects, all the time. This change reproduces our previous behavior by resolving the effects+statuses against a base "empty" effect, which is what we want: we don't do any style compositing (that I know of) and only apply styles to unstyled text.

Top is current master, bottom is with this change.
![Screenshot 2026-02-02 at 3 16 19 PM](https://github.com/user-attachments/assets/babb90fc-5b2d-435c-ad62-e81887a69de1)
