### PR TITLE
fix(revset): use correct revset expression

### DIFF
--- a/git-branchless-revset/src/grammar.lalrpop
+++ b/git-branchless-revset/src/grammar.lalrpop
@@ -46,7 +46,7 @@ Expr4: Expr<'input> = {
     <lhs:Expr4> "~"            => Expr::FunctionCall(Cow::Borrowed("ancestors.nth"), vec![lhs, Expr::Name(Cow::Borrowed("1"))]),
     <lhs:Expr4> "~" <rhs:Name> => Expr::FunctionCall(Cow::Borrowed("ancestors.nth"), vec![lhs, Expr::Name(rhs)]),
 
-    <lhs:Expr4> "!"            => Expr::FunctionCall(Cow::Borrowed("sole"),  vec![Expr::FunctionCall(Cow::Borrowed("children"), vec![lhs])]),
+    <lhs:Expr4> "!"            => Expr::FunctionCall(Cow::Borrowed("exactly"),  vec![Expr::FunctionCall(Cow::Borrowed("children"), vec![lhs]), Expr::Name(Cow::Borrowed("1"))]),
 
     <Expr5>
 }

--- a/git-branchless-revset/src/parser.rs
+++ b/git-branchless-revset/src/parser.rs
@@ -673,7 +673,7 @@ mod tests {
         insta::assert_debug_snapshot!(parse("foo!"), @r###"
         Ok(
             FunctionCall(
-                "sole",
+                "exactly",
                 [
                     FunctionCall(
                         "children",
@@ -682,6 +682,9 @@ mod tests {
                                 "foo",
                             ),
                         ],
+                    ),
+                    Name(
+                        "1",
                     ),
                 ],
             ),
@@ -694,7 +697,7 @@ mod tests {
                 "union",
                 [
                     FunctionCall(
-                        "sole",
+                        "exactly",
                         [
                             FunctionCall(
                                 "children",
@@ -704,16 +707,19 @@ mod tests {
                                     ),
                                 ],
                             ),
+                            Name(
+                                "1",
+                            ),
                         ],
                     ),
                     FunctionCall(
-                        "sole",
+                        "exactly",
                         [
                             FunctionCall(
                                 "children",
                                 [
                                     FunctionCall(
-                                        "sole",
+                                        "exactly",
                                         [
                                             FunctionCall(
                                                 "children",
@@ -723,9 +729,15 @@ mod tests {
                                                     ),
                                                 ],
                                             ),
+                                            Name(
+                                                "1",
+                                            ),
                                         ],
                                     ),
                                 ],
+                            ),
+                            Name(
+                                "1",
                             ),
                         ],
                     ),


### PR DESCRIPTION
`!` was inplemented incorrectly in #1461: I had the lalrpop grammar translate `!` using the `sole()` revset function, but `sole()` doesn't exist! I have a revset *alias* defined locally that translates `sole()` to `exactly(.., 1)`, and this alias was being used unwittingly when I have been using !

The test for `!` didn't catch this because it only did the translation; it didn't try to evaluate the expression.

Disabling my local alias caused this operator to stop working, and this fix restored it.