### PR TITLE
fix(git): handle submodule gitlinks and directory symlinks in working-copy snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (#1462) BREAKING: `git record` will use a default commit message with `--stash` (instead of prompting for one)
 - (#1463): `git switch` now accepts a revset whose sole head will be checked out, and correctly treats `-` to mean last checked out commit or branch
 - (#1492): `scm-record` upgraded to [v0.5.0](https://github.com/arxanas/scm-record/releases/tag/v0.5.0).
-- (#1591): improved performance of some revset expressions 
+- (#1591): improved performance of some revset expressions
 - (#1593) BREAKING: ~~The minimum supported Rust version (MSRV) is now 1.82.~~ See #1638 below.
 - (#1638) BREAKING: The minimum supported Rust version (MSRV) is now 1.86, and the rust edition is now 2024.
 
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (#1439): fix panic with custom git status configuration
 - (#1611): fix behavior of `git record --stash` on a detached HEAD
 - (#1618): fix behavior of various commands when operating on branches that have the same name as files in the current directory
+- (#1659): fix snapshotting for submodules and symlinks ending in a `/`
 
 ## [v0.10.0] - 2024-10-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "similar",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,5 @@ vt100 = "0.15.2"
 # dev-dependencies
 cc = "1.2.61"
 criterion = { version = "0.8.2", features = ["html_reports"] }
-insta = "1.47.2"
+insta = { version = "1.47.2", features = ["filters"] }
 maplit = "1.0.2"

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -13,6 +13,8 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::num::TryFromIntError;
 use std::ops::Add;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
@@ -1242,6 +1244,68 @@ impl Repo {
         Ok(Some(blob))
     }
 
+    /// Read a symlink and create a blob corresponding to its target path.
+    /// If the symlink doesn't exist on disk, returns `None` instead.
+    #[instrument]
+    pub fn create_blob_from_symlink_path(&self, path: &Path) -> Result<Option<NonZeroOid>> {
+        let path = self
+            .get_working_copy_path()
+            .ok_or_else(|| Error::CreateBlobFromPath {
+                source: eyre::eyre!(
+                    "Repository at {:?} has no working copy path (is bare)",
+                    self.get_path()
+                ),
+                path: path.to_path_buf(),
+            })?
+            .join(path);
+        let link_target = match std::fs::read_link(&path) {
+            Ok(link_target) => link_target,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(Error::CreateBlobFromPath {
+                    source: err.into(),
+                    path,
+                });
+            }
+        };
+
+        #[cfg(unix)]
+        let link_target_bytes = link_target.as_os_str().as_bytes().to_vec();
+        #[cfg(not(unix))]
+        let link_target_bytes = link_target.to_string_lossy().into_owned().into_bytes();
+
+        let blob_oid = self.create_blob_from_contents(&link_target_bytes)?;
+        Ok(Some(blob_oid))
+    }
+
+    /// Create an object for the given path in the working copy according to its file mode.
+    #[instrument]
+    pub fn create_blob_from_path_for_mode(
+        &self,
+        path: &Path,
+        file_mode: FileMode,
+        index: &Index,
+    ) -> Result<Option<NonZeroOid>> {
+        match file_mode {
+            FileMode::Blob | FileMode::BlobExecutable | FileMode::BlobGroupWritable => {
+                self.create_blob_from_path(path)
+            }
+            FileMode::Link => self.create_blob_from_symlink_path(path),
+            FileMode::Commit => match index.get_entry(path) {
+                Some(IndexEntry {
+                    oid: MaybeZeroOid::NonZero(oid),
+                    ..
+                }) => Ok(Some(oid)),
+                Some(IndexEntry {
+                    oid: MaybeZeroOid::Zero,
+                    ..
+                })
+                | None => Ok(None),
+            },
+            FileMode::Tree | FileMode::Unreadable => Ok(None),
+        }
+    }
+
     /// Create a blob corresponding to the provided byte slice.
     #[instrument]
     pub fn create_blob_from_contents(&self, contents: &[u8]) -> Result<NonZeroOid> {
@@ -1547,48 +1611,41 @@ impl Repo {
             self.dehydrate_commit(parent_commit, changed_paths.as_slice(), true)?;
         let dehydrated_parent_tree = dehydrated_parent.get_tree()?;
 
-        let repo_path = self
-            .get_working_copy_path()
-            .ok_or(Error::NoWorkingCopyPath)?;
-        let repo_path = &repo_path;
+        let index = self.get_index()?;
+        let index = &index;
         let new_tree_entries: HashMap<PathBuf, Option<(NonZeroOid, FileMode)>> = match opts {
             AmendFastOptions::FromWorkingCopy { status_entries } => status_entries
                 .iter()
                 .flat_map(|entry| {
+                    let file_mode = entry.working_copy_file_mode;
                     entry.paths().into_iter().map(
                         move |path| -> Result<(PathBuf, Option<(NonZeroOid, FileMode)>)> {
-                            let file_path = repo_path.join(&path);
-                            // Try to create a new blob OID based on the current on-disk
-                            // contents of the file in the working copy.
                             let entry = self
-                                .create_blob_from_path(&file_path)?
-                                .map(|oid| (oid, entry.working_copy_file_mode));
+                                .create_blob_from_path_for_mode(&path, file_mode, index)?
+                                .map(|oid| (oid, file_mode));
                             Ok((path, entry))
                         },
                     )
                 })
                 .collect::<Result<HashMap<_, _>>>()?,
-            AmendFastOptions::FromIndex { paths } => {
-                let index = self.get_index()?;
-                paths
-                    .iter()
-                    .filter_map(|path| match index.get_entry(path) {
-                        Some(IndexEntry {
-                            oid: MaybeZeroOid::Zero,
-                            ..
-                        }) => {
-                            warn!(?path, "index entry was zero");
-                            None
-                        }
-                        Some(IndexEntry {
-                            oid: MaybeZeroOid::NonZero(oid),
-                            file_mode,
-                            ..
-                        }) => Some((path.clone(), Some((oid, file_mode)))),
-                        None => Some((path.clone(), None)),
-                    })
-                    .collect::<HashMap<_, _>>()
-            }
+            AmendFastOptions::FromIndex { paths } => paths
+                .iter()
+                .filter_map(|path| match index.get_entry(path) {
+                    Some(IndexEntry {
+                        oid: MaybeZeroOid::Zero,
+                        ..
+                    }) => {
+                        warn!(?path, "index entry was zero");
+                        None
+                    }
+                    Some(IndexEntry {
+                        oid: MaybeZeroOid::NonZero(oid),
+                        file_mode,
+                        ..
+                    }) => Some((path.clone(), Some((oid, file_mode)))),
+                    None => Some((path.clone(), None)),
+                })
+                .collect::<HashMap<_, _>>(),
             AmendFastOptions::FromCommit { commit } => {
                 let amended_tree = self.cherry_pick_fast(
                     commit,

--- a/git-branchless-lib/src/git/snapshot.rs
+++ b/git-branchless-lib/src/git/snapshot.rs
@@ -121,7 +121,12 @@ impl<'repo> WorkingCopySnapshot<'repo> {
         let head_reference_name: Option<ReferenceName> = head_info.reference_name.clone();
 
         let commit_unstaged_oid: NonZeroOid = {
-            Self::create_commit_for_unstaged_changes(repo, head_commit.as_ref(), status_entries)?
+            Self::create_commit_for_unstaged_changes(
+                repo,
+                index,
+                head_commit.as_ref(),
+                status_entries,
+            )?
         };
 
         let commit_stage0 = Self::create_commit_for_stage(
@@ -299,6 +304,7 @@ branchless: automated working copy snapshot
     #[instrument]
     fn create_commit_for_unstaged_changes(
         repo: &Repo,
+        index: &Index,
         head_commit: Option<&Commit>,
         status_entries: &[StatusEntry],
     ) -> eyre::Result<NonZeroOid> {
@@ -342,7 +348,7 @@ branchless: automated working copy snapshot
                     // the index.
                     None
                 } else {
-                    repo.create_blob_from_path(&path)?
+                    repo.create_blob_from_path_for_mode(&path, file_mode, index)?
                         .map(|blob_oid| (blob_oid, file_mode))
                 };
                 result.insert(path, entry);

--- a/git-branchless-lib/tests/test_status.rs
+++ b/git-branchless-lib/tests/test_status.rs
@@ -1,9 +1,10 @@
+use std::fs;
 use std::path::PathBuf;
 
 use branchless::core::effects::Effects;
 use branchless::core::formatting::Glyphs;
 use branchless::git::{FileMode, FileStatus, StatusEntry, WorkingCopyChangesType};
-use branchless::testing::make_git;
+use branchless::testing::{GitInitOptions, GitRunOptions, make_git};
 
 #[test]
 fn test_parse_status_line() {
@@ -277,6 +278,147 @@ fn test_get_status() -> eyre::Result<()> {
             },
         }
         "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_status_with_dirty_submodule() -> eyre::Result<()> {
+    let git = make_git()?;
+    let git_run_info = git.get_git_run_info();
+    git.init_repo_with_options(&GitInitOptions {
+        make_initial_commit: true,
+        run_branchless_init: false,
+    })?;
+    let glyphs = Glyphs::text();
+    let effects = Effects::new_suppress_for_test(glyphs);
+    let repo = git.get_repo()?;
+
+    let submodule_source_path = git.repo_path.join("submodule-source");
+    let submodule_source_path_str = submodule_source_path
+        .to_str()
+        .expect("submodule source path should be UTF-8");
+
+    {
+        // create repo for submodule
+        fs::create_dir(&submodule_source_path)?;
+        git.run(&["-C", submodule_source_path_str, "init"])?;
+        git.run(&[
+            "-C",
+            submodule_source_path_str,
+            "config",
+            "user.name",
+            "Testy McTestface",
+        ])?;
+        git.run(&[
+            "-C",
+            submodule_source_path_str,
+            "config",
+            "user.email",
+            "test@example.com",
+        ])?;
+        fs::write(submodule_source_path.join("file.txt"), "contents\n")?;
+        git.run(&["-C", submodule_source_path_str, "add", "file.txt"])?;
+        git.run(&["-C", submodule_source_path_str, "commit", "-m", "initial"])?;
+    }
+
+    {
+        // add submodule to main repo
+        git.run_with_options(
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                submodule_source_path_str,
+                "sm",
+            ],
+            &GitRunOptions::default(),
+        )?;
+        git.run(&["add", ".gitmodules", "sm"])?;
+        git.run(&["commit", "-m", "add submodule"])?;
+    }
+
+    {
+        // make change in submodule
+        git.run(&["-C", "sm", "config", "user.name", "Testy McTestface"])?;
+        git.run(&["-C", "sm", "config", "user.email", "test@example.com"])?;
+        fs::write(git.repo_path.join("sm/file.txt"), "updated\n")?;
+        git.run(&["-C", "sm", "commit", "-am", "update"])?;
+    }
+
+    let (_snapshot, status) = repo.get_status(
+        &effects,
+        &git_run_info,
+        &repo.get_index()?,
+        &repo.get_head_info()?,
+        None,
+    )?;
+
+    // Should contain a single entry for the modified submodule.
+    insta::assert_debug_snapshot!(status, @r###"
+        [
+            StatusEntry {
+                index_status: Unmodified,
+                working_copy_status: Modified,
+                working_copy_file_mode: Commit,
+                path: "sm",
+                orig_path: None,
+            },
+        ]
+    "###);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_get_status_with_directory_symlink_trailing_slash() -> eyre::Result<()> {
+    let git = make_git()?;
+    let git_run_info = git.get_git_run_info();
+    git.init_repo_with_options(&GitInitOptions {
+        make_initial_commit: false,
+        run_branchless_init: false,
+    })?;
+    let glyphs = Glyphs::text();
+    let effects = Effects::new_suppress_for_test(glyphs);
+    let repo = git.get_repo()?;
+
+    {
+        fs::create_dir(git.repo_path.join("dir"))?;
+        fs::write(git.repo_path.join("dir/file.txt"), "contents\n")?;
+        std::os::unix::fs::symlink("dir/", git.repo_path.join("dir_symlink"))?;
+        git.run(&["add", "dir/file.txt", "dir_symlink"])?;
+    }
+
+    let (_snapshot, status) = repo.get_status(
+        &effects,
+        &git_run_info,
+        &repo.get_index()?,
+        &repo.get_head_info()?,
+        None,
+    )?;
+
+    // Should contain new (added) entries for 2 files: dir/file.txt (blob) and
+    // dir_symlink (link)
+    insta::assert_debug_snapshot!(status, @r###"
+        [
+            StatusEntry {
+                index_status: Added,
+                working_copy_status: Unmodified,
+                working_copy_file_mode: Blob,
+                path: "dir/file.txt",
+                orig_path: None,
+            },
+            StatusEntry {
+                index_status: Added,
+                working_copy_status: Unmodified,
+                working_copy_file_mode: Link,
+                path: "dir_symlink",
+                orig_path: None,
+            },
+        ]
+    "###);
 
     Ok(())
 }

--- a/git-branchless/tests/test_amend.rs
+++ b/git-branchless/tests/test_amend.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use lib::testing::{
     GitRunOptions, make_git,
     pty::{PtyAction, run_in_pty},
@@ -1495,6 +1497,93 @@ fn test_amend_with_branch_name_matching_file() -> eyre::Result<()> {
         @ d408d49 (> foo) create test1.txt
         "###);
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_amend_with_dirty_submodule() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.detach_head()?;
+    git.commit_file("test1", 1)?;
+
+    let submodule_source_path = git.repo_path.join("submodule-source");
+    let submodule_source_path_str = submodule_source_path
+        .to_str()
+        .expect("submodule source path should be UTF-8");
+
+    {
+        // create repo for submodule
+        fs::create_dir(&submodule_source_path)?;
+        git.run(&["-C", submodule_source_path_str, "init"])?;
+        git.run(&[
+            "-C",
+            submodule_source_path_str,
+            "config",
+            "user.name",
+            "Testy McTestface",
+        ])?;
+        git.run(&[
+            "-C",
+            submodule_source_path_str,
+            "config",
+            "user.email",
+            "test@example.com",
+        ])?;
+        fs::write(submodule_source_path.join("file.txt"), "contents\n")?;
+        git.run(&["-C", submodule_source_path_str, "add", "file.txt"])?;
+        git.run(&["-C", submodule_source_path_str, "commit", "-m", "initial"])?;
+    }
+
+    {
+        // add submodule to main repo
+        git.run_with_options(
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                submodule_source_path_str,
+                "sm",
+            ],
+            &GitRunOptions::default(),
+        )?;
+        git.run(&["add", ".gitmodules", "sm"])?;
+        git.run(&["commit", "-m", "add submodule"])?;
+    }
+
+    {
+        // make change in submodule
+        git.run(&["-C", "sm", "config", "user.name", "Testy McTestface"])?;
+        git.run(&["-C", "sm", "config", "user.email", "test@example.com"])?;
+        fs::write(git.repo_path.join("sm/file.txt"), "updated\n")?;
+        git.run(&["-C", "sm", "commit", "-am", "update"])?;
+        git.write_file_txt("test1", "updated contents")?;
+    }
+
+    let (stdout, _stderr) = git.branchless("amend", &[])?;
+
+    insta::with_settings!(
+        {
+            filters => [
+                // The commit SHA will always be nondeterministic because the
+                // submodule is in a directory created by tempdir, which has a
+                // random name, and is included in .gitmodules. So even if we
+                // can control the author and timestamp, we can't control the
+                // content of that commit.
+                ("reset [0-9a-f]+ --", "reset REDACTED_SHA --")
+            ]
+        },
+        {
+            insta::assert_snapshot!(stdout, @r###"
+                branchless: running command: <git-executable> reset REDACTED_SHA --
+                Unstaged changes after reset:
+                M	sm
+                Amended with 2 uncommitted changes.
+            "###);
+        }
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Cherry-picked from my fork's megamerge branch.

Fix panics in working-copy snapshot/amend paths when changed entries are not regular files.

Previously, snapshot/amend attempted to create blobs by reading paths from disk unconditionally. That fails for:
- submodule gitlinks (mode 160000), where path is a directory in superproject
- directory symlinks like `ln -s dir/ link`, where symlink handling must use link target bytes, not file read semantics

Changes:
- add mode-aware object creation for working-copy paths
  - regular blobs: read file bytes
  - symlinks: read symlink target and store as blob content
  - gitlinks/submodules: use index OID instead of reading filesystem path
  - unreadable/tree: skip as absent
- wire mode-aware logic into:
  - snapshot unstaged commit creation
  - amend_fast working-copy path processing
- add regressions:
  - dirty submodule no longer crashes status/snapshot flow
  - trailing-slash directory symlink no longer crashes snapshot flow
  - amend with dirty submodule no longer crashes
- make tests use per-repo submodule source paths to avoid cross-test collisions

Fixes https://github.com/arxanas/git-branchless/issues/517
Fixes https://github.com/arxanas/git-branchless/issues/645