### PR TITLE
feat(smartlog): show linked worktrees

### DIFF
--- a/git-branchless-lib/src/core/config.rs
+++ b/git-branchless-lib/src/core/config.rs
@@ -115,6 +115,13 @@ pub fn get_smartlog_reverse(repo: &Repo) -> eyre::Result<bool> {
         .get_or("branchless.smartlog.reverse", false)
 }
 
+/// Whether to show linked worktrees in the smartlog by default.
+#[instrument]
+pub fn get_smartlog_show_worktrees(repo: &Repo) -> eyre::Result<bool> {
+    repo.get_readonly_config()?
+        .get_or("branchless.smartlog.showWorktrees", false)
+}
+
 /// Get the default comment character.
 #[instrument]
 pub fn get_comment_char(repo: &Repo) -> eyre::Result<char> {

--- a/git-branchless-lib/src/core/formatting.rs
+++ b/git-branchless-lib/src/core/formatting.rs
@@ -134,6 +134,12 @@ pub struct Glyphs {
     /// Character used to point to the currently-checked-out branch.
     pub branch_arrow: &'static str,
 
+    /// Character used to point to the current worktree.
+    pub worktree_current: &'static str,
+
+    /// Character used to point to a linked worktree.
+    pub worktree_linked: &'static str,
+
     /// Bullet-point character for a list of newline-separated items.
     pub bullet_point: &'static str,
 
@@ -185,6 +191,8 @@ impl Glyphs {
             commit_merge: "&",
             commit_merge_rev: "&",
             branch_arrow: ">",
+            worktree_current: ">",
+            worktree_linked: "wt",
             bullet_point: "-",
             cycle_arrow: ">",
             cycle_horizontal_line: "-",
@@ -215,6 +223,8 @@ impl Glyphs {
             commit_main_obsolete: "✕",
             commit_main_obsolete_head: "❖",
             branch_arrow: "ᐅ",
+            worktree_current: "ᐅ",
+            worktree_linked: "⎇",
             bullet_point: "•",
             cycle_arrow: "ᐅ",
             cycle_horizontal_line: "─",

--- a/git-branchless-lib/src/core/mod.rs
+++ b/git-branchless-lib/src/core/mod.rs
@@ -12,3 +12,4 @@ pub mod repo_ext;
 pub mod rewrite;
 pub mod task;
 pub mod untracked_file_cache;
+pub mod worktree;

--- a/git-branchless-lib/src/core/node_descriptors.rs
+++ b/git-branchless-lib/src/core/node_descriptors.rs
@@ -395,7 +395,7 @@ impl<'a> WorktreeDescriptor<'a> {
 impl NodeDescriptor for WorktreeDescriptor<'_> {
     fn describe_node(
         &mut self,
-        _glyphs: &Glyphs,
+        glyphs: &Glyphs,
         object: &NodeObject,
     ) -> eyre::Result<Option<StyledString>> {
         if self.worktree_snapshot.entries.len() <= 1 {
@@ -407,7 +407,11 @@ impl NodeDescriptor for WorktreeDescriptor<'_> {
             .find_by_head_oid(object.get_oid())
             .into_iter()
             .map(|entry| {
-                let icon = if entry.is_current { "ᐅ" } else { "⎇" }.to_string();
+                let icon = if entry.is_current {
+                    glyphs.worktree_current
+                } else {
+                    glyphs.worktree_linked
+                };
                 format!("{icon} {}", entry.display_name())
             })
             .collect();

--- a/git-branchless-lib/src/core/node_descriptors.rs
+++ b/git-branchless-lib/src/core/node_descriptors.rs
@@ -377,6 +377,52 @@ impl NodeDescriptor for BranchesDescriptor<'_> {
     }
 }
 
+/// Display linked worktrees which currently have a commit checked out.
+#[derive(Debug)]
+pub struct WorktreeDescriptor<'a> {
+    worktree_snapshot: &'a crate::core::worktree::WorktreeSnapshot,
+}
+
+impl<'a> WorktreeDescriptor<'a> {
+    /// Constructor.
+    pub fn new(
+        worktree_snapshot: &'a crate::core::worktree::WorktreeSnapshot,
+    ) -> eyre::Result<Self> {
+        Ok(Self { worktree_snapshot })
+    }
+}
+
+impl NodeDescriptor for WorktreeDescriptor<'_> {
+    fn describe_node(
+        &mut self,
+        _glyphs: &Glyphs,
+        object: &NodeObject,
+    ) -> eyre::Result<Option<StyledString>> {
+        if self.worktree_snapshot.entries.len() <= 1 {
+            return Ok(None);
+        }
+
+        let worktrees: Vec<String> = self
+            .worktree_snapshot
+            .find_by_head_oid(object.get_oid())
+            .into_iter()
+            .map(|entry| {
+                let icon = if entry.is_current { "ᐅ" } else { "⎇" }.to_string();
+                format!("{icon} {}", entry.display_name())
+            })
+            .collect();
+
+        if worktrees.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(StyledString::styled(
+                format!("({})", worktrees.join(", ")),
+                BaseColor::Blue.light(),
+            )))
+        }
+    }
+}
+
 /// Display the associated Phabricator revision for a given commit.
 #[derive(Debug)]
 pub struct DifferentialRevisionDescriptor<'a> {

--- a/git-branchless-lib/src/core/worktree.rs
+++ b/git-branchless-lib/src/core/worktree.rs
@@ -1,0 +1,362 @@
+//! Utilities for discovering and describing linked worktrees.
+
+use std::collections::HashSet;
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Path, PathBuf};
+
+use eyre::Context;
+
+use crate::git::{GitRunInfo, GitRunOpts, NonZeroOid, ReferenceName, Repo};
+
+/// Information about a linked worktree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    /// Canonicalized worktree path, if available.
+    pub path: PathBuf,
+
+    /// Human-friendly name for the worktree, disambiguated within the current snapshot.
+    pub display_name: String,
+
+    /// The OID checked out in the worktree.
+    pub head_oid: Option<NonZeroOid>,
+
+    /// The checked-out branch reference, if any.
+    pub branch_name: Option<ReferenceName>,
+
+    /// Whether this is the current worktree.
+    pub is_current: bool,
+
+    /// Whether this is the main/home worktree for the repository.
+    pub is_main: bool,
+}
+
+impl WorktreeEntry {
+    /// Get a stable display name for the worktree.
+    pub fn display_name(&self) -> String {
+        self.display_name.clone()
+    }
+}
+
+/// A snapshot of all linked worktrees for the current repository.
+#[derive(Clone, Debug, Default)]
+pub struct WorktreeSnapshot {
+    /// All linked worktrees.
+    pub entries: Vec<WorktreeEntry>,
+}
+
+impl WorktreeSnapshot {
+    /// Return the current worktree, if it could be identified.
+    pub fn current(&self) -> Option<&WorktreeEntry> {
+        self.entries.iter().find(|entry| entry.is_current)
+    }
+
+    /// Return the worktree which owns the provided branch.
+    pub fn find_by_branch(&self, branch_name: &ReferenceName) -> Option<&WorktreeEntry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.branch_name.as_ref() == Some(branch_name))
+    }
+
+    /// Return all worktrees checked out at the provided OID.
+    pub fn find_by_head_oid(&self, oid: NonZeroOid) -> Vec<&WorktreeEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.head_oid == Some(oid))
+            .collect()
+    }
+
+    /// Return all active head commits across linked worktrees.
+    pub fn active_head_oids(&self) -> HashSet<NonZeroOid> {
+        self.entries
+            .iter()
+            .filter_map(|entry| entry.head_oid)
+            .collect()
+    }
+}
+
+fn canonicalize_best_effort(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    #[cfg(unix)]
+    {
+        PathBuf::from(OsString::from_vec(bytes.to_vec()))
+    }
+    #[cfg(not(unix))]
+    {
+        PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+fn field_to_string_lossy(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn escape_display_name(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for ch in name.chars() {
+        match ch {
+            '\n' => result.push_str(r"\n"),
+            '\r' => result.push_str(r"\r"),
+            '\t' => result.push_str(r"\t"),
+            '\\' => result.push_str(r"\\"),
+            ch if ch.is_control() => result.push_str(&format!(r"\u{{{:x}}}", u32::from(ch))),
+            ch => result.push(ch),
+        }
+    }
+    result
+}
+
+fn get_path_display_name_candidates(path: &Path) -> Vec<String> {
+    let segments: Vec<String> = path
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(segment) => {
+                Some(escape_display_name(&segment.to_string_lossy()))
+            }
+            _ => None,
+        })
+        .collect();
+    if segments.is_empty() {
+        return vec![escape_display_name(&path.to_string_lossy())];
+    }
+    (0..segments.len())
+        .rev()
+        .map(|start| segments[start..].join("/"))
+        .collect()
+}
+
+fn update_display_names(entries: &mut [WorktreeEntry]) {
+    let candidate_lists: Vec<Vec<String>> = entries
+        .iter()
+        .map(|entry| get_path_display_name_candidates(&entry.path))
+        .collect();
+
+    for (index, entry) in entries.iter_mut().enumerate() {
+        let display_name = candidate_lists[index]
+            .iter()
+            .find(|candidate| {
+                candidate_lists
+                    .iter()
+                    .enumerate()
+                    .all(|(other_index, other_candidates)| {
+                        other_index == index
+                            || !other_candidates.iter().any(|other| other == *candidate)
+                    })
+            })
+            .cloned()
+            .or_else(|| candidate_lists[index].last().cloned())
+            .unwrap_or_else(|| entry.path.to_string_lossy().into_owned());
+        entry.display_name = display_name;
+    }
+}
+
+fn parse_worktree_head_info(
+    lines: &[Vec<u8>],
+) -> eyre::Result<(Option<NonZeroOid>, Option<ReferenceName>, bool)> {
+    let mut head_oid = None;
+    let mut branch_name = None;
+    let mut detached = false;
+    let mut prunable = false;
+
+    for line in lines {
+        if let Some(value) = line.strip_prefix(b"HEAD ") {
+            let value = field_to_string_lossy(value);
+            head_oid = match value.parse() {
+                Ok(oid) => Some(oid),
+                Err(_) if value == "0000000000000000000000000000000000000000" => None,
+                Err(err) => return Err(err).wrap_err("Parsing worktree HEAD OID"),
+            };
+        } else if let Some(value) = line.strip_prefix(b"branch ") {
+            branch_name = Some(ReferenceName::from(field_to_string_lossy(value)));
+        } else if line == b"detached" {
+            detached = true;
+        } else if line == b"prunable" || line.starts_with(b"prunable ") {
+            prunable = true;
+        }
+    }
+
+    if detached {
+        branch_name = None;
+    }
+
+    Ok((head_oid, branch_name, prunable))
+}
+
+fn parse_worktree_snapshot_from_nul_porcelain(
+    stdout: &[u8],
+    current_worktree_path: Option<PathBuf>,
+    main_worktree_path: Option<PathBuf>,
+) -> eyre::Result<WorktreeSnapshot> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_lines: Vec<Vec<u8>> = Vec::new();
+
+    let flush = |current_path: &mut Option<PathBuf>,
+                 current_lines: &mut Vec<Vec<u8>>,
+                 entries: &mut Vec<WorktreeEntry>|
+     -> eyre::Result<()> {
+        let Some(path) = current_path.take() else {
+            current_lines.clear();
+            return Ok(());
+        };
+        let (head_oid, branch_name, prunable) = parse_worktree_head_info(current_lines)?;
+        if prunable {
+            current_lines.clear();
+            return Ok(());
+        }
+        if !path.exists() {
+            current_lines.clear();
+            return Ok(());
+        }
+        let path = canonicalize_best_effort(&path);
+        let is_current = current_worktree_path.as_ref() == Some(&path);
+        let is_main = main_worktree_path.as_ref() == Some(&path);
+        entries.push(WorktreeEntry {
+            path,
+            display_name: String::new(),
+            head_oid,
+            branch_name,
+            is_current,
+            is_main,
+        });
+        current_lines.clear();
+        Ok(())
+    };
+
+    for field in stdout.split(|byte| *byte == b'\0') {
+        if field.is_empty() {
+            flush(&mut current_path, &mut current_lines, &mut entries)?;
+            continue;
+        }
+
+        if let Some(path) = field.strip_prefix(b"worktree ") {
+            flush(&mut current_path, &mut current_lines, &mut entries)?;
+            current_path = Some(path_from_bytes(path));
+        } else {
+            current_lines.push(field.to_vec());
+        }
+    }
+    flush(&mut current_path, &mut current_lines, &mut entries)?;
+    update_display_names(&mut entries);
+
+    Ok(WorktreeSnapshot { entries })
+}
+
+fn parse_worktree_snapshot_from_porcelain(
+    stdout: &[u8],
+    current_worktree_path: Option<PathBuf>,
+    main_worktree_path: Option<PathBuf>,
+) -> eyre::Result<WorktreeSnapshot> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_lines: Vec<Vec<u8>> = Vec::new();
+
+    let flush = |current_path: &mut Option<PathBuf>,
+                 current_lines: &mut Vec<Vec<u8>>,
+                 entries: &mut Vec<WorktreeEntry>|
+     -> eyre::Result<()> {
+        let Some(path) = current_path.take() else {
+            current_lines.clear();
+            return Ok(());
+        };
+        let (head_oid, branch_name, prunable) = parse_worktree_head_info(current_lines)?;
+        if prunable {
+            current_lines.clear();
+            return Ok(());
+        }
+        if !path.exists() {
+            current_lines.clear();
+            return Ok(());
+        }
+        let path = canonicalize_best_effort(&path);
+        let is_current = current_worktree_path.as_ref() == Some(&path);
+        let is_main = main_worktree_path.as_ref() == Some(&path);
+        entries.push(WorktreeEntry {
+            path,
+            display_name: String::new(),
+            head_oid,
+            branch_name,
+            is_current,
+            is_main,
+        });
+        current_lines.clear();
+        Ok(())
+    };
+
+    for mut line in stdout.split(|byte| *byte == b'\n') {
+        if let Some(stripped_line) = line.strip_suffix(b"\r") {
+            line = stripped_line;
+        }
+        if line.is_empty() {
+            flush(&mut current_path, &mut current_lines, &mut entries)?;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix(b"worktree ") {
+            flush(&mut current_path, &mut current_lines, &mut entries)?;
+            current_path = Some(path_from_bytes(path));
+        } else {
+            current_lines.push(line.to_vec());
+        }
+    }
+    flush(&mut current_path, &mut current_lines, &mut entries)?;
+    update_display_names(&mut entries);
+
+    Ok(WorktreeSnapshot { entries })
+}
+
+/// Discover all linked worktrees for the current repository.
+pub fn get_linked_worktrees(
+    git_run_info: &GitRunInfo,
+    repo: &Repo,
+) -> eyre::Result<WorktreeSnapshot> {
+    let current_worktree_path = repo
+        .get_working_copy_path()
+        .map(|path| canonicalize_best_effort(&path));
+    let main_worktree_path = repo
+        .open_worktree_parent_repo()?
+        .as_ref()
+        .unwrap_or(repo)
+        .get_working_copy_path()
+        .map(|path| canonicalize_best_effort(&path));
+    let result = git_run_info.run_silent(
+        repo,
+        None,
+        &["worktree", "list", "--porcelain", "-z"],
+        GitRunOpts {
+            treat_git_failure_as_error: false,
+            ..Default::default()
+        },
+    )?;
+    if result.exit_code.is_success() {
+        return parse_worktree_snapshot_from_nul_porcelain(
+            &result.stdout,
+            current_worktree_path,
+            main_worktree_path,
+        );
+    }
+
+    let result = git_run_info.run_silent(
+        repo,
+        None,
+        &["worktree", "list", "--porcelain"],
+        GitRunOpts {
+            treat_git_failure_as_error: false,
+            ..Default::default()
+        },
+    )?;
+    if !result.exit_code.is_success() {
+        return Ok(WorktreeSnapshot::default());
+    }
+
+    parse_worktree_snapshot_from_porcelain(
+        &result.stdout,
+        current_worktree_path,
+        main_worktree_path,
+    )
+}

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -112,6 +112,12 @@ impl Git {
             .to_str()
             .ok_or_else(|| eyre::eyre!("Could not convert repo path to string"))?;
         let output = output.replace(repo_path, "<repo-path>");
+        lazy_static! {
+            static ref TEMPFILE_NAME_RE: Regex = Regex::new(r"\.tmp[[:alnum:]]+").unwrap();
+        }
+        let output = TEMPFILE_NAME_RE
+            .replace_all(&output, "<repo-name>")
+            .into_owned();
 
         lazy_static! {
             // Simulate clearing the terminal line by searching for the

--- a/git-branchless-lib/tests/test_repo.rs
+++ b/git-branchless-lib/tests/test_repo.rs
@@ -277,9 +277,15 @@ fn test_worktree_working_copy_path() -> eyre::Result<()> {
     let GitWorktreeWrapper { temp_dir, worktree } = make_git_worktree(&git, "new-worktree")?;
     {
         let stdout = worktree.smartlog()?;
+        let repo_name = git
+            .repo_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        let stdout = stdout.replace(repo_name, "<repo-name>");
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d (master) create test1.txt
+        @ 62fc20d (master) (⎇ <repo-name>, ᐅ new-worktree) create test1.txt
         "###);
     }
 

--- a/git-branchless-lib/tests/test_repo.rs
+++ b/git-branchless-lib/tests/test_repo.rs
@@ -285,7 +285,7 @@ fn test_worktree_working_copy_path() -> eyre::Result<()> {
         let stdout = stdout.replace(repo_name, "<repo-name>");
         insta::assert_snapshot!(stdout, @r###"
         :
-        @ 62fc20d (master) (⎇ <repo-name>, ᐅ new-worktree) create test1.txt
+        @ 62fc20d (master) create test1.txt
         "###);
     }
 

--- a/git-branchless-opts/src/lib.rs
+++ b/git-branchless-opts/src/lib.rs
@@ -373,6 +373,10 @@ pub struct SmartlogArgs {
     #[clap(long)]
     pub exact: bool,
 
+    /// Show linked worktrees in the smartlog.
+    #[clap(long)]
+    pub worktrees: bool,
+
     /// Options for resolving revset expressions.
     #[clap(flatten)]
     pub resolve_revset_options: ResolveRevsetOptions,

--- a/git-branchless-smartlog/src/lib.rs
+++ b/git-branchless-smartlog/src/lib.rs
@@ -20,7 +20,7 @@ use git_branchless_invoke::CommandContext;
 use git_branchless_opts::{Revset, SmartlogArgs};
 use lib::core::config::{
     Hint, get_hint_enabled, get_hint_string, get_smartlog_default_revset, get_smartlog_reverse,
-    print_hint_suppression_notice,
+    get_smartlog_show_worktrees, print_hint_suppression_notice,
 };
 use lib::core::repo_ext::RepoExt;
 use lib::core::rewrite::find_rewrite_target;
@@ -34,8 +34,9 @@ use lib::core::formatting::Pluralize;
 use lib::core::node_descriptors::{
     BranchesDescriptor, CommitMessageDescriptor, CommitOidDescriptor,
     DifferentialRevisionDescriptor, ObsolescenceExplanationDescriptor, Redactor,
-    RelativeTimeDescriptor,
+    RelativeTimeDescriptor, WorktreeDescriptor,
 };
+use lib::core::worktree::get_linked_worktrees;
 use lib::git::{GitRunInfo, Repo};
 
 pub use graph::{SmartlogGraph, make_smartlog_graph};
@@ -753,6 +754,9 @@ mod render {
 
         /// Normally HEAD and the main branch are included. Set this to exclude them.
         pub exact: bool,
+
+        /// Include linked worktrees in the smartlog output.
+        pub worktrees: bool,
     }
 }
 
@@ -769,6 +773,7 @@ pub fn smartlog(
         resolve_revset_options,
         reverse,
         exact,
+        worktrees,
     } = options;
 
     let repo = Repo::from_dir(&git_run_info.working_directory)?;
@@ -798,6 +803,21 @@ pub fn smartlog(
         event_cursor,
         &references_snapshot,
     )?;
+    let show_worktrees = event_id.is_none() && (worktrees || get_smartlog_show_worktrees(&repo)?);
+    let worktree_snapshot = if show_worktrees {
+        get_linked_worktrees(git_run_info, &repo)?
+    } else {
+        Default::default()
+    };
+    let worktree_head_oids = worktree_snapshot.active_head_oids();
+    if !worktree_head_oids.is_empty() {
+        dag.sync_from_oids(
+            effects,
+            &repo,
+            CommitSet::empty(),
+            worktree_head_oids.iter().copied().collect(),
+        )?;
+    }
 
     let revset = match revset {
         Some(revset) => revset,
@@ -814,6 +834,11 @@ pub fn smartlog(
                 return Ok(Err(ExitCode(1)));
             }
         };
+    let commits = if show_worktrees && !exact {
+        commits.union(&worktree_snapshot.active_head_oids().into_iter().collect())
+    } else {
+        commits
+    };
 
     let graph = make_smartlog_graph(
         effects,
@@ -854,6 +879,7 @@ pub fn smartlog(
                 &references_snapshot,
                 &Redactor::Disabled,
             )?,
+            &mut WorktreeDescriptor::new(&worktree_snapshot)?,
             &mut DifferentialRevisionDescriptor::new(&repo, &Redactor::Disabled)?,
             &mut CommitMessageDescriptor::new(&Redactor::Disabled)?,
         ],
@@ -926,6 +952,7 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
         resolve_revset_options,
         reverse,
         exact,
+        worktrees,
     } = args;
 
     smartlog(
@@ -937,6 +964,7 @@ pub fn command_main(ctx: CommandContext, args: SmartlogArgs) -> EyreExitOr<()> {
             resolve_revset_options,
             reverse,
             exact,
+            worktrees,
         },
     )
 }

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -317,9 +317,9 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
        0: branchless::core::eventlog::from_event_log_db with effects=<Output fancy=false> repo=<Git repository at: "<repo-path>/.git/"> event_log_db=<EventLogDb path=Some("<repo-path>/.git/branchless/db.sqlite3")>
           at some/file/path.rs:123
-       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false, exact: false }
+       1: git_branchless_smartlog::smartlog with effects=<Output fancy=false> git_run_info=<GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> options=SmartlogOptions { event_id: None, revset: None, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false }, reverse: false, exact: false, worktrees: false }
           at some/file/path.rs:123
