### PR TITLE
fix(help): show correct name with --version

### DIFF
--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -842,7 +842,7 @@ pub struct GlobalArgs {
 ///
 /// See the documentation at https://github.com/arxanas/git-branchless/wiki.
 #[derive(Debug, Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"), author = "Waleed Khan <me@waleedkhan.name>")]
+#[clap(name = "git-branchless", version = env!("CARGO_PKG_VERSION"), author = "Waleed Khan <me@waleedkhan.name>")]
 pub struct Opts {
     /// Global arguments.
     #[clap(flatten)]


### PR DESCRIPTION
Without this, clap defaults the name to the crate name (in this case, git-branchless-opts), not the application or workspace name.

```
❯ git branchless --version
git-branchless-opts 0.11.1

❯ cargo run -- --version
git-branchless 0.11.1
```