### PR TITLE
build: bump scm-bisect to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,7 @@ checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "scm-bisect"
-version = "0.3.0"
+version = "0.11.0"
 dependencies = [
  "indexmap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ portable-pty = "0.9.0"
 rayon = "1.12.0"
 regex = "1.12.3"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
-scm-bisect = { version = "0.3.0", path = "scm-bisect" }
+scm-bisect = { version = "0.11.0", path = "scm-bisect" }
 scm-diff-editor = "0.10.1"
 scm-record = "0.10.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/scm-bisect/Cargo.toml
+++ b/scm-bisect/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "scm-bisect"
 repository = "https://github.com/arxanas/git-branchless"
-version = "0.3.0"
+version = "0.11.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This will align it with the other git-branchless crates, which I hope will make it easier to release with the rest of the crates. After this passes/merges, I'll prepare a v0.11.1 release. 😵‍💫