### PR TITLE
fix(worktree): respect active worktrees in existing commands

### DIFF
--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -22,6 +22,7 @@ use super::config::get_undo_create_snapshots;
 use super::effects::Effects;
 use super::eventlog::{Event, EventLogDb, EventTransactionId};
 use super::repo_ext::{RepoExt, RepoReferencesSnapshot};
+use super::worktree::get_linked_worktrees;
 
 /// An entity to check out.
 #[derive(Clone, Debug)]
@@ -67,6 +68,7 @@ impl Default for CheckOutCommitOptions {
 }
 
 fn maybe_get_branch_name(
+    git_run_info: &GitRunInfo,
     current_target: Option<String>,
     oid: Option<NonZeroOid>,
     repo: &Repo,
@@ -94,6 +96,10 @@ fn maybe_get_branch_name(
         Some(oid) => match branch_oid_to_names.get(&oid) {
             Some(branch_names) => match branch_names.iter().exactly_one() {
                 Ok(branch_name) => {
+                    let worktree_snapshot = get_linked_worktrees(git_run_info, repo)?;
+                    if worktree_snapshot.find_by_branch(branch_name).is_some() {
+                        return Ok(current_target);
+                    }
                     // To remove the `refs/heads/` prefix
                     let name = CategorizedReferenceName::new(branch_name);
                     Ok(Some(name.render_suffix()))
@@ -140,7 +146,7 @@ pub fn check_out_commit(
     }
 
     let target = if get_auto_switch_branches(repo)? && !reset && !force_detach {
-        maybe_get_branch_name(target, oid, repo)?
+        maybe_get_branch_name(git_run_info, target, oid, repo)?
     } else {
         target
     };

--- a/git-branchless-lib/src/core/rewrite/execute.rs
+++ b/git-branchless-lib/src/core/rewrite/execute.rs
@@ -13,6 +13,7 @@ use crate::core::effects::Effects;
 use crate::core::eventlog::{EventLogDb, EventTransactionId};
 use crate::core::formatting::Pluralize;
 use crate::core::repo_ext::RepoExt;
+use crate::core::worktree::get_linked_worktrees;
 use crate::git::{
     BranchType, CategorizedReferenceName, GitRunInfo, MaybeZeroOid, NonZeroOid, ReferenceName,
     Repo, ResolvedReferenceInfo,
@@ -20,6 +21,35 @@ use crate::git::{
 use crate::util::{ExitCode, EyreExitOr};
 
 use super::plan::RebasePlan;
+
+fn check_branches_active_in_other_worktrees(
+    git_run_info: &GitRunInfo,
+    repo: &Repo,
+    rewritten_oids_map: &HashMap<NonZeroOid, MaybeZeroOid>,
+    branch_oid_to_names: &HashMap<NonZeroOid, HashSet<ReferenceName>>,
+) -> eyre::Result<()> {
+    let worktree_snapshot = get_linked_worktrees(git_run_info, repo)?;
+
+    for (old_oid, names) in branch_oid_to_names.iter() {
+        if !rewritten_oids_map.contains_key(old_oid) {
+            continue;
+        }
+        for reference_name in names {
+            if let Some(entry) = worktree_snapshot.find_by_branch(reference_name) {
+                if !entry.is_current {
+                    let branch_name = CategorizedReferenceName::new(reference_name).render_suffix();
+                    eyre::bail!(
+                        "Branch '{}' is active in another worktree at '{}'. Refusing to move it.",
+                        branch_name,
+                        entry.path.to_string_lossy()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
 
 /// Given a list of rewritten OIDs, move the branches attached to those OIDs
 /// from their old commits to their new commits. Invoke the
@@ -34,6 +64,12 @@ pub fn move_branches<'a>(
     let main_branch = repo.get_main_branch()?;
     let main_branch_name = main_branch.get_reference_name()?;
     let branch_oid_to_names = repo.get_branch_oid_to_names()?;
+    check_branches_active_in_other_worktrees(
+        git_run_info,
+        repo,
+        rewritten_oids_map,
+        &branch_oid_to_names,
+    )?;
 
     // We may experience an error in the case of a branch move. Ideally, we
     // would use `git2::Transaction::commit`, which stops the transaction at the
@@ -432,6 +468,7 @@ mod in_memory {
     use crate::core::effects::{Effects, OperationIcon, OperationType};
     use crate::core::eventlog::EventLogDb;
     use crate::core::gc::mark_commit_reachable;
+    use crate::core::repo_ext::RepoExt;
     use crate::core::rewrite::execute::check_out_updated_head;
     use crate::core::rewrite::move_branches;
     use crate::core::rewrite::plan::{OidOrLabel, RebaseCommand, RebasePlan};
@@ -439,7 +476,7 @@ mod in_memory {
         AmendFastOptions, CherryPickFastOptions, CreateCommitFastError, GitRunInfo, MaybeZeroOid,
         NonZeroOid, Repo,
     };
-    use crate::util::EyreExitOr;
+    use crate::util::{ExitCode, EyreExitOr};
 
     use super::{ExecuteRebasePlanOptions, FailedMergeInfo};
 
@@ -921,6 +958,17 @@ mod in_memory {
             }
         }
 
+        let branch_oid_to_names = repo.get_branch_oid_to_names()?;
+        if let Err(err) = super::check_branches_active_in_other_worktrees(
+            git_run_info,
+            repo,
+            rewritten_oids,
+            &branch_oid_to_names,
+        ) {
+            writeln!(effects.get_error_stream(), "{err}")?;
+            return Ok(Err(ExitCode(1)));
+        }
+
         let head_info = repo.get_head_info()?;
         if head_info.oid.is_some() {
             // Avoid moving the branch which HEAD points to, or else the index will show
@@ -928,7 +976,10 @@ mod in_memory {
             repo.detach_head(&head_info)?;
         }
 
-        move_branches(effects, git_run_info, repo, *event_tx_id, rewritten_oids)?;
+        if let Err(err) = move_branches(effects, git_run_info, repo, *event_tx_id, rewritten_oids) {
+            writeln!(effects.get_error_stream(), "{err}")?;
+            return Ok(Err(ExitCode(1)));
+        }
 
         // Call the `post-rewrite` hook only after moving branches so that we don't
         // produce a spurious abandoned-branch warning.
@@ -1311,9 +1362,8 @@ pub fn execute_rebase_plan(
                     options,
                 )? {
                     Ok(()) => {}
-                    Err(_exit_code) => {
-                        // FIXME: we may still want to propagate the exit code to the
-                        // caller.
+                    Err(exit_code) => {
+                        return Ok(ExecuteRebasePlanResult::Failed { exit_code });
                     }
                 }
 

--- a/git-branchless-navigation/src/lib.rs
+++ b/git-branchless-navigation/src/lib.rs
@@ -36,7 +36,9 @@ use lib::core::formatting::Pluralize;
 use lib::core::node_descriptors::{
     BranchesDescriptor, CommitMessageDescriptor, CommitOidDescriptor,
     DifferentialRevisionDescriptor, NodeDescriptor, Redactor, RelativeTimeDescriptor,
+    WorktreeDescriptor,
 };
+use lib::core::worktree::get_linked_worktrees;
 use lib::git::{GitRunInfo, NonZeroOid, Repo};
 
 use crate::prompt::prompt_select_commit;
@@ -361,6 +363,7 @@ pub fn traverse_commits(
     let references_snapshot = repo.get_references_snapshot()?;
     let conn = repo.get_db_conn()?;
     let event_log_db = EventLogDb::new(&conn)?;
+    let worktree_snapshot = get_linked_worktrees(git_run_info, &repo)?;
     let event_tx_id = event_log_db.make_transaction_id(
         now,
         match command {
@@ -398,6 +401,7 @@ pub fn traverse_commits(
                 &references_snapshot,
                 &Redactor::Disabled,
             )?,
+            &mut WorktreeDescriptor::new(&worktree_snapshot)?,
             &mut DifferentialRevisionDescriptor::new(&repo, &Redactor::Disabled)?,
             &mut CommitMessageDescriptor::new(&Redactor::Disabled)?,
         ],
@@ -438,7 +442,11 @@ pub fn traverse_commits(
                 CheckoutTarget::Oid(current_oid)
             } else if branches.len() == 1 {
                 let branch = branches.iter().next().unwrap();
-                CheckoutTarget::Reference(branch.to_owned())
+                if worktree_snapshot.find_by_branch(branch).is_some() {
+                    CheckoutTarget::Oid(current_oid)
+                } else {
+                    CheckoutTarget::Reference(branch.to_owned())
+                }
             } else {
                 // It's ambiguous which branch the user wants; just check out the commit directly.
                 CheckoutTarget::Oid(current_oid)
@@ -491,6 +499,7 @@ pub fn switch(
     let references_snapshot = repo.get_references_snapshot()?;
     let conn = repo.get_db_conn()?;
     let event_log_db = EventLogDb::new(&conn)?;
+    let worktree_snapshot = get_linked_worktrees(git_run_info, &repo)?;
     let event_tx_id = event_log_db.make_transaction_id(now, "checkout")?;
     let event_replayer = EventReplayer::from_event_log_db(effects, &repo, &event_log_db)?;
     let event_cursor = event_replayer.make_default_cursor();
@@ -554,6 +563,7 @@ pub fn switch(
                         &references_snapshot,
                         &Redactor::Disabled,
                     )?,
+                    &mut WorktreeDescriptor::new(&worktree_snapshot)?,
                     &mut DifferentialRevisionDescriptor::new(&repo, &Redactor::Disabled)?,
                     &mut CommitMessageDescriptor::new(&Redactor::Disabled)?,
                 ],

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -45,6 +45,7 @@ use lib::core::node_descriptors::{
     DifferentialRevisionDescriptor, ObsolescenceExplanationDescriptor, Redactor,
     RelativeTimeDescriptor,
 };
+use lib::core::worktree::get_linked_worktrees;
 use lib::git::{CategorizedReferenceName, GitRunInfo, MaybeZeroOid, Repo, ResolvedReferenceInfo};
 
 fn render_cursor_smartlog(
@@ -784,6 +785,70 @@ fn extract_checkout_target(
     Ok((checkout_target, new_events))
 }
 
+fn infer_checkout_target_for_moved_head_ref(
+    head_info: &ResolvedReferenceInfo,
+    events: &[&Event],
+) -> Option<UndoCheckoutTarget> {
+    let head_ref_name = head_info.reference_name.as_ref()?;
+    let new_oid = events.iter().rev().find_map(|event| match event {
+        Event::RefUpdateEvent {
+            ref_name,
+            old_oid: _,
+            new_oid: MaybeZeroOid::NonZero(new_oid),
+            ..
+        } if ref_name == head_ref_name => Some(*new_oid),
+        _ => None,
+    })?;
+    Some(UndoCheckoutTarget {
+        target: CheckoutTarget::Oid(new_oid),
+        options: CheckOutCommitOptions {
+            additional_args: vec!["--detach".into()],
+            force_detach: false,
+            reset: false,
+            render_smartlog: true,
+        },
+    })
+}
+
+fn check_for_branches_active_in_other_worktrees(
+    effects: &Effects,
+    git_run_info: &GitRunInfo,
+    repo: &Repo,
+    events: &[&Event],
+) -> EyreExitOr<()> {
+    let worktree_snapshot = get_linked_worktrees(git_run_info, repo)?;
+    for event in events {
+        let Event::RefUpdateEvent {
+            ref_name,
+            old_oid: _,
+            new_oid: _,
+            ..
+        } = event
+        else {
+            continue;
+        };
+
+        let CategorizedReferenceName::LocalBranch { .. } = CategorizedReferenceName::new(ref_name)
+        else {
+            continue;
+        };
+
+        if let Some(entry) = worktree_snapshot.find_by_branch(ref_name) {
+            if !entry.is_current {
+                let branch_name = CategorizedReferenceName::new(ref_name).render_suffix();
+                writeln!(
+                    effects.get_error_stream(),
+                    "Branch '{}' is active in another worktree at '{}'. Refusing to undo it.",
+                    branch_name,
+                    entry.path.to_string_lossy()
+                )?;
+                return Ok(Err(ExitCode(1)));
+            }
+        }
+    }
+    Ok(Ok(()))
+}
+
 #[instrument(skip(in_))]
 fn undo_events(
     in_: &mut impl Read,
@@ -862,6 +927,14 @@ fn undo_events(
     .to_string();
 
     let (checkout_target, filtered_events) = extract_checkout_target(&inverse_events)?;
+    let checkout_target = checkout_target
+        .or_else(|| infer_checkout_target_for_moved_head_ref(&head_info, &filtered_events));
+    try_exit_code!(check_for_branches_active_in_other_worktrees(
+        effects,
+        git_run_info,
+        repo,
+        &filtered_events,
+    )?);
     if checkout_target.is_some() {
         repo.detach_head(&head_info)?;
     }
@@ -1051,6 +1124,46 @@ mod tests {
     use super::*;
 
     use lib::core::eventlog::testing::new_event_transaction_id;
+    use lib::git::{NonZeroOid, ReferenceName};
+
+    #[test]
+    fn test_infer_checkout_target_for_moved_head_ref_uses_final_ref_update() -> eyre::Result<()> {
+        let first_oid: NonZeroOid = "1111111111111111111111111111111111111111".parse()?;
+        let final_oid: NonZeroOid = "2222222222222222222222222222222222222222".parse()?;
+        let head_ref_name = ReferenceName::from("refs/heads/master");
+        let head_info = ResolvedReferenceInfo {
+            oid: Some(first_oid),
+            reference_name: Some(head_ref_name.clone()),
+        };
+        let events = [
+            Event::RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId::Id(1),
+                ref_name: head_ref_name.clone(),
+                old_oid: MaybeZeroOid::NonZero(final_oid),
+                new_oid: MaybeZeroOid::NonZero(first_oid),
+                message: None,
+            },
+            Event::RefUpdateEvent {
+                timestamp: 0.0,
+                event_tx_id: EventTransactionId::Id(2),
+                ref_name: head_ref_name,
+                old_oid: MaybeZeroOid::NonZero(first_oid),
+                new_oid: MaybeZeroOid::NonZero(final_oid),
+                message: None,
+            },
+        ];
+        let event_refs: Vec<_> = events.iter().collect();
+
+        let checkout_target =
+            infer_checkout_target_for_moved_head_ref(&head_info, &event_refs).unwrap();
+        match checkout_target.target {
+            CheckoutTarget::Oid(oid) => assert_eq!(oid, final_oid),
+            target => panic!("unexpected checkout target: {target:?}"),
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn test_optimize_inverse_events() -> eyre::Result<()> {

--- a/git-branchless/tests/test_restack.rs
+++ b/git-branchless/tests/test_restack.rs
@@ -1,4 +1,6 @@
-use lib::testing::{GitInitOptions, GitRunOptions, make_git, remove_rebase_lines};
+use lib::testing::{
+    GitInitOptions, GitRunOptions, make_git, make_git_worktree, remove_rebase_lines,
+};
 
 #[test]
 fn test_restack_amended_commit() -> eyre::Result<()> {
@@ -579,6 +581,45 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
         @ 59e7581 (> foo, master) create test2.txt
         "###);
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_restack_refuses_branch_active_in_other_worktree() -> eyre::Result<()> {
+    let git = make_git()?;
+    git.init_repo()?;
+
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["branch", "foo"])?;
+
+    let worktree_wrapper = make_git_worktree(&git, "foo-wt")?;
+    let worktree = worktree_wrapper.worktree;
+    worktree.run(&["checkout", "foo"])?;
+
+    git.run(&["checkout", "HEAD^"])?;
+    git.run(&["commit", "--amend", "-m", "test1 amended"])?;
+    git.run(&["checkout", "master"])?;
+
+    let (stdout, stderr) = git.run_with_options(
+        &["restack", "-f", "all()"],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    )?;
+    assert!(
+        stdout.contains("Attempting rebase in-memory..."),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stderr.contains("Branch 'foo' is active in another worktree"),
+        "stderr was: {stderr}"
+    );
+    assert!(stderr.contains("foo-wt"), "stderr was: {stderr}");
+    let (current_branch, _stderr) = git.run(&["branch", "--show-current"])?;
+    assert_eq!(current_branch.trim(), "master");
 
     Ok(())
 }

--- a/git-branchless/tests/test_undo.rs
+++ b/git-branchless/tests/test_undo.rs
@@ -12,7 +12,7 @@ use lib::core::eventlog::{EventCursor, EventLogDb, EventReplayer};
 use lib::core::formatting::Glyphs;
 use lib::core::repo_ext::RepoExt;
 use lib::git::{GitRunInfo, GitVersion, Repo};
-use lib::testing::{Git, GitInitOptions, GitRunOptions, make_git, trim_lines};
+use lib::testing::{Git, GitInitOptions, GitRunOptions, make_git, make_git_worktree, trim_lines};
 
 use cursive_core::event::Key;
 use cursive_core::{Cursive, CursiveRunner};
@@ -339,7 +339,7 @@ fn test_undo_hide() -> eyre::Result<()> {
     insta::assert_debug_snapshot!(event_cursor, @r###"
         Some(
             EventCursor {
-                event_id: 9,
+                event_id: 10,
             },
         )
         "###);
@@ -410,10 +410,8 @@ fn test_undo_move_refs() -> eyre::Result<()> {
 
         2. Move branch master from 96d1c37 create test2.txt
                                 to 62fc20d create test1.txt
-        3. Check out from 96d1c37 create test2.txt
-                       to 62fc20d create test1.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
-        Applied 3 inverse events.
+        Applied 2 inverse events.
         "###);
         assert_eq!(exit_code, 0);
     }
@@ -425,6 +423,63 @@ fn test_undo_move_refs() -> eyre::Result<()> {
         @ 62fc20d (master) create test1.txt
         "###);
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_undo_refuses_branch_active_in_other_worktree() -> eyre::Result<()> {
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+
+    git.init_repo()?;
+    let test1_oid = git.commit_file("test1", 1)?;
+    git.run(&["branch", "foo"])?;
+    let test2_oid = git.commit_file("test2", 2)?;
+
+    let worktree_wrapper = make_git_worktree(&git, "foo-wt")?;
+    let worktree = worktree_wrapper.worktree;
+    worktree.run(&["checkout", "foo"])?;
+
+    git.run(&[
+        "update-ref",
+        "refs/heads/foo",
+        &test2_oid.to_string(),
+        &test1_oid.to_string(),
+    ])?;
+
+    let (stdout, stderr) = git.run_with_options(
+        &["undo", "--yes"],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    )?;
+    let stdout = trim_lines(stdout);
+    let stderr = trim_lines(stderr);
+    insta::assert_snapshot!(stdout, @r###"
+    Will apply these actions:
+    1. Move branch foo from 96d1c37 create test2.txt
+                         to 62fc20d create test1.txt
+    "###);
+    assert!(
+        stderr.contains("Branch 'foo' is active in another worktree"),
+        "stderr was: {stderr}"
+    );
+    assert!(stderr.contains("foo-wt"), "stderr was: {stderr}");
+
+    let (foo_oid, _stderr) = git.run(&["rev-parse", "foo"])?;
+    assert_eq!(foo_oid.trim(), test2_oid.to_string());
+
+    let stdout = git.smartlog()?;
+    assert!(stdout.contains("foo"), "smartlog was: {stdout}");
+    assert!(
+        stdout.contains(&test2_oid.to_string()[..7]),
+        "smartlog was: {stdout}"
+    );
 
     Ok(())
 }
@@ -638,12 +693,10 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
 
         3. Move branch master from 62fc20d create test1.txt
                                 to f777ecc create initial.txt
-        4. Check out from 62fc20d create test1.txt
-                       to f777ecc create initial.txt
-        5. Delete branch foo at f777ecc create initial.txt
+        4. Delete branch foo at f777ecc create initial.txt
 
         Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
-        Applied 5 inverse events.
+        Applied 4 inverse events.
         "###);
         assert_eq!(exit_code, 0);
     }
@@ -846,8 +899,6 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
 
         3. Move branch master from 9ed8f9a bad message
                                 to 96d1c37 create test2.txt
-        4. Check out from 9ed8f9a bad message
-                       to 96d1c37 create test2.txt
         Confirm? [yN] Aborted.
         "###);
     }
@@ -878,12 +929,10 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
 
         3. Move branch master from 9ed8f9a bad message
                                 to 96d1c37 create test2.txt
-        4. Check out from 9ed8f9a bad message
-                       to 96d1c37 create test2.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         :
         @ 96d1c37 (master) create test2.txt
-        Applied 4 inverse events.
+        Applied 3 inverse events.
         "###);
     }
 


### PR DESCRIPTION
This teaches existing branchless commands to respect branches that are currently checked out in linked worktrees.

Before this, commands which rewrote or revisited refs could accidentally move a branch that was active in another worktree, leaving that other checkout inconsistent with its branch. The change adds a shared linked-worktree check before branch moves, makes undo refuse to replay ref updates for branches active elsewhere, and avoids auto-switching onto branches already checked out in a worktree.

This also updates navigation display to include worktree context when selecting commits, and adds regression coverage for restack and undo behavior around active linked worktrees.

Validated locally with `cargo check -p git-branchless-navigation -p git-branchless-undo -p git-branchless` and `TEST_GIT=$(which git) TEST_GIT_EXEC_PATH=$(git --exec-path) cargo test -p git-branchless --test test_restack --test test_undo`.

Prepared with substantial Codex assistance.