-       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, exact: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
+       2: git_branchless_smartlog::command_main with ctx=CommandContext { effects: <Output fancy=false>, git_run_info: <GitRunInfo path_to_git="<git-executable>" working_directory="<repo-path>" env=not shown> } args=SmartlogArgs { event_id: None, revset: None, reverse: false, exact: false, worktrees: false, resolve_revset_options: ResolveRevsetOptions { show_hidden_commits: false } }
           at some/file/path.rs:123
 
     Suggestion:
@@ -628,6 +628,12 @@ fn test_init_worktree() -> eyre::Result<()> {
     worktree.branchless("init", &[])?;
     {
         let stdout = worktree.smartlog()?;
+        let repo_name = git
+            .repo_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        let stdout = stdout.replace(repo_name, "<repo-name>");
         insta::assert_snapshot!(stdout, @r###"
         :
         @ 96d1c37 (master) create test2.txt

--- a/git-branchless/tests/test_smartlog_worktree.rs
+++ b/git-branchless/tests/test_smartlog_worktree.rs
@@ -29,7 +29,7 @@ fn test_smartlog_shows_detached_linked_worktree() -> eyre::Result<()> {
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ side) create test1.txt
+    @ 62fc20d (> master) (> <repo-name>, wt side) create test1.txt
     "###);
 
     Ok(())
@@ -47,7 +47,7 @@ fn test_smartlog_shows_current_and_home_worktree_annotations() -> eyre::Result<(
     let (stdout, _stderr) = worktree.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d (master) (⎇ <repo-name>, ᐅ topic-wt) create test1.txt
+    @ 62fc20d (master) (wt <repo-name>, > topic-wt) create test1.txt
     "###);
 
     Ok(())
@@ -65,7 +65,7 @@ fn test_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
     let stdout = git.smartlog()?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ side) create test1.txt
+    @ 62fc20d (> master) (> <repo-name>, wt side) create test1.txt
     "###);
 
     Ok(())
@@ -83,9 +83,9 @@ fn test_navigation_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
     let (stdout, _stderr) = git.branchless("prev", &[])?;
     insta::assert_snapshot!(stdout, @r###"
     branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
-    @ f777ecc (ᐅ <repo-name>) create initial.txt
+    @ f777ecc (> <repo-name>) create initial.txt
     |
-    O 62fc20d (master) (⎇ side) create test1.txt
+    O 62fc20d (master) (wt side) create test1.txt
     "###);
 
     Ok(())
@@ -107,9 +107,9 @@ fn test_smartlog_shows_attached_linked_worktree_outside_default_selection() -> e
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    O 62fc20d (topic) (⎇ topic-wt) create test1.txt
+    O 62fc20d (topic) (wt topic-wt) create test1.txt
     |
-    @ 96d1c37 (> master) (ᐅ <repo-name>) create test2.txt
+    @ 96d1c37 (> master) (> <repo-name>) create test2.txt
     "###);
 
     Ok(())
@@ -141,11 +141,11 @@ fn test_move_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
     branchless: processing 1 rewritten commit
     branchless: running command: <git-executable> checkout 4838e49b08954becdd17c0900c1179c2c654c627 --
     :
-    O 62fc20d (master) (⎇ <repo-name>) create test1.txt
+    O 62fc20d (master) (wt <repo-name>) create test1.txt
     |\
     | o 96d1c37 create test2.txt
     |
-    @ 4838e49 (ᐅ topic-wt) create test3.txt
+    @ 4838e49 (> topic-wt) create test3.txt
     In-memory rebase succeeded.
     "###);
 
@@ -178,9 +178,9 @@ fn test_smartlog_syncs_detached_linked_worktree_head_not_in_dag() -> eyre::Resul
 
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
-    o b1ee011 (⎇ outside-wt) outside
+    o b1ee011 (wt outside-wt) outside
     :
-    @ 62fc20d (> master) (ᐅ <repo-name>) create test1.txt
+    @ 62fc20d (> master) (> <repo-name>) create test1.txt
     "###);
 
     Ok(())
@@ -232,7 +232,7 @@ fn test_smartlog_handles_worktree_path_with_newline() -> eyre::Result<()> {
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ line\nbreak) create test1.txt
+    @ 62fc20d (> master) (> <repo-name>, wt line\nbreak) create test1.txt
     "###);
 
     Ok(())
@@ -271,7 +271,7 @@ fn test_smartlog_disambiguates_duplicate_worktree_names() -> eyre::Result<()> {
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
     insta::assert_snapshot!(stdout, @r###"
     :
-    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ bugfix/topic, ⎇ feature/topic) create test1.txt
+    @ 62fc20d (> master) (> <repo-name>, wt bugfix/topic, wt feature/topic) create test1.txt
     "###);
 
     Ok(())

--- a/git-branchless/tests/test_smartlog_worktree.rs
+++ b/git-branchless/tests/test_smartlog_worktree.rs
@@ -1,0 +1,221 @@
+use lib::testing::{make_git, make_git_worktree};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn test_smartlog_hides_linked_worktrees_by_default() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let _worktree = make_git_worktree(&git, "side")?;
+
+    let stdout = git.smartlog()?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_shows_detached_linked_worktree() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let _worktree = make_git_worktree(&git, "side")?;
+
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ side) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_shows_current_and_home_worktree_annotations() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let worktree_wrapper = make_git_worktree(&git, "topic-wt")?;
+    let worktree = worktree_wrapper.worktree;
+
+    let (stdout, _stderr) = worktree.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (master) (⎇ <repo-name>, ᐅ topic-wt) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let _worktree = make_git_worktree(&git, "side")?;
+
+    git.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
+    let stdout = git.smartlog()?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ side) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_shows_attached_linked_worktree_outside_default_selection() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    let topic_oid = git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    git.run(&["branch", "topic", &topic_oid.to_string()])?;
+    let worktree_wrapper = make_git_worktree(&git, "topic-wt")?;
+    let worktree = worktree_wrapper.worktree;
+    worktree.run(&["checkout", "topic"])?;
+
+    git.run(&["config", "branchless.smartlog.defaultRevset", "none()"])?;
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    O 62fc20d (topic) (⎇ topic-wt) create test1.txt
+    |
+    @ 96d1c37 (> master) (ᐅ <repo-name>) create test2.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_syncs_detached_linked_worktree_head_not_in_dag() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let (commit_oid, _stderr) = git.run(&["commit-tree", "HEAD^{tree}", "-m", "outside"])?;
+    let commit_oid = commit_oid.trim();
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let temp_dir =
+        std::env::temp_dir().join(format!("git-branchless-smartlog-outside-{unique_suffix}"));
+    let worktree_path = temp_dir.join("outside-wt");
+    std::fs::create_dir_all(worktree_path.parent().unwrap())?;
+    git.run(&[
+        "worktree",
+        "add",
+        "--detach",
+        worktree_path.to_string_lossy().as_ref(),
+        commit_oid,
+    ])?;
+
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    o b1ee011 (⎇ outside-wt) outside
+    :
+    @ 62fc20d (> master) (ᐅ <repo-name>) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_ignores_prunable_worktree() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let worktree_wrapper = make_git_worktree(&git, "gone-wt")?;
+    std::fs::remove_dir_all(&worktree_wrapper.worktree.repo_path)?;
+
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_handles_worktree_path_with_newline() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    if git.run(&["worktree", "list", "--porcelain", "-z"]).is_err() {
+        return Ok(());
+    }
+
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let temp_dir =
+        std::env::temp_dir().join(format!("git-branchless-smartlog-newline-{unique_suffix}"));
+    let worktree_path = temp_dir.join("line\nbreak");
+    std::fs::create_dir_all(worktree_path.parent().unwrap())?;
+
+    git.run(&[
+        "worktree",
+        "add",
+        "--detach",
+        worktree_path.to_string_lossy().as_ref(),
+    ])?;
+
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ line\nbreak) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_smartlog_disambiguates_duplicate_worktree_names() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let temp_dir =
+        std::env::temp_dir().join(format!("git-branchless-smartlog-worktree-{unique_suffix}"));
+    let feature_topic = temp_dir.join("feature").join("topic");
+    let bugfix_topic = temp_dir.join("bugfix").join("topic");
+    std::fs::create_dir_all(feature_topic.parent().unwrap())?;
+    std::fs::create_dir_all(bugfix_topic.parent().unwrap())?;
+
+    git.run(&[
+        "worktree",
+        "add",
+        "--detach",
+        feature_topic.to_string_lossy().as_ref(),
+    ])?;
+    git.run(&[
+        "worktree",
+        "add",
+        "--detach",
+        bugfix_topic.to_string_lossy().as_ref(),
+    ])?;
+
+    let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    :
+    @ 62fc20d (> master) (ᐅ <repo-name>, ⎇ bugfix/topic, ⎇ feature/topic) create test1.txt
+    "###);
+
+    Ok(())
+}

--- a/git-branchless/tests/test_smartlog_worktree.rs
+++ b/git-branchless/tests/test_smartlog_worktree.rs
@@ -72,6 +72,26 @@ fn test_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_navigation_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+
+    let _worktree = make_git_worktree(&git, "side")?;
+
+    git.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
+    let (stdout, _stderr) = git.branchless("prev", &[])?;
+    insta::assert_snapshot!(stdout, @r###"
+    branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
+    @ f777ecc (ᐅ <repo-name>) create initial.txt
+    |
+    O 62fc20d (master) (⎇ side) create test1.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn test_smartlog_shows_attached_linked_worktree_outside_default_selection() -> eyre::Result<()> {
     let git = make_git()?;
     git.init_repo()?;
@@ -90,6 +110,43 @@ fn test_smartlog_shows_attached_linked_worktree_outside_default_selection() -> e
     O 62fc20d (topic) (⎇ topic-wt) create test1.txt
     |
     @ 96d1c37 (> master) (ᐅ <repo-name>) create test2.txt
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn test_move_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+
+    git.commit_file("test1", 1)?;
+    git.detach_head()?;
+    git.commit_file("test2", 2)?;
+    git.commit_file("test3", 3)?;
+
+    let worktree_wrapper = make_git_worktree(&git, "topic-wt")?;
+    let worktree = worktree_wrapper.worktree;
+    git.run(&["checkout", "master"])?;
+    worktree.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
+
+    let (stdout, _stderr) = worktree.branchless("move", &["-s", "@", "-d", "master"])?;
+    insta::assert_snapshot!(stdout, @r###"
+    Attempting rebase in-memory...
+    [1/1] Committed as: 4838e49 create test3.txt
+    branchless: processing 1 rewritten commit
+    branchless: running command: <git-executable> checkout 4838e49b08954becdd17c0900c1179c2c654c627 --
+    :
+    O 62fc20d (master) (⎇ <repo-name>) create test1.txt
+    |\
+    | o 96d1c37 create test2.txt
+    |
+    @ 4838e49 (ᐅ topic-wt) create test3.txt
+    In-memory rebase succeeded.
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds worktree awareness to `git smartlog`.

Smartlog now discovers linked worktrees via `git worktree list --porcelain [-z]`, includes active linked-worktree HEADs in the rendered graph, and annotates commits with the worktrees currently checked out there. This makes it easier to see work spread across multiple worktrees without switching context.

Worktrees are named in the view using shortest unique path suffix.

## Screenshots

Here's how it looks on my personal machine: 
<img width="1836" height="382" alt="CleanShot 2026-05-31 at 11 49 45@2x" src="https://github.com/user-attachments/assets/aa1c76f4-ec10-4fcb-90f4-5c9f82313072" />

## Details

- Adds a shared linked-worktree snapshot model.
- Shows current and linked worktree markers in smartlog output.
- Includes linked-worktree HEAD commits even when they are outside the default smartlog revset.
- Skips prunable worktrees.
- Syncs active worktree HEAD OIDs into the DAG before rendering, preventing crashes for detached worktree commits not already known to branchless.

## AI Assistance Disclosure

This PR was generated with heavy assistance from OpenAI Codex. I reviewed the design, behavior, and generated changes before submitting.