### PR TITLE
submit: omit commit title from GitHub PR body

### DIFF
--- a/git-branchless-lib/src/git/object.rs
+++ b/git-branchless-lib/src/git/object.rs
@@ -109,6 +109,12 @@ impl<'repo> Commit<'repo> {
         BString::from(self.inner.message_bytes())
     }
 
+    /// Get the commit message body.
+    #[instrument]
+    pub fn get_body(&self) -> Option<&str> {
+        self.inner.body()
+    }
+
     /// Get the commit message, without any whitespace trimmed.
     #[instrument]
     pub fn get_message_raw(&self) -> BString {

--- a/git-branchless-submit/src/github.rs
+++ b/git-branchless-submit/src/github.rs
@@ -18,6 +18,7 @@ use lib::core::eventlog::EventLogDb;
 use lib::core::repo_ext::RepoExt;
 use lib::core::repo_ext::RepoReferencesSnapshot;
 use lib::git::CategorizedReferenceName;
+use lib::git::Commit;
 use lib::git::GitErrorCode;
 use lib::git::GitRunInfo;
 use lib::git::RepoError;
@@ -56,6 +57,14 @@ fn commit_summary_slug(summary: &str) -> String {
     } else {
         summary_slug.to_owned()
     }
+}
+
+fn get_commit_message_body(commit: &Commit<'_>) -> String {
+    let mut body = commit.get_body().unwrap_or_default().to_owned();
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    body
 }
 
 fn singleton<K: Debug + Eq + Hash, V: Clone>(
@@ -345,7 +354,7 @@ impl Forge for GithubForge<'_> {
 
             let commit = self.repo.find_commit_or_fail(commit_oid)?;
             let title = String::from_utf8_lossy(&commit.get_summary()?).into_owned();
-            let body = String::from_utf8_lossy(&commit.get_message_pretty()).into_owned();
+            let body = get_commit_message_body(&commit);
             try_exit_code!(self.client.create_pull_request(
                 effects,
                 client::CreatePullRequestArgs {
@@ -651,19 +660,28 @@ impl GithubForge<'_> {
         let commit_summary = commit.get_summary()?;
         let commit_summary = String::from_utf8_lossy(&commit_summary).into_owned();
         let title = format!("[{stack_index}/{stack_size}] {commit_summary}");
-        let commit_message = commit.get_message_pretty();
-        let commit_message = String::from_utf8_lossy(&commit_message);
-        let body = format!(
-            "\
+        let commit_message_body = get_commit_message_body(&commit);
+        let body = if commit_message_body.is_empty() {
+            format!(
+                "\
+**Stack:**
+
+{stack_list}
+"
+            )
+        } else {
+            format!(
+                "\
 **Stack:**
 
 {stack_list}
 
 ---
 
-{commit_message}
+{commit_message_body}
 "
-        );
+            )
+        };
 
         let stack_ancestor_oids = {
             let main_branch_oid = CommitSet::from(references_snapshot.main_branch_oid);

--- a/git-branchless-submit/tests/test_github_forge.rs
+++ b/git-branchless-submit/tests/test_github_forge.rs
@@ -70,6 +70,92 @@ fn rebase_and_merge(remote_repo: &Git, branch_name: &str) -> eyre::Result<()> {
 }
 
 #[test]
+fn test_github_forge_uses_commit_message_body_for_pull_request_body() -> eyre::Result<()> {
+    let GitWrapperWithRemoteRepo {
+        temp_dir: _temp_dir,
+        original_repo: remote_repo,
+        cloned_repo: local_repo,
+    } = make_git_with_remote_repo()?;
+    if remote_repo.get_version()? < MIN_VERSION {
+        return Ok(());
+    }
+
+    remote_repo.init_repo()?;
+    remote_repo.clone_repo_into(&local_repo, &[])?;
+
+    local_repo.detach_head()?;
+    local_repo.write_file_txt("test1", "test1 contents\n")?;
+    local_repo.run(&["add", "."])?;
+    local_repo.run_with_options(
+        &[
+            "commit",
+            "-m",
+            "Summarize bridge behavior",
+            "-m",
+            "Explain why the collision model has to change.\n\nInclude the follow-up notes.",
+        ],
+        &GitRunOptions {
+            time: 1,
+            ..Default::default()
+        },
+    )?;
+
+    {
+        let (stdout, _stderr) = local_repo.branchless_with_options(
+            "submit",
+            &["--create", "--forge", "github"],
+            &GitRunOptions {
+                env: mock_env(&remote_repo),
+                ..Default::default()
+            },
+        )?;
+        insta::assert_snapshot!(stdout, @r###"
+        branchless: running command: <git-executable> push --set-upstream origin mock-github-username/summarize-bridge-behavior
+        branch 'mock-github-username/summarize-bridge-behavior' set up to track 'origin/mock-github-username/summarize-bridge-behavior'.
+        Updating pull request (title, body) for commit 09180d7 Summarize bridge behavior
+        branchless: running command: <git-executable> push --force-with-lease origin mock-github-username/summarize-bridge-behavior
+        Submitted 1 commit: mock-github-username/summarize-bridge-behavior
+        "###);
+    }
+    {
+        let state = dump_state(&local_repo, &remote_repo)?;
+        insta::assert_snapshot!(state, @r###"
+        Local state:
+        O f777ecc (master) create initial.txt
+        |
+        @ 09180d7 (mock-github-username/summarize-bridge-behavior) Summarize bridge behavior
+
+
+        Remote state:
+        @ f777ecc (> master) create initial.txt
+        |
+        o 09180d7 (mock-github-username/summarize-bridge-behavior) Summarize bridge behavior
+
+
+        Pull request info:
+        {
+          "pull_request_index": 1,
+          "pull_requests": {
+            "mock-github-username/summarize-bridge-behavior": {
+              "number": 1,
+              "url": "https://example.com/mock-github-username/mock-github-repo/pulls/1",
+              "headRefName": "mock-github-username/summarize-bridge-behavior",
+              "headRefOid": "09180d7e58d6f28c46a11d4e25ca0fec879d62d0",
+              "baseRefName": "master",
+              "closed": false,
+              "isDraft": false,
+              "title": "[1/1] Summarize bridge behavior",
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n\n---\n\nExplain why the collision model has to change.\n\nInclude the follow-up notes.\n\n"
+            }
+          }
+        }
+        "###);
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_github_forge_reorder_commits() -> eyre::Result<()> {
     let GitWrapperWithRemoteRepo {
         temp_dir: _temp_dir,
@@ -139,7 +225,7 @@ fn test_github_forge_reorder_commits() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[1/2] create test1.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test1.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             },
             "mock-github-username/create-test2-txt": {
               "number": 2,
@@ -150,7 +236,7 @@ fn test_github_forge_reorder_commits() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[2/2] create test2.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test2.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             }
           }
         }
@@ -210,7 +296,7 @@ fn test_github_forge_reorder_commits() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[2/2] create test1.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n\n---\n\ncreate test1.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n"
             },
             "mock-github-username/create-test2-txt": {
               "number": 2,
@@ -221,7 +307,7 @@ fn test_github_forge_reorder_commits() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[1/2] create test2.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n\n---\n\ncreate test2.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n"
             }
           }
         }
@@ -302,7 +388,7 @@ fn test_github_forge_mock_client_closes_pull_requests() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[1/2] create test1.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test1.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             },
             "mock-github-username/create-test2-txt": {
               "number": 2,
@@ -313,7 +399,7 @@ fn test_github_forge_mock_client_closes_pull_requests() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[2/2] create test2.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test2.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             }
           }
         }
@@ -392,7 +478,7 @@ fn test_github_forge_mock_client_closes_pull_requests() -> eyre::Result<()> {
               "closed": true,
               "isDraft": false,
               "title": "[1/2] create test1.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test1.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             },
             "mock-github-username/create-test2-txt": {
               "number": 2,
@@ -403,7 +489,7 @@ fn test_github_forge_mock_client_closes_pull_requests() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[1/1] create test2.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n\n---\n\ncreate test2.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/2\n\n"
             }
           }
         }
@@ -493,7 +579,7 @@ fn test_github_forge_no_include_unsubmitted_commits_in_stack() -> eyre::Result<(
               "closed": false,
               "isDraft": false,
               "title": "[1/1] create test1.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n\n---\n\ncreate test1.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n"
             }
           }
         }
