### PR TITLE
fix(split): don't unhide obsolete children

### DIFF
--- a/git-branchless/src/commands/split.rs
+++ b/git-branchless/src/commands/split.rs
@@ -530,6 +530,7 @@ pub fn split(
         builder.move_subtree(target_oid, vec![remainder_commit_oid])?
     } else {
         let children = dag.query_children(CommitSet::from(target_oid))?;
+        let children = dag.filter_visible_commits(children)?;
         for child in dag.commit_set_to_vec(&children)? {
             match (&split_mode, extracted_commit_oid) {
                 (_, None) | (SplitMode::DetachAfter, Some(_)) => {


### PR DESCRIPTION
I noticed this yesterday. When rebasing child commits back onto the split commits, I had failed to filter out rewritten/obsolete commits. This caused previous versions of those commits to reappear in the smartlog after a `split`. I think that this was limited to immediate children, though, and wasn't affecting further removed descendants.