### PR TITLE
chore(build): enable clap derive in git-branchless-lib

### DIFF
--- a/git-branchless-lib/Cargo.toml
+++ b/git-branchless-lib/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = { workspace = true }
 bstr = { workspace = true }
 chashmap = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
 concolor = { workspace = true }
 console = { workspace = true }


### PR DESCRIPTION
Cherry-picked from my fork's megamerge branch.

`UntrackedFileStrategy` in `git-branchless-lib` derives `clap::ValueEnum`, which requires clap's `derive` feature. The workspace often compiles fine because other crates enable that feature, but isolated commands like:

- cargo check -p git-branchless-lib
- cargo test -p git-branchless-lib ...

can fail when feature unification does not pull in `clap_derive`.

Enable `clap`'s `derive` feature directly in `git-branchless-lib` to make the crate self-sufficient and avoid environment-dependent build behavior.