@@ -587,7 +673,7 @@ fn test_github_forge_multiple_commits_in_pull_request() -> eyre::Result<()> {
               "closed": false,
               "isDraft": false,
               "title": "[1/1] create test3.txt",
-              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n\n---\n\ncreate test3.txt\n\n"
+              "body": "**Stack:**\n\n* https://example.com/mock-github-username/mock-github-repo/pulls/1\n\n"
             }
           }
         }


### PR DESCRIPTION
Fixes #1680.

## Problem
`git branchless submit --forge github` uses the commit summary as the GitHub pull request title, but the create and update paths also include the full commit message in the pull request body. For a conventional subject/body commit message, that repeats the subject in the PR description. Projects that squash-merge with title plus body then get the title twice in the final commit message.

## Changes
- Derive the GitHub pull request body from the commit-message body after the summary.
- Use the same body helper for initial PR creation and later stack metadata updates.
- Omit the message separator when a commit has no body, leaving only the stack metadata.
- Add a GitHub forge regression test for a subject plus multi-paragraph body commit.

## Verification
- `cargo build -p git-branchless -p git-branchless-submit`
- `TEST_GIT="$(which git)" TEST_GIT_EXEC_PATH="$(git --exec-path)" cargo test -p git-branchless-submit test_github_forge --test test_github_forge -- --nocapture`
- `cargo fmt --all -- --check`
