### PR TITLE
fix(test): sanitize path-invalid characters in test command slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (#1629): `git test` no longer fails to create its results directory when the test command contains characters that are invalid in a path on Windows (such as `|`, `<`, `>`, `:`, `*`, `?`, `"`, or `\`).
+
 ## [v0.11.1] - 2026-05-21
 
 ### Changed

--- a/git-branchless-lib/src/git/test.rs
+++ b/git-branchless-lib/src/git/test.rs
@@ -43,7 +43,23 @@ pub const TEST_ABORT_EXIT_CODE: i32 = 127;
 
 /// Convert a command string into a string that's safe to use as a filename.
 pub fn make_test_command_slug(command: String) -> String {
-    command.replace(['/', ' ', '\n'], "__")
+    // The slug is used as a directory name, so replace every character that is
+    // invalid in a path component on any supported platform. Windows forbids
+    // `<>:"/\|?*` and ASCII control characters (`/` is also a path separator on
+    // Unix); spaces are replaced for readability. Without this, `git test -x`
+    // commands containing e.g. pipes or redirects fail to create their cache
+    // directory on Windows. See
+    // https://github.com/arxanas/git-branchless/issues/1629.
+    command.replace(
+        |c: char| {
+            c.is_control()
+                || matches!(
+                    c,
+                    '/' | '\\' | '<' | '>' | ':' | '"' | '|' | '?' | '*' | ' '
+                )
+        },
+        "__",
+    )
 }
 
 /// A version of `NonZeroOid` that can be serialized and deserialized.
@@ -136,4 +152,46 @@ pub fn get_test_worktrees_dir(repo: &Repo) -> Result<PathBuf, RepoError> {
 /// Get the path to the file where the latest test command is stored.
 pub fn get_latest_test_command_path(repo: &Repo) -> Result<PathBuf, RepoError> {
     Ok(get_test_dir(repo)?.join("latest-command"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_test_command_slug_replaces_path_invalid_chars() {
+        // The slug is used as a directory name, so it must not contain
+        // characters that are invalid in a path component on any supported
+        // platform. Windows forbids `<>:"/\|?*` and control characters; before
+        // #1629 these passed through unchanged and broke `git test`'s cache
+        // directory creation. This asserts the slug's output contract, so it
+        // fails on every platform (not just Windows).
+        let slug = make_test_command_slug("echo <a> | tee \"f:i*l?e\" > /x\\y".to_string());
+        for invalid in ['/', '\\', '<', '>', ':', '"', '|', '?', '*'] {
+            assert!(
+                !slug.contains(invalid),
+                "slug {slug:?} still contains path-invalid char {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_make_test_command_slug_replaces_control_chars() {
+        // Control characters (including the newline handled before #1629) are
+        // invalid in Windows paths and must not survive into the slug.
+        let slug = make_test_command_slug("a\nb\tc\rd".to_string());
+        assert!(
+            !slug.chars().any(|c| c.is_control()),
+            "slug {slug:?} still contains a control character"
+        );
+    }
+
+    #[test]
+    fn test_make_test_command_slug_preserves_simple_command() {
+        // An ordinary command keeps a human-readable, unchanged slug.
+        assert_eq!(
+            make_test_command_slug("cargo test".to_string()),
+            "cargo__test"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`git test -x <command>` slugifies the command into a directory name (under `.git/branchless/test/<tree_oid>/<slug>`) via `make_test_command_slug`, which only replaced `/`, space, and newline:

```rust
command.replace(['/', ' ', '\n'], "__")
```

On Windows the other characters that are invalid in a path component (`< > : " \ | ? *` and ASCII control characters) passed through unchanged, so `create_dir_all` failed and `git test` errored out. Pipes, redirects, and globs are everyday `-x` syntax (`cargo build 2>&1 | tee log`, `eslint 'src/**/*.js'`), so this bites real commands. Fixes #1629.

## Fix

Replace any control character, or any of `/ \ < > : " | ? *`, or a space, with `__`. Sanitization is unconditional (not `#[cfg(windows)]`) so slugs are portable across platforms and the behavior is testable everywhere.

## On the design choice (replacing the invalid set, not all non-alphanumerics)

The issue suggested two robust directions: a platform-specific list of chars to exclude, **or** replacing all non-alphanumeric characters. I went with the targeted invalid-char list on purpose:

- It preserves the slug for ordinary commands. `bash test.sh 10` stays `bash__test.sh__10`; replacing all non-alphanumerics would make it `bash__test__sh__10`.
- That keeps users' existing cached test results valid across the upgrade (the cache is keyed by the slug), and keeps the existing `test_test.rs` snapshots unchanged. I checked the test corpus — no existing test command contains a character this newly replaces, so no snapshot changes.

Happy to switch to replace-all-non-alphanumeric if you'd prefer the simpler rule; it'd just churn the snapshots and existing caches.

**Tradeoff worth noting:** collapsing more characters to `__` does widen slug collisions (e.g. `echo a:b` and `echo a|b` now map to the same slug, where on Unix they previously differed). The function already collided by design (`a/b`, `a b`, `a\nb` all mapped to `a__b`), so this doesn't introduce a new class of behavior, and on Windows the affected commands didn't work at all before. A collision-free slug would need hashing, which would orphan every existing cache — out of scope for this fix, but I'm glad to follow up if you want it.

## Testing

Added unit tests on `make_test_command_slug` asserting (a) no path-invalid char survives, (b) control characters are replaced, and (c) an ordinary command keeps its readable slug. These assert the function's output contract, so they fail on macOS/Linux too — which sidesteps the "couldn't reproduce on a non-Windows machine" problem noted on the issue.

`cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets -- --deny warnings`, and the new tests all pass locally.
