### PR TITLE
[1/1] tests: upgrade `insta` from 1.47 to 1.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,14 +2099,15 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "similar",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -3923,6 +3924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte 0.14.1",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4492,6 +4502,15 @@ dependencies = [
  "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,5 @@ vt100 = "0.15.2"
 # dev-dependencies
 cc = "1.2.61"
 criterion = { version = "0.8.2", features = ["html_reports"] }
-insta = { version = "1.47.2", features = ["filters"] }
+insta = { version = "1.48.0", features = ["filters"] }
 maplit = "1.0.2"

--- a/git-branchless-hook/tests/test_hook.rs
+++ b/git-branchless-hook/tests/test_hook.rs
@@ -56,13 +56,13 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        @ 96d1c37 create test2.txt
-        "###);
+            insta::assert_snapshot!(stdout, @"
+            O f777ecc (master) create initial.txt
+            |
+            o 62fc20d create test1.txt
+            |
+            @ 96d1c37 create test2.txt
+            ");
         }
     }
 
@@ -93,21 +93,19 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
                 })
                 .collect();
 
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             Executing: exit 1
             warning: execution failed: exit 1
             You can fix the problem, and then run
 
               git rebase --continue
-
-
-            "###);
+            ");
             insta::assert_snapshot!(stdout, @"");
         }
 
         {
             let (stdout, stderr) = git.run(&["rebase", "--continue"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 rewritten commit
             branchless: This operation abandoned 1 commit!
             branchless: Consider running one of the following:
@@ -118,7 +116,7 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
             branchless:   - git undo: undo the operation
             hint: disable this hint by running: git config --global branchless.hint.restackWarnAbandoned false
             Successfully rebased and updated detached HEAD.
-            "###);
+            ");
             insta::assert_snapshot!(stdout, @"");
         }
 
@@ -128,7 +126,7 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc (master) create initial.txt
             |\
             | o 047b7ad create test1.txt
@@ -139,7 +137,7 @@ fn test_rebase_no_process_new_commits_until_conclusion() -> eyre::Result<()> {
             hint: there is 1 abandoned commit in your commit graph
             hint: to fix this, run: git restack
             hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-            "###);
+            ");
         }
     }
 
@@ -166,64 +164,62 @@ fn test_hooks_in_worktree() -> eyre::Result<()> {
     {
         let (stdout, stderr) =
             worktree.run(&["commit", "--allow-empty", "-m", "new empty commit"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: 1bed0d8 new empty commit
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
-        [detached HEAD 1bed0d8] new empty commit
-        "###);
+        ");
+        insta::assert_snapshot!(stdout, @"[detached HEAD 1bed0d8] new empty commit");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
         |
         o 1bed0d8 new empty commit
-        "###);
+        ");
     }
     {
         let stdout = worktree.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ 1bed0d8 new empty commit
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) =
             worktree.run(&["commit", "--amend", "--allow-empty", "--message", "amended"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: cc4313e amended
         branchless: processing 1 rewritten commit
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD cc4313e] amended
          Date: Thu Oct 29 12:34:56 2020 +0000
-        "###);
+        ");
     }
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
         |
         o cc4313e amended
-        "###);
+        ");
     }
     {
         let stdout = worktree.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ cc4313e amended
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless-lib/tests/test_eventlog.rs
+++ b/git-branchless-lib/tests/test_eventlog.rs
@@ -61,7 +61,7 @@ fn test_different_event_transaction_ids() -> eyre::Result<()> {
     let event_tx_ids: Vec<EventTransactionId> =
         events.iter().map(|event| event.get_event_tx_id()).collect();
     if git.supports_reference_transactions()? {
-        insta::assert_debug_snapshot!(event_tx_ids, @r###"
+        insta::assert_debug_snapshot!(event_tx_ids, @"
         [
             Id(
                 1,
@@ -76,9 +76,9 @@ fn test_different_event_transaction_ids() -> eyre::Result<()> {
                 3,
             ),
         ]
-        "###);
+        ");
     } else {
-        insta::assert_debug_snapshot!(event_tx_ids, @r###"
+        insta::assert_debug_snapshot!(event_tx_ids, @"
         [
             Id(
                 1,
@@ -87,7 +87,7 @@ fn test_different_event_transaction_ids() -> eyre::Result<()> {
                 2,
             ),
         ]
-        "###);
+        ");
     }
     Ok(())
 }

--- a/git-branchless-lib/tests/test_git_run.rs
+++ b/git-branchless-lib/tests/test_git_run.rs
@@ -27,18 +27,18 @@ fn test_hook_working_dir() -> eyre::Result<()> {
     {
         // Trigger the `post-rewrite` hook that we wrote above.
         let (stdout, stderr) = git.run(&["commit", "--amend", "-m", "foo"])?;
-        insta::assert_snapshot!(stderr, @r###"
-            branchless: processing 2 updates: branch master, ref HEAD
-            branchless: processed commit: f23bf8f foo
-            Check if test1.txt exists
-            test1.txt exists
-            "###);
-        insta::assert_snapshot!(stdout, @r###"
-                [master f23bf8f] foo
-                 Date: Thu Oct 29 12:34:56 2020 -0100
-                 1 file changed, 1 insertion(+)
-                 create mode 100644 test1.txt
-                "###);
+        insta::assert_snapshot!(stderr, @"
+        branchless: processing 2 updates: branch master, ref HEAD
+        branchless: processed commit: f23bf8f foo
+        Check if test1.txt exists
+        test1.txt exists
+        ");
+        insta::assert_snapshot!(stdout, @"
+        [master f23bf8f] foo
+         Date: Thu Oct 29 12:34:56 2020 -0100
+         1 file changed, 1 insertion(+)
+         create mode 100644 test1.txt
+        ");
     }
 
     Ok(())

--- a/git-branchless-lib/tests/test_git_tree.rs
+++ b/git-branchless-lib/tests/test_git_tree.rs
@@ -22,7 +22,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
     let head_commit = repo.find_commit_or_fail(head_oid)?;
     let head_tree = head_commit.get_tree()?;
 
-    insta::assert_debug_snapshot!(head_tree.get_entries_for_testing(), @r###"
+    insta::assert_debug_snapshot!(head_tree.get_entries_for_testing(), @r#"
     [
         (
             "bar",
@@ -41,7 +41,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
             "7c465afc533f95ff7d2c91e18921f94aac8292fc",
         ),
     ]
-    "###);
+    "#);
 
     {
         let hydrated_tree = {
@@ -62,7 +62,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
             })?;
             repo.find_tree(hydrated_tree_oid)?.unwrap()
         };
-        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r###"
+        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r#"
         [
             (
                 "bar",
@@ -81,7 +81,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
                 "7c465afc533f95ff7d2c91e18921f94aac8292fc",
             ),
         ]
-        "###);
+        "#);
     }
 
     {
@@ -93,7 +93,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
             })?;
             repo.find_tree(hydrated_tree_oid)?.unwrap()
         };
-        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r###"
+        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r#"
         [
             (
                 "bar",
@@ -112,7 +112,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
                 "7c465afc533f95ff7d2c91e18921f94aac8292fc",
             ),
         ]
-        "###);
+        "#);
     }
 
     {
@@ -125,7 +125,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
             })?;
             repo.find_tree(hydrated_tree_oid)?.unwrap()
         };
-        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r###"
+        insta::assert_debug_snapshot!(hydrated_tree.get_entries_for_testing(), @r#"
         [
             (
                 "foo.txt",
@@ -140,7 +140,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
                 "7c465afc533f95ff7d2c91e18921f94aac8292fc",
             ),
         ]
-        "###);
+        "#);
     }
 
     {
@@ -150,7 +150,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
             &[Path::new("bar/baz.txt"), Path::new("foo.txt")],
         )?;
         let dehydrated_tree = repo.find_tree(dehydrated_tree_oid)?.unwrap();
-        insta::assert_debug_snapshot!(dehydrated_tree.get_entries_for_testing(), @r###"
+        insta::assert_debug_snapshot!(dehydrated_tree.get_entries_for_testing(), @r#"
         [
             (
                 "bar",
@@ -161,7 +161,7 @@ fn test_hydrate_tree() -> eyre::Result<()> {
                 "19102815663d23f8b75a47e7a01965dcdc96468c",
             ),
         ]
-        "###);
+        "#);
     }
 
     Ok(())
@@ -184,11 +184,11 @@ fn test_detect_path_only_changed_file_mode() -> eyre::Result<()> {
     let rhs_tree = commit.get_tree()?;
     let changed_paths = get_changed_paths_between_trees(&repo, Some(&lhs_tree), Some(&rhs_tree))?;
 
-    insta::assert_debug_snapshot!(changed_paths, @r###"
-        {
-            "initial.txt",
-        }
-        "###);
+    insta::assert_debug_snapshot!(changed_paths, @r#"
+    {
+        "initial.txt",
+    }
+    "#);
 
     Ok(())
 }

--- a/git-branchless-lib/tests/test_repo.rs
+++ b/git-branchless-lib/tests/test_repo.rs
@@ -60,20 +60,20 @@ fn test_cherry_pick_fast() -> eyre::Result<()> {
         },
     )?;
 
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 367f91ddd5df2d1c18742ce3f09b4944944cac3a,
-            },
-        }
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 367f91ddd5df2d1c18742ce3f09b4944944cac3a,
+        },
+    }
+    ");
 
-    insta::assert_debug_snapshot!(tree.get_entry_paths_for_testing(), @r###"
-        [
-            "initial.txt",
-            "test1.txt",
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree.get_entry_paths_for_testing(), @r#"
+    [
+        "initial.txt",
+        "test1.txt",
+    ]
+    "#);
 
     Ok(())
 }
@@ -91,21 +91,21 @@ fn test_amend_fast_from_index() -> eyre::Result<()> {
     let initial_commit = repo.find_commit_or_fail(initial_oid)?;
 
     let tree = initial_commit.get_tree()?;
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 01deb7745d411223bbf6b9cb1abaeed451bb25a0,
-            },
-        }
-        "###);
-    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r###"
-        [
-            (
-                "initial.txt",
-                "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
-            ),
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 01deb7745d411223bbf6b9cb1abaeed451bb25a0,
+        },
+    }
+    ");
+    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r#"
+    [
+        (
+            "initial.txt",
+            "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
+        ),
+    ]
+    "#);
 
     let tree = repo.amend_fast(
         &initial_commit,
@@ -114,21 +114,21 @@ fn test_amend_fast_from_index() -> eyre::Result<()> {
         },
     )?;
 
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 01deb7745d411223bbf6b9cb1abaeed451bb25a0,
-            },
-        }
-        "###);
-    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r###"
-        [
-            (
-                "initial.txt",
-                "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
-            ),
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 01deb7745d411223bbf6b9cb1abaeed451bb25a0,
+        },
+    }
+    ");
+    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r#"
+    [
+        (
+            "initial.txt",
+            "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
+        ),
+    ]
+    "#);
 
     git.run(&["add", "initial.txt"])?;
     let tree = repo.amend_fast(
@@ -138,21 +138,21 @@ fn test_amend_fast_from_index() -> eyre::Result<()> {
         },
     )?;
 
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 1c15b79a72c3285df172fcfdaceedb7259283eb5,
-            },
-        }
-        "###);
-    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r###"
-        [
-            (
-                "initial.txt",
-                "53cd9398c8a2d92f18d279c6cad3f5dde67235e7",
-            ),
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 1c15b79a72c3285df172fcfdaceedb7259283eb5,
+        },
+    }
+    ");
+    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r#"
+    [
+        (
+            "initial.txt",
+            "53cd9398c8a2d92f18d279c6cad3f5dde67235e7",
+        ),
+    ]
+    "#);
 
     Ok(())
 }
@@ -181,21 +181,21 @@ fn test_amend_fast_from_working_tree() -> eyre::Result<()> {
         },
     )?;
 
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 1c15b79a72c3285df172fcfdaceedb7259283eb5,
-            },
-        }
-        "###);
-    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r###"
-        [
-            (
-                "initial.txt",
-                "53cd9398c8a2d92f18d279c6cad3f5dde67235e7",
-            ),
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 1c15b79a72c3285df172fcfdaceedb7259283eb5,
+        },
+    }
+    ");
+    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r#"
+    [
+        (
+            "initial.txt",
+            "53cd9398c8a2d92f18d279c6cad3f5dde67235e7",
+        ),
+    ]
+    "#);
 
     git.write_file_txt("file2", "another file")?;
     git.write_file_txt("initial", "updated contents again")?;
@@ -211,25 +211,25 @@ fn test_amend_fast_from_working_tree() -> eyre::Result<()> {
             }],
         },
     )?;
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 1a9fbbecd825881c3e79f0fb194a1c1e1104fe0f,
-            },
-        }
-        "###);
-    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r###"
-        [
-            (
-                "file2.txt",
-                "cdcb28483da7783a8b505a074c50632a5481a69b",
-            ),
-            (
-                "initial.txt",
-                "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
-            ),
-        ]
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 1a9fbbecd825881c3e79f0fb194a1c1e1104fe0f,
+        },
+    }
+    ");
+    insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @r#"
+    [
+        (
+            "file2.txt",
+            "cdcb28483da7783a8b505a074c50632a5481a69b",
+        ),
+        (
+            "initial.txt",
+            "5c41c3d7e736911dbbd53d62c10292b9bc78f838",
+        ),
+    ]
+    "#);
 
     git.delete_file("initial")?;
     let tree = repo.amend_fast(
@@ -244,13 +244,13 @@ fn test_amend_fast_from_working_tree() -> eyre::Result<()> {
             }],
         },
     )?;
-    insta::assert_debug_snapshot!(tree, @r###"
-        Tree {
-            inner: Tree {
-                id: 4b825dc642cb6eb9a060e54bf8d69288fbee4904,
-            },
-        }
-        "###);
+    insta::assert_debug_snapshot!(tree, @"
+    Tree {
+        inner: Tree {
+            id: 4b825dc642cb6eb9a060e54bf8d69288fbee4904,
+        },
+    }
+    ");
     insta::assert_debug_snapshot!(tree.get_entries_for_testing(), @"[]");
 
     Ok(())
@@ -263,7 +263,7 @@ fn test_branch_debug() -> eyre::Result<()> {
 
     let repo = git.get_repo()?;
     let branch = repo.find_branch("master", BranchType::Local)?.unwrap();
-    insta::assert_debug_snapshot!(branch, @r###"<Branch name="master">"###);
+    insta::assert_debug_snapshot!(branch, @r#"<Branch name="master">"#);
 
     Ok(())
 }
@@ -283,10 +283,10 @@ fn test_worktree_working_copy_path() -> eyre::Result<()> {
             .and_then(|name| name.to_str())
             .unwrap();
         let stdout = stdout.replace(repo_name, "<repo-name>");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     fn canonicalize(path: Option<PathBuf>) -> PathBuf {

--- a/git-branchless-lib/tests/test_rewrite_plan.rs
+++ b/git-branchless-lib/tests/test_rewrite_plan.rs
@@ -79,17 +79,17 @@ fn test_plan_moving_subtree_again_overrides_previous_move() -> eyre::Result<()> 
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |\
-        | @ 8556cef create test4.txt
-        |
-        o 70deb1e create test3.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |\
+    | @ 8556cef create test4.txt
+    |
+    o 70deb1e create test3.txt
+    ");
 
     Ok(())
 }
@@ -111,17 +111,17 @@ fn test_plan_moving_subtree_within_moved_subtree() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | @ 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | @ 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    ");
 
     Ok(())
 }
@@ -143,17 +143,17 @@ fn test_plan_moving_subtree_within_moved_subtree_in_other_order() -> eyre::Resul
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | @ 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | @ 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    ");
 
     Ok(())
 }
@@ -175,17 +175,17 @@ fn test_plan_moving_commit_again_overrides_previous_move() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |\
-        | @ 8556cef create test4.txt
-        |
-        o 70deb1e create test3.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |\
+    | @ 8556cef create test4.txt
+    |
+    o 70deb1e create test3.txt
+    ");
 
     Ok(())
 }
@@ -211,21 +211,21 @@ fn test_plan_moving_nonconsecutive_commits() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 4ec3989 create test5.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        o 8556cef create test4.txt
-        |
-        @ 0a34830 create test6.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 4ec3989 create test5.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 8556cef create test4.txt
+    |
+    @ 0a34830 create test6.txt
+    ");
 
     Ok(())
 }
@@ -248,19 +248,19 @@ fn test_plan_moving_consecutive_commits() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ f26f28e create test5.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    @ f26f28e create test5.txt
+    ");
 
     Ok(())
 }
@@ -283,19 +283,19 @@ fn test_plan_moving_consecutive_commits_in_other_order() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ f26f28e create test5.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    @ f26f28e create test5.txt
+    ");
 
     Ok(())
 }
@@ -314,19 +314,19 @@ fn test_plan_moving_commit_and_one_child_leaves_other_child() -> eyre::Result<()
     git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        o 70deb1e create test3.txt
-        |\
-        | o 355e173 create test4.txt
-        |
-        @ 9ea1b36 create test5.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 70deb1e create test3.txt
+    |\
+    | o 355e173 create test4.txt
+    |
+    @ 9ea1b36 create test5.txt
+    ");
 
     create_and_execute_plan(&git, move |builder: &mut RebasePlanBuilder| {
         builder.move_commit(test3_oid, test1_oid)?;
@@ -335,19 +335,19 @@ fn test_plan_moving_commit_and_one_child_leaves_other_child() -> eyre::Result<()
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ f26f28e create test5.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    @ f26f28e create test5.txt
+    ");
 
     Ok(())
 }
@@ -370,19 +370,19 @@ fn test_plan_moving_commit_add_then_giving_it_a_child() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o ad2c2fc create test3.txt
-        | |
-        | @ ee4aebf create test5.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        o 8556cef create test4.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o ad2c2fc create test3.txt
+    | |
+    | @ ee4aebf create test5.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    o 8556cef create test4.txt
+    ");
 
     Ok(())
 }
@@ -406,21 +406,21 @@ fn test_plan_moving_range_again_overrides_previous_move() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |\
-        | o 8556cef create test4.txt
-        | |
-        | o 566236a create test5.txt
-        |
-        o 70deb1e create test3.txt
-        |
-        @ 35928ae create test6.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |\
+    | o 8556cef create test4.txt
+    | |
+    | o 566236a create test5.txt
+    |
+    o 70deb1e create test3.txt
+    |
+    @ 35928ae create test6.txt
+    ");
 
     Ok(())
 }
@@ -451,21 +451,21 @@ fn test_plan_moving_range_and_then_partial_beginning_range_again() -> eyre::Resu
     //
     // NOTE See also the next test for the other case: where the end of the
     // range is moved again. That *does* feel correct.
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o ad2c2fc create test3.txt
-        | |
-        | o 2b45b52 create test4.txt
-        |
-        o 96d1c37 create test2.txt
-        |\
-        | @ 99a62a3 create test6.txt
-        |
-        o f26f28e create test5.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o ad2c2fc create test3.txt
+    | |
+    | o 2b45b52 create test4.txt
+    |
+    o 96d1c37 create test2.txt
+    |\
+    | @ 99a62a3 create test6.txt
+    |
+    o f26f28e create test5.txt
+    ");
 
     Ok(())
 }
@@ -489,21 +489,21 @@ fn test_plan_moving_range_and_then_partial_ending_range_again() -> eyre::Result<
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        | |
-        | o 3d57d30 create test5.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ 99a62a3 create test6.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    | |
+    | o 3d57d30 create test5.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    @ 99a62a3 create test6.txt
+    ");
 
     Ok(())
 }
@@ -526,19 +526,19 @@ fn test_plan_moving_subtree_and_commit_within_subtree() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        |\
-        | o ad2c2fc create test3.txt
-        | |
-        | @ ee4aebf create test5.txt
-        |
-        o 96d1c37 create test2.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    |\
+    | o ad2c2fc create test3.txt
+    | |
+    | @ ee4aebf create test5.txt
+    |
+    o 96d1c37 create test2.txt
+    ");
 
     Ok(())
 }
@@ -561,19 +561,19 @@ fn test_plan_moving_subtree_and_then_its_parent_commit() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |\
-        | o 8e71a64 create test4.txt
-        | |
-        | @ 3d57d30 create test5.txt
-        |\
-        | o ad2c2fc create test3.txt
-        |
-        o 96d1c37 create test2.txt
-        "###);
+    insta::assert_snapshot!(stdout, @r"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |\
+    | o 8e71a64 create test4.txt
+    | |
+    | @ 3d57d30 create test5.txt
+    |\
+    | o ad2c2fc create test3.txt
+    |
+    o 96d1c37 create test2.txt
+    ");
 
     Ok(())
 }
@@ -596,19 +596,19 @@ fn test_plan_moving_subtree_to_descendant_of_itself() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ f26f28e create test5.txt
-        |
-        o 2b42d9c create test3.txt
-        |
-        o c533a65 create test4.txt
-        "###);
+    insta::assert_snapshot!(stdout, @"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    o 96d1c37 create test2.txt
+    |
+    @ f26f28e create test5.txt
+    |
+    o 2b42d9c create test3.txt
+    |
+    o c533a65 create test4.txt
+    ");
 
     Ok(())
 }
@@ -633,7 +633,7 @@ fn test_plan_moving_subtree_with_merge_commit() -> eyre::Result<()> {
     })?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
@@ -650,7 +650,7 @@ fn test_plan_moving_subtree_with_merge_commit() -> eyre::Result<()> {
     | & (merge) 355e173 create test4.txt
     |/
     o 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-    "###);
+    ");
 
     Ok(())
 }
@@ -670,13 +670,13 @@ fn test_plan_fixup_child_into_parent() -> eyre::Result<()> {
     })?;
 
     let (stdout, _stderr) = git.run(&["smartlog"])?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        @ 64da0f2 create test2.txt
-        "###);
+    insta::assert_snapshot!(stdout, @"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    @ 64da0f2 create test2.txt
+    ");
 
     Ok(())
 }
@@ -696,13 +696,13 @@ fn test_plan_fixup_parent_into_child() -> eyre::Result<()> {
     })?;
 
     let (stdout, _stderr) = git.run(&["smartlog"])?;
-    insta::assert_snapshot!(stdout, @r###"
-        O f777ecc (master) create initial.txt
-        |
-        o 62fc20d create test1.txt
-        |
-        @ 1f599a2 create test3.txt
-        "###);
+    insta::assert_snapshot!(stdout, @"
+    O f777ecc (master) create initial.txt
+    |
+    o 62fc20d create test1.txt
+    |
+    @ 1f599a2 create test3.txt
+    ");
 
     Ok(())
 }

--- a/git-branchless-lib/tests/test_snapshot.rs
+++ b/git-branchless-lib/tests/test_snapshot.rs
@@ -40,17 +40,17 @@ fn test_has_conflicts() -> eyre::Result<()> {
         &head_info,
         Some(event_tx_id),
     )?;
-    insta::assert_debug_snapshot!(status, @r###"
-        [
-            StatusEntry {
-                index_status: Unmerged,
-                working_copy_status: Added,
-                working_copy_file_mode: Blob,
-                path: "test2.txt",
-                orig_path: None,
-            },
-        ]
-        "###);
+    insta::assert_debug_snapshot!(status, @r#"
+    [
+        StatusEntry {
+            index_status: Unmerged,
+            working_copy_status: Added,
+            working_copy_file_mode: Blob,
+            path: "test2.txt",
+            orig_path: None,
+        },
+    ]
+    "#);
     assert_eq!(
         snapshot.get_working_copy_changes_type()?,
         WorkingCopyChangesType::Conflicts

--- a/git-branchless-lib/tests/test_status.rs
+++ b/git-branchless-lib/tests/test_status.rs
@@ -128,59 +128,59 @@ fn test_get_status() -> eyre::Result<()> {
         WorkingCopyChangesType::None
     );
     assert_eq!(status, vec![]);
-    insta::assert_debug_snapshot!(snapshot, @r###"
-        WorkingCopySnapshot {
-            base_commit: Commit {
+    insta::assert_debug_snapshot!(snapshot, @r#"
+    WorkingCopySnapshot {
+        base_commit: Commit {
+            inner: Commit {
+                id: ad8334119626cc9aee5322f9ed35273de834ea36,
+                summary: "branchless: automated working copy snapshot",
+            },
+        },
+        head_commit: Some(
+            Commit {
                 inner: Commit {
-                    id: ad8334119626cc9aee5322f9ed35273de834ea36,
-                    summary: "branchless: automated working copy snapshot",
+                    id: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                    summary: "create test1.txt",
                 },
             },
-            head_commit: Some(
-                Commit {
-                    inner: Commit {
-                        id: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                        summary: "create test1.txt",
-                    },
-                },
+        ),
+        head_reference_name: Some(
+            ReferenceName(
+                "refs/heads/master",
             ),
-            head_reference_name: Some(
-                ReferenceName(
-                    "refs/heads/master",
-                ),
-            ),
-            commit_unstaged: Commit {
-                inner: Commit {
-                    id: cd8605eef8b78e22427fa3846f1a23f95e88aa7e,
-                    summary: "branchless: working copy snapshot data: 0 unstaged changes",
-                },
+        ),
+        commit_unstaged: Commit {
+            inner: Commit {
+                id: cd8605eef8b78e22427fa3846f1a23f95e88aa7e,
+                summary: "branchless: working copy snapshot data: 0 unstaged changes",
             },
-            commit_stage0: Commit {
-                inner: Commit {
-                    id: a4edb48b44f5b19d0c2c25fd65251d0bfaba68c1,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 0",
-                },
+        },
+        commit_stage0: Commit {
+            inner: Commit {
+                id: a4edb48b44f5b19d0c2c25fd65251d0bfaba68c1,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 0",
             },
-            commit_stage1: Commit {
-                inner: Commit {
-                    id: e1e0c856237e53e2c889a723ee7ec50a21c1f952,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 1",
-                },
+        },
+        commit_stage1: Commit {
+            inner: Commit {
+                id: e1e0c856237e53e2c889a723ee7ec50a21c1f952,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 1",
             },
-            commit_stage2: Commit {
-                inner: Commit {
-                    id: e5dda473c3266aafa14b827b1a009e35a3c61679,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 2",
-                },
+        },
+        commit_stage2: Commit {
+            inner: Commit {
+                id: e5dda473c3266aafa14b827b1a009e35a3c61679,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 2",
             },
-            commit_stage3: Commit {
-                inner: Commit {
-                    id: 19b98ca24cc7b241122593fc1a9307e24e26a846,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 3",
-                },
+        },
+        commit_stage3: Commit {
+            inner: Commit {
+                id: 19b98ca24cc7b241122593fc1a9307e24e26a846,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 3",
             },
-        }
-        "###);
+        },
+    }
+    "#);
 
     git.write_file_txt("new_file", "another file")?;
     git.run(&["add", "new_file.txt"])?;
@@ -225,59 +225,59 @@ fn test_get_status() -> eyre::Result<()> {
             }
         ]
     );
-    insta::assert_debug_snapshot!(snapshot, @r###"
-        WorkingCopySnapshot {
-            base_commit: Commit {
+    insta::assert_debug_snapshot!(snapshot, @r#"
+    WorkingCopySnapshot {
+        base_commit: Commit {
+            inner: Commit {
+                id: 2f8be3a55bd58854a5871d7260abc37ab5d1199c,
+                summary: "branchless: automated working copy snapshot",
+            },
+        },
+        head_commit: Some(
+            Commit {
                 inner: Commit {
-                    id: 2f8be3a55bd58854a5871d7260abc37ab5d1199c,
-                    summary: "branchless: automated working copy snapshot",
+                    id: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
+                    summary: "create test1.txt",
                 },
             },
-            head_commit: Some(
-                Commit {
-                    inner: Commit {
-                        id: 62fc20d2a290daea0d52bdc2ed2ad4be6491010e,
-                        summary: "create test1.txt",
-                    },
-                },
+        ),
+        head_reference_name: Some(
+            ReferenceName(
+                "refs/heads/master",
             ),
-            head_reference_name: Some(
-                ReferenceName(
-                    "refs/heads/master",
-                ),
-            ),
-            commit_unstaged: Commit {
-                inner: Commit {
-                    id: 329d438eaf36089efa9a49a3942a10985c037dce,
-                    summary: "branchless: working copy snapshot data: 4 unstaged changes",
-                },
+        ),
+        commit_unstaged: Commit {
+            inner: Commit {
+                id: 329d438eaf36089efa9a49a3942a10985c037dce,
+                summary: "branchless: working copy snapshot data: 4 unstaged changes",
             },
-            commit_stage0: Commit {
-                inner: Commit {
-                    id: ccfd588cf59116f67664ac718c404b09fc9e35d2,
-                    summary: "branchless: working copy snapshot data: 3 changes in stage 0",
-                },
+        },
+        commit_stage0: Commit {
+            inner: Commit {
+                id: ccfd588cf59116f67664ac718c404b09fc9e35d2,
+                summary: "branchless: working copy snapshot data: 3 changes in stage 0",
             },
-            commit_stage1: Commit {
-                inner: Commit {
-                    id: e1e0c856237e53e2c889a723ee7ec50a21c1f952,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 1",
-                },
+        },
+        commit_stage1: Commit {
+            inner: Commit {
+                id: e1e0c856237e53e2c889a723ee7ec50a21c1f952,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 1",
             },
-            commit_stage2: Commit {
-                inner: Commit {
-                    id: e5dda473c3266aafa14b827b1a009e35a3c61679,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 2",
-                },
+        },
+        commit_stage2: Commit {
+            inner: Commit {
+                id: e5dda473c3266aafa14b827b1a009e35a3c61679,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 2",
             },
-            commit_stage3: Commit {
-                inner: Commit {
-                    id: 19b98ca24cc7b241122593fc1a9307e24e26a846,
-                    summary: "branchless: working copy snapshot data: 0 changes in stage 3",
-                },
+        },
+        commit_stage3: Commit {
+            inner: Commit {
+                id: 19b98ca24cc7b241122593fc1a9307e24e26a846,
+                summary: "branchless: working copy snapshot data: 0 changes in stage 3",
             },
-        }
-        "###);
+        },
+    }
+    "#);
 
     Ok(())
 }
@@ -356,17 +356,17 @@ fn test_get_status_with_dirty_submodule() -> eyre::Result<()> {
     )?;
 
     // Should contain a single entry for the modified submodule.
-    insta::assert_debug_snapshot!(status, @r###"
-        [
-            StatusEntry {
-                index_status: Unmodified,
-                working_copy_status: Modified,
-                working_copy_file_mode: Commit,
-                path: "sm",
-                orig_path: None,
-            },
-        ]
-    "###);
+    insta::assert_debug_snapshot!(status, @r#"
+    [
+        StatusEntry {
+            index_status: Unmodified,
+            working_copy_status: Modified,
+            working_copy_file_mode: Commit,
+            path: "sm",
+            orig_path: None,
+        },
+    ]
+    "#);
 
     Ok(())
 }
@@ -401,24 +401,24 @@ fn test_get_status_with_directory_symlink_trailing_slash() -> eyre::Result<()> {
 
     // Should contain new (added) entries for 2 files: dir/file.txt (blob) and
     // dir_symlink (link)
-    insta::assert_debug_snapshot!(status, @r###"
-        [
-            StatusEntry {
-                index_status: Added,
-                working_copy_status: Unmodified,
-                working_copy_file_mode: Blob,
-                path: "dir/file.txt",
-                orig_path: None,
-            },
-            StatusEntry {
-                index_status: Added,
-                working_copy_status: Unmodified,
-                working_copy_file_mode: Link,
-                path: "dir_symlink",
-                orig_path: None,
-            },
-        ]
-    "###);
+    insta::assert_debug_snapshot!(status, @r#"
+    [
+        StatusEntry {
+            index_status: Added,
+            working_copy_status: Unmodified,
+            working_copy_file_mode: Blob,
+            path: "dir/file.txt",
+            orig_path: None,
+        },
+        StatusEntry {
+            index_status: Added,
+            working_copy_status: Unmodified,
+            working_copy_file_mode: Link,
+            path: "dir_symlink",
+            orig_path: None,
+        },
+    ]
+    "#);
 
     Ok(())
 }

--- a/git-branchless-query/tests/test_query.rs
+++ b/git-branchless-query/tests/test_query.rs
@@ -12,19 +12,19 @@ fn test_query() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("query", &[".^::"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         96d1c37 create test2.txt
         70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("query", &[".^::", "--raw"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         96d1c37a3d4363611c49f7e52186e189a04c531f
         70deb1e28791d8e7dd5a1f0c871a51b91282562f
-        "###);
+        ");
     }
 
     Ok(())
@@ -44,10 +44,10 @@ fn test_query_parse_error() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r#"
         Parse error for expression 'foo(': parse error: Unrecognized EOF found at 4
         Expected one of a commit/branch/tag, a string literal, "(", ")", "..", ":" or "::"
-        "###);
+        "#);
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -72,8 +72,7 @@ fn test_query_eval_error() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'foo': no commit, branch, or reference with the name 'foo' could be found
-");
+        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'foo': no commit, branch, or reference with the name 'foo' could be found");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -86,9 +85,7 @@ fn test_query_eval_error() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
-        Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, current, descendants, difference, draft, exactly, heads, intersection, main, merges, message, none, not, only, parents, parents.nth, paths.changed, public, range, roots, siblings, stack, tests.failed, tests.fixable, tests.passed, union
-        "###);
+        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'foo()': no function with the name 'foo' could be found; these functions are available: all, ancestors, ancestors.nth, author.date, author.email, author.name, branches, children, committer.date, committer.email, committer.name, current, descendants, difference, draft, exactly, heads, intersection, main, merges, message, none, not, only, parents, parents.nth, paths.changed, public, range, roots, siblings, stack, tests.failed, tests.fixable, tests.passed, union");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -107,9 +104,7 @@ fn test_query_legacy_git_syntax() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("query", &["HEAD~2"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        62fc20d create test1.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"62fc20d create test1.txt");
     }
 
     {
@@ -121,8 +116,7 @@ fn test_query_legacy_git_syntax() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'foo-@': no commit, branch, or reference with the name 'foo-@' could be found
-");
+        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'foo-@': no commit, branch, or reference with the name 'foo-@' could be found");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -141,8 +135,7 @@ fn test_query_branches() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("query", &["-b", "."])?;
-        insta::assert_snapshot!(stdout, @"master
-");
+        insta::assert_snapshot!(stdout, @"master");
     }
 
     {
@@ -159,18 +152,18 @@ fn test_query_branches() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("query", &["-b", "::."])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         foo
         master
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("query", &["branches()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         62fc20d create test1.txt
         70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -191,19 +184,17 @@ fn test_query_hidden_commits() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("query", &[&format!("{test2_oid}::")])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         96d1c37 create test2.txt
         70deb1e create test3.txt
-        "###);
+        ");
     }
 
     git.run(&["checkout", "-B", "master"])?;
     {
         let (stdout, stderr) = git.branchless("query", &[&format!("{test2_oid}::")])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        96d1c37 create test2.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"96d1c37 create test2.txt");
     }
 
     Ok(())

--- a/git-branchless-record/tests/test_record.rs
+++ b/git-branchless-record/tests/test_record.rs
@@ -14,15 +14,15 @@ fn test_record_unstaged_changes() -> eyre::Result<()> {
     git.write_file_txt("test1", "contents1\n")?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "-m", "bar"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master 872eae1] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 872eae10daf1e94d0c346540f6d655027c60e7ae
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -38,7 +38,7 @@ fn test_record_unstaged_changes() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +contents1
-        "###);
+        ");
     }
 
     Ok(())
@@ -73,7 +73,7 @@ fn test_record_unstaged_changes_interactive() -> eyre::Result<()> {
     {
         // The above should not have committed anything.
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0100
@@ -87,7 +87,7 @@ fn test_record_unstaged_changes_interactive() -> eyre::Result<()> {
         +++ b/test1.txt
         @@ -0,0 +1 @@
         +test1 contents
-        "###);
+        ");
     }
 
     {
@@ -107,7 +107,7 @@ fn test_record_unstaged_changes_interactive() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 914812ae3220add483f11d851dc59f0b5dbdeaa0
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -121,7 +121,7 @@ fn test_record_unstaged_changes_interactive() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +contents1
-        "###);
+        ");
     }
 
     Ok(())
@@ -143,15 +143,15 @@ fn test_record_staged_changes() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master b437fb4] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit b437fb44ab49995a1b59877960830841ff7a7a23
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -165,7 +165,7 @@ fn test_record_staged_changes() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +new test1 contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -192,8 +192,8 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -203,15 +203,15 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test2", "test2 new")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master 36be832] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test1.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -221,18 +221,18 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         // test2 should still be considered "new" because last run was disabled
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Including 1 new untracked file: test2.txt
         [master 765c01b] foo
          2 files changed, 2 insertions(+), 1 deletion(-)
          create mode 100644 test2.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 +-
-            test2.txt | 1 +
-            2 files changed, 2 insertions(+), 1 deletion(-)
+        test1.txt | 2 +-
+        test2.txt | 1 +
+        2 files changed, 2 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -242,19 +242,19 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test3", "test3 new")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--untracked", "skip"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 new untracked file: test3.txt
         hint: this file will remain skipped and will not be automatically reconsidered
         hint: to add it yourself: git add
         hint: disable this hint by running: git config --global branchless.hint.addSkippedFiles false
         [master 371fc94] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test2.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -273,9 +273,9 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 2 +-
-            test4.txt | 1 +
-            2 files changed, 2 insertions(+), 1 deletion(-)
+        test2.txt | 2 +-
+        test4.txt | 1 +
+        2 files changed, 2 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -286,18 +286,18 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test5", "test5 new")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 previously skipped file: test3.txt
         Including 1 new untracked file: test5.txt
         [master af69c1a] foo
          1 file changed, 1 insertion(+)
          create mode 100644 test5.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test5.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test5.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -308,15 +308,15 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.run(&["add", "test5.txt"])?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master cbc1ddc] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test5.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test5.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -325,15 +325,15 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test1", "test1 updated 7")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master c3b6590] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test1.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -344,20 +344,20 @@ fn test_record_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test1", "test1 updated 8")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 previously skipped file: test3.txt
         Including 1 new untracked file: test6.txt
         [master be357c9] foo
          2 files changed, 2 insertions(+), 1 deletion(-)
          create mode 100644 test6.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(&stdout, @r###"
+        insta::assert_snapshot!(&stdout, @"
         test1.txt | 2 +-
         test6.txt | 1 +
         2 files changed, 2 insertions(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     Ok(())
@@ -377,8 +377,8 @@ fn test_record_with_new_untracked_files_prompt() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -395,8 +395,8 @@ fn test_record_with_new_untracked_files_prompt() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -414,8 +414,8 @@ fn test_record_with_new_untracked_files_prompt() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 3 ++-
-            1 file changed, 2 insertions(+), 1 deletion(-)
+        test2.txt | 3 ++-
+        1 file changed, 2 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -442,11 +442,11 @@ fn test_record_with_new_untracked_files_prompt() -> eyre::Result<()> {
         )?;
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(&stdout, @r###"
+        insta::assert_snapshot!(&stdout, @"
         test2.txt | 3 +--
         test4.txt | 1 +
         2 files changed, 2 insertions(+), 2 deletions(-)
-        "###);
+        ");
     }
 
     Ok(())
@@ -475,15 +475,15 @@ fn test_record_staged_changes_interactive() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Cannot select changes interactively while there are already staged changes.
         Either commit or unstage your changes and try again. Aborting.
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 96d1c37a3d4363611c49f7e52186e189a04c531f
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0200
@@ -497,7 +497,7 @@ fn test_record_staged_changes_interactive() -> eyre::Result<()> {
         +++ b/test2.txt
         @@ -0,0 +1 @@
         +test2 contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -520,43 +520,43 @@ fn test_record_detach() -> eyre::Result<()> {
     git.run(&["add", "test1.txt"])?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--detach"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master (root-commit) d41ddf7] foo
          1 file changed, 1 insertion(+)
          create mode 100644 test1.txt
         branchless: running command: <git-executable> update-ref -d refs/heads/master d41ddf7dd8a526054ce1ebbc739f613824cecfef
-        "###);
+        ");
     }
 
     git.commit_file("test1", 1)?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         o d41ddf7 foo
 
         @ 6118a39 (> master) create test1.txt
-        "###);
+        ");
     }
 
     git.write_file_txt("test1", "new test1 contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--detach"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master 2e9aec4] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> branch -f master 6118a39b4dd4c986d17da2123d907ac17696cb85
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         o d41ddf7 foo
 
         O 6118a39 (master) create test1.txt
         |
         @ 2e9aec4 foo
-        "###);
+        ");
     }
 
     Ok(())
@@ -575,41 +575,41 @@ fn test_record_stash() -> eyre::Result<()> {
     git.run(&["add", "test1.txt"])?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--stash"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master 4fe46bd] foo
          1 file changed, 1 insertion(+)
          create mode 100644 test1.txt
         branchless: running command: <git-executable> branch -f master f777ecc9b0db5ed372b2615695191a8a17f79f24
         branchless: running command: <git-executable> checkout master --
-        "###);
+        ");
     }
 
     git.commit_file("test1", 1)?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o 4fe46bd foo
         |
         @ 62fc20d (> master) create test1.txt
-        "###);
+        ");
     }
 
     git.write_file_txt("test1", "new test1 contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--stash"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master 9b6164c] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> branch -f master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
         branchless: running command: <git-executable> checkout master --
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o 4fe46bd foo
@@ -617,7 +617,7 @@ fn test_record_stash() -> eyre::Result<()> {
         @ 62fc20d (> master) create test1.txt
         |
         o 9b6164c foo
-        "###);
+        ");
     }
 
     Ok(())
@@ -638,33 +638,33 @@ fn test_record_stash_detached_head() -> eyre::Result<()> {
         git.commit_file("test1", 1)?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     {
         git.write_file_txt("test1", "new test1 contents\n")?;
 
         let (stdout, _stderr) = git.branchless("record", &["-m", "foo", "--stash"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD 9b6164c] foo
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
         |
         o 9b6164c foo
-        "###);
+        ");
     }
 
     Ok(())
@@ -685,22 +685,22 @@ fn test_record_stash_default_message() -> eyre::Result<()> {
         git.write_file_txt("test1", "new test1 contents\n")?;
 
         let (stdout, _stderr) = git.branchless("record", &["--stash"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [master fd2ffa4] stash: test1.txt (+1/-1)
          1 file changed, 1 insertion(+), 1 deletion(-)
         branchless: running command: <git-executable> branch -f master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
         branchless: running command: <git-executable> checkout master --
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (> master) create test1.txt
         |
         o fd2ffa4 stash: test1.txt (+1/-1)
-        "###);
+        ");
     }
 
     Ok(())
@@ -715,22 +715,22 @@ fn test_record_create_branch() -> eyre::Result<()> {
     git.write_file_txt("test1", "new contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("record", &["-c", "foo", "-m", "Update"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout master -b foo --
         M	test1.txt
         [foo 836023f] Update
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ 836023f (> foo) Update
-        "###);
+        ");
     }
 
     Ok(())
@@ -750,7 +750,7 @@ fn test_record_insert() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("record", &["-m", "update test1.txt", "--insert"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD c17ec22] update test1.txt
          1 file changed, 1 insertion(+), 1 deletion(-)
         Attempting rebase in-memory...
@@ -758,12 +758,12 @@ fn test_record_insert() -> eyre::Result<()> {
         branchless: processing 1 update: branch foo
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -771,7 +771,7 @@ fn test_record_insert() -> eyre::Result<()> {
         @ c17ec22 update test1.txt
         |
         o 734e7f6 (foo) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -790,26 +790,26 @@ fn test_record_insert_rewrite_public_commit() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("record", &["-m", "update test1.txt", "--insert"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD c17ec22] update test1.txt
          1 file changed, 1 insertion(+), 1 deletion(-)
         You are trying to rewrite 1 public commit, such as: 96d1c37 create test2.txt
         It is generally not advised to rewrite public commits, because your
         collaborators will have difficulty merging your changes.
         To proceed anyways, run: git move -f -s 'siblings(.)
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
         | @ c17ec22 update test1.txt
         |
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -829,19 +829,19 @@ fn test_record_insert_merge_conflict() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("record", &["-m", "update test1.txt", "--insert"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD c36bf7c] update test1.txt
          1 file changed, 1 insertion(+), 1 deletion(-)
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
         - (1 conflicting file) ae32734 create test1.txt
         To resolve merge conflicts, run: git move -m -s 'siblings(.)'
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -849,7 +849,7 @@ fn test_record_insert_merge_conflict() -> eyre::Result<()> {
         | @ c36bf7c update test1.txt
         |
         o ae32734 (foo) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -870,7 +870,7 @@ fn test_record_insert_obsolete_siblings() -> eyre::Result<()> {
     git.run(&["add", "."])?;
     {
         let (stdout, _stderr) = git.run(&["record", "-I", "-m", "new commit"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD 1b3a1aa] new commit
          1 file changed, 1 insertion(+)
          create mode 100644 test3.txt
@@ -878,12 +878,12 @@ fn test_record_insert_obsolete_siblings() -> eyre::Result<()> {
         [1/1] Committed as: 9253fc4 updated message
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -891,7 +891,7 @@ fn test_record_insert_obsolete_siblings() -> eyre::Result<()> {
         @ 1b3a1aa new commit
         |
         o 9253fc4 updated message
-        "###);
+        ");
     }
 
     Ok(())
@@ -909,7 +909,7 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
     git.branchless("record", &["-m", "update file mode"])?;
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit a0568bf022a0211551dd8e4d3b9db40288633e47
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -919,14 +919,14 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
         diff --git a/test1.txt b/test1.txt
         old mode 100644
         new mode 100755
-        "###);
+        ");
     }
 
     // The file mode change was only to the index, so we don't need to revert the
     // file mode on disk. It will already be non-executable on disk.
     {
         let (stdout, _stderr) = git.run(&["status"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         HEAD detached from f777ecc
         Changes not staged for commit:
           (use "git add <file>..." to update what will be committed)
@@ -934,7 +934,7 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
         	modified:   test1.txt
 
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     git.write_file_txt("test1", "new contents\n")?;
@@ -955,7 +955,7 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 6d2873ff3352132d510a9f98a169105529b31974
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -969,11 +969,11 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +new contents
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["status"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         HEAD detached from f777ecc
         Changes not staged for commit:
           (use "git add <file>..." to update what will be committed)
@@ -981,7 +981,7 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
         	modified:   test1.txt
 
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     let exit_status = run_in_pty(
@@ -997,7 +997,7 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
     assert!(exit_status.success());
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit dae4fe3e4c7defeba5605f9ae9b018dce8993a8a
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -1007,15 +1007,15 @@ fn test_record_file_mode_change() -> eyre::Result<()> {
         diff --git a/test1.txt b/test1.txt
         old mode 100755
         new mode 100644
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         HEAD detached from f777ecc
         nothing to commit, working tree clean
-        "###);
+        ");
     }
 
     Ok(())
@@ -1047,7 +1047,7 @@ fn test_record_binary_contents() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 7f10d49c57bba90e7dbeb59282de954bd0a53535
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -1057,7 +1057,7 @@ fn test_record_binary_contents() -> eyre::Result<()> {
         diff --git a/foo b/foo
         index 21317ba..c2575e5 100644
         Binary files a/foo and b/foo differ
-        "###);
+        ");
     }
 
     Ok(())
@@ -1095,12 +1095,12 @@ fn test_record_interactive_commit_message_template() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 4ab51ca (master) create test1.txt
         |
         @ 88e5a87 This is a commit template!
-        "###);
+        ");
     }
 
     Ok(())
@@ -1120,7 +1120,7 @@ fn test_record_fixup() -> eyre::Result<()> {
     git.write_file_txt("test1", "update test1\n")?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
@@ -1131,7 +1131,7 @@ fn test_record_fixup() -> eyre::Result<()> {
     git.branchless("record", &["--fixup", "roots(all())"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
@@ -1144,7 +1144,7 @@ fn test_record_fixup() -> eyre::Result<()> {
     git.run(&["checkout", &test1_oid.to_string()])?;
     git.write_file_txt("test1", "update test1 again\n")?;
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     @ 62fc20d create test1.txt
@@ -1162,7 +1162,7 @@ fn test_record_fixup() -> eyre::Result<()> {
             ..Default::default()
         },
     )?;
-    insta::assert_snapshot!(stderr, @r"
+    insta::assert_snapshot!(stderr, @"
     The commit supplied to --fixup must be an ancestor of the commit being created.
     Aborting.
     ");

--- a/git-branchless-revset/src/eval.rs
+++ b/git-branchless-revset/src/eval.rs
@@ -415,7 +415,7 @@ mod tests {
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("all"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -468,16 +468,16 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("none"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
         }
 
         {
@@ -488,7 +488,7 @@ mod tests {
                     Expr::Name(Cow::Owned(test2_oid.to_string())),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -505,7 +505,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -516,11 +516,11 @@ mod tests {
                     Expr::Name(Cow::Owned(test2_oid.to_string())),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
 
             let expr = Expr::FunctionCall(
                 Cow::Borrowed("intersection"),
@@ -529,7 +529,7 @@ mod tests {
                     Expr::Name(Cow::Owned(test1_oid.to_string())),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -540,7 +540,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -551,7 +551,7 @@ mod tests {
                     Expr::Name(Cow::Owned(test2_oid.to_string())),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -562,7 +562,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
 
             let expr = Expr::FunctionCall(
                 Cow::Borrowed("difference"),
@@ -571,11 +571,11 @@ mod tests {
                     Expr::Name(Cow::Owned(test1_oid.to_string())),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
         }
 
         {
@@ -583,7 +583,7 @@ mod tests {
                 Cow::Borrowed("siblings"),
                 vec![Expr::Name(Cow::Owned(test2_oid.to_string()))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -594,12 +594,12 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("stack"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -622,12 +622,12 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("main"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -638,12 +638,12 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("public"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -666,7 +666,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -674,7 +674,7 @@ mod tests {
                 Cow::Borrowed("stack"),
                 vec![Expr::Name(Cow::Owned(test2_oid.to_string()))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -691,12 +691,12 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("draft"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -731,7 +731,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -739,7 +739,7 @@ mod tests {
                 Cow::Borrowed("not"),
                 vec![Expr::FunctionCall(Cow::Borrowed("draft"), vec![])],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -762,7 +762,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -773,7 +773,7 @@ mod tests {
                     Expr::Name(Cow::Borrowed("1")),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -784,7 +784,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -795,7 +795,7 @@ mod tests {
                     Expr::Name(Cow::Borrowed("2")),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -806,7 +806,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -814,7 +814,7 @@ mod tests {
                 Cow::Borrowed("message"),
                 vec![Expr::Name(Cow::Borrowed("test4"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -825,7 +825,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -833,7 +833,7 @@ mod tests {
                 Cow::Borrowed("message"),
                 vec![Expr::Name(Cow::Borrowed("exact:create test4.txt"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -844,7 +844,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -852,7 +852,7 @@ mod tests {
                 Cow::Borrowed("message"),
                 vec![Expr::Name(Cow::Borrowed("regex:^create test4.txt$"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -863,7 +863,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -871,7 +871,7 @@ mod tests {
                 Cow::Borrowed("paths.changed"),
                 vec![Expr::Name(Cow::Borrowed("glob:test[1-3].txt"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -894,7 +894,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -905,7 +905,7 @@ mod tests {
                     Expr::Name(Cow::Borrowed("3")),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -928,7 +928,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -939,7 +939,7 @@ mod tests {
                     Expr::Name(Cow::Borrowed("2")),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Err(
                 UnexpectedSetLength {
                     expr: "stack()",
@@ -947,7 +947,7 @@ mod tests {
                     actual_len: 3,
                 },
             )
-            "###);
+            "#);
         }
 
         Ok(())
@@ -1018,7 +1018,7 @@ mod tests {
                 Cow::Borrowed("author.name"),
                 vec![Expr::Name(Cow::Borrowed("Foo"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1029,7 +1029,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1037,7 +1037,7 @@ mod tests {
                 Cow::Borrowed("author.email"),
                 vec![Expr::Name(Cow::Borrowed("foo"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1048,7 +1048,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1056,7 +1056,7 @@ mod tests {
                 Cow::Borrowed("author.date"),
                 vec![Expr::Name(Cow::Borrowed("before:today"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1079,7 +1079,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1087,11 +1087,11 @@ mod tests {
                 Cow::Borrowed("author.date"),
                 vec![Expr::Name(Cow::Borrowed("after:yesterday"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
         }
 
         {
@@ -1099,7 +1099,7 @@ mod tests {
                 Cow::Borrowed("committer.name"),
                 vec![Expr::Name(Cow::Borrowed("Foo"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1110,7 +1110,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1118,7 +1118,7 @@ mod tests {
                 Cow::Borrowed("committer.email"),
                 vec![Expr::Name(Cow::Borrowed("foo"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1129,7 +1129,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1137,7 +1137,7 @@ mod tests {
                 Cow::Borrowed("committer.date"),
                 vec![Expr::Name(Cow::Borrowed("before:today"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1160,7 +1160,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1168,11 +1168,11 @@ mod tests {
                 Cow::Borrowed("committer.date"),
                 vec![Expr::Name(Cow::Borrowed("after:yesterday"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
         }
 
         Ok(())
@@ -1221,11 +1221,11 @@ mod tests {
                     Expr::Name(Cow::Borrowed(original_test4_oid)),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @"
             Ok(
                 [],
             )
-            "###);
+            ");
 
             let expr = Expr::FunctionCall(
                 Cow::Borrowed("current"),
@@ -1237,7 +1237,7 @@ mod tests {
                     ],
                 )],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1254,7 +1254,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
         Ok(())
     }
@@ -1288,7 +1288,7 @@ mod tests {
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("merges"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1305,13 +1305,13 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
 
             let expr = Expr::FunctionCall(
                 Cow::Borrowed("not"),
                 vec![Expr::FunctionCall(Cow::Borrowed("merges"), vec![])],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1334,7 +1334,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
         Ok(())
     }
@@ -1367,7 +1367,7 @@ mod tests {
 
         {
             let expr = Expr::FunctionCall(Cow::Borrowed("branches"), vec![]);
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1390,13 +1390,13 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
 
             let expr = Expr::FunctionCall(
                 Cow::Borrowed("branches"),
                 vec![Expr::Name(Cow::Borrowed("glob:test*"))],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1413,7 +1413,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
         Ok(())
     }
@@ -1454,7 +1454,7 @@ mod tests {
                 Cow::Borrowed("simpleAlias"),
                 vec![Expr::FunctionCall(Cow::Borrowed("stack"), vec![])],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1465,7 +1465,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1479,7 +1479,7 @@ mod tests {
                 Cow::Borrowed("complexAlias"),
                 vec![Expr::FunctionCall(Cow::Borrowed("stack"), vec![])],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Ok(
                 [
                     Commit {
@@ -1490,7 +1490,7 @@ mod tests {
                     },
                 ],
             )
-            "###);
+            "#);
         }
 
         {
@@ -1504,11 +1504,11 @@ mod tests {
                     ..Default::default()
                 },
             )?;
-            insta::assert_snapshot!(_stderr, @r###"
+            insta::assert_snapshot!(_stderr, @r#"
             Evaluation error for expression 'parseError()': failed to parse alias expression 'foo('
             parse error: Unrecognized EOF found at 4
             Expected one of a commit/branch/tag, a string literal, "(", ")", "..", ":" or "::"
-            "###);
+            "#);
         }
 
         {
@@ -1541,13 +1541,13 @@ mod tests {
                     Expr::FunctionCall(Cow::Borrowed("nonsense"), vec![]),
                 ],
             );
-            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r###"
+            insta::assert_debug_snapshot!(eval_and_sort(&effects, &repo, &mut dag, &expr), @r#"
             Err(
                 UnboundName {
                     name: "$2",
                 },
             )
-            "###);
+            "#);
         }
 
         Ok(())

--- a/git-branchless-revset/src/parser.rs
+++ b/git-branchless-revset/src/parser.rs
@@ -60,27 +60,27 @@ mod tests {
 
     #[test]
     fn test_revset_parser() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("hello"), @r###"
+        insta::assert_debug_snapshot!(parse("hello"), @r#"
         Ok(
             Name(
                 "hello",
             ),
         )
-        "###);
+        "#);
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_function_calls() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("foo()"), @r###"
+        insta::assert_debug_snapshot!(parse("foo()"), @r#"
         Ok(
             FunctionCall(
                 "foo",
                 [],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(bar)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(bar)"), @r#"
         Ok(
             FunctionCall(
                 "foo",
@@ -91,23 +91,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(bar, baz)"), @r###"
-        Ok(
-            FunctionCall(
-                "foo",
-                [
-                    Name(
-                        "bar",
-                    ),
-                    Name(
-                        "baz",
-                    ),
-                ],
-            ),
-        )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(bar, baz,)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(bar, baz)"), @r#"
         Ok(
             FunctionCall(
                 "foo",
@@ -121,34 +106,49 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(,)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(bar, baz,)"), @r#"
+        Ok(
+            FunctionCall(
+                "foo",
+                [
+                    Name(
+                        "bar",
+                    ),
+                    Name(
+                        "baz",
+                    ),
+                ],
+            ),
+        )
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(,)"), @r#"
         Err(
             ParseError(
                 "Unrecognized token `,` found at 4:5\nExpected one of a commit/branch/tag, a string literal, \"(\", \")\", \"..\", \":\" or \"::\"",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(,bar)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(,bar)"), @r#"
         Err(
             ParseError(
                 "Unrecognized token `,` found at 4:5\nExpected one of a commit/branch/tag, a string literal, \"(\", \")\", \"..\", \":\" or \"::\"",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo(bar,,)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo(bar,,)"), @r#"
         Err(
             ParseError(
                 "Unrecognized token `,` found at 8:9\nExpected one of a commit/branch/tag, a string literal, \"(\", \")\", \"..\", \":\" or \"::\"",
             ),
         )
-        "###);
+        "#);
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_set_operators() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("foo | bar & bar"), @r###"
+        insta::assert_debug_snapshot!(parse("foo | bar & bar"), @r#"
         Ok(
             FunctionCall(
                 "union",
@@ -170,8 +170,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo & bar | bar")?, @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo & bar | bar")?, @r#"
         FunctionCall(
             "union",
             [
@@ -191,8 +191,8 @@ mod tests {
                 ),
             ],
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo | bar")?, @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo | bar")?, @r#"
         FunctionCall(
             "union",
             [
@@ -204,8 +204,8 @@ mod tests {
                 ),
             ],
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo | bar - baz")?, @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo | bar - baz")?, @r#"
         FunctionCall(
             "union",
             [
@@ -225,20 +225,20 @@ mod tests {
                 ),
             ],
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo |"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo |"), @r#"
         Err(
             ParseError(
                 "Unrecognized EOF found at 5\nExpected one of a commit/branch/tag, a string literal, \"(\", \"..\", \":\" or \"::\"",
             ),
         )
-        "###);
+        "#);
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_range_operator() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("foo:bar"), @r###"
+        insta::assert_debug_snapshot!(parse("foo:bar"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -252,8 +252,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo:"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo:"), @r#"
         Ok(
             FunctionCall(
                 "descendants",
@@ -264,8 +264,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(":foo"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(":foo"), @r#"
         Ok(
             FunctionCall(
                 "ancestors",
@@ -276,9 +276,9 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(parse("foo-bar/baz:qux-grault"), @r###"
+        insta::assert_debug_snapshot!(parse("foo-bar/baz:qux-grault"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -292,9 +292,9 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(parse("foo..bar"), @r###"
+        insta::assert_debug_snapshot!(parse("foo..bar"), @r#"
         Ok(
             FunctionCall(
                 "only",
@@ -308,8 +308,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo.."), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo.."), @r#"
         Ok(
             FunctionCall(
                 "only",
@@ -323,8 +323,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("..bar"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("..bar"), @r#"
         Ok(
             FunctionCall(
                 "only",
@@ -338,49 +338,49 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_string() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse(r#" "" "#), @r###"
+        insta::assert_debug_snapshot!(parse(r#" "" "#), @r#"
         Ok(
             Name(
                 "",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(r#" "foo" "#), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(r#" "foo" "#), @r#"
         Ok(
             Name(
                 "foo",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(r#" "foo bar" "#), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(r#" "foo bar" "#), @r#"
         Ok(
             Name(
                 "foo bar",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(r#" "foo\nbar\\baz" "#), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(r#" "foo\nbar\\baz" "#), @r#"
         Ok(
             Name(
                 "foo\nba\r\\\\baz",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(r" 'foo\nbar\\baz' "), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(r" 'foo\nbar\\baz' "), @r#"
         Ok(
             Name(
                 "foo\nba\r\\\\baz",
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse(r#" foo('bar') - baz(qux('qubit')) "#), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse(r#" foo('bar') - baz(qux('qubit')) "#), @r#"
         Ok(
             FunctionCall(
                 "difference",
@@ -409,22 +409,22 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_parentheses() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("((foo()))"), @r###"
+        insta::assert_debug_snapshot!(parse("((foo()))"), @r#"
         Ok(
             FunctionCall(
                 "foo",
                 [],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("(foo) - bar"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("(foo) - bar"), @r#"
         Ok(
             FunctionCall(
                 "difference",
@@ -438,8 +438,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo - (bar)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo - (bar)"), @r#"
         Ok(
             FunctionCall(
                 "difference",
@@ -453,8 +453,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("(foo) & bar"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("(foo) & bar"), @r#"
         Ok(
             FunctionCall(
                 "intersection",
@@ -468,8 +468,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo & (bar)"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo & (bar)"), @r#"
         Ok(
             FunctionCall(
                 "intersection",
@@ -483,8 +483,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("(foo | bar):"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("(foo | bar):"), @r#"
         Ok(
             FunctionCall(
                 "descendants",
@@ -503,8 +503,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("(foo)^"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("(foo)^"), @r#"
         Ok(
             FunctionCall(
                 "parents.nth",
@@ -518,14 +518,14 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
         Ok(())
     }
 
     #[test]
     fn test_revset_parse_git_revision_syntax() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("foo:bar^"), @r###"
+        insta::assert_debug_snapshot!(parse("foo:bar^"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -547,8 +547,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo|bar^"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo|bar^"), @r#"
         Ok(
             FunctionCall(
                 "union",
@@ -570,8 +570,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo:bar^3"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo:bar^3"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -593,9 +593,9 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(parse("foo:bar~"), @r###"
+        insta::assert_debug_snapshot!(parse("foo:bar~"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -617,8 +617,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo|bar~"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo|bar~"), @r#"
         Ok(
             FunctionCall(
                 "union",
@@ -640,8 +640,8 @@ mod tests {
                 ],
             ),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("foo:bar~3"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("foo:bar~3"), @r#"
         Ok(
             FunctionCall(
                 "range",
@@ -663,14 +663,14 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
         Ok(())
     }
 
     #[test]
     fn test_revset_child_operator() -> eyre::Result<()> {
-        insta::assert_debug_snapshot!(parse("foo!"), @r###"
+        insta::assert_debug_snapshot!(parse("foo!"), @r#"
         Ok(
             FunctionCall(
                 "exactly",
@@ -689,9 +689,9 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(parse("@! + @!!"), @r###"
+        insta::assert_debug_snapshot!(parse("@! + @!!"), @r#"
         Ok(
             FunctionCall(
                 "union",
@@ -744,7 +744,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
 
         Ok(())
     }

--- a/git-branchless-reword/src/lib.rs
+++ b/git-branchless-reword/src/lib.rs
@@ -751,14 +751,14 @@ mod tests {
                 InitialCommitMessages::Discard,
                 &[head_commit.clone()],
                 |message| {
-                    insta::assert_snapshot!(message.trim(), @r###"
+                    insta::assert_snapshot!(message.trim(), @"
                     # Original message:
                     # create test1.txt
 
                     # Rewording: Please enter the commit message to apply to this 1 commit.
                     # Lines starting with '#' will be ignored, and an empty message aborts
                     # rewording.
-                    "###);
+                    ");
                     Ok(message.to_string())
                 },
             )?;
@@ -779,7 +779,7 @@ This is a template!
                 InitialCommitMessages::Discard,
                 &[head_commit],
                 |message| {
-                    insta::assert_snapshot!(message.trim(), @r###"
+                    insta::assert_snapshot!(message.trim(), @"
                     This is a template!
 
                     # Original message:
@@ -788,7 +788,7 @@ This is a template!
                     # Rewording: Please enter the commit message to apply to this 1 commit.
                     # Lines starting with '#' will be ignored, and an empty message aborts
                     # rewording.
-                    "###);
+                    ");
                     Ok(message.to_string())
                 },
             )?;
@@ -815,7 +815,7 @@ This is a template!
                 InitialCommitMessages::Messages([].to_vec()),
                 &[test1_commit.clone(), test2_commit.clone()],
                 |message| {
-                    insta::assert_snapshot!(message.trim(), @r###"
+                    insta::assert_snapshot!(message.trim(), @"
                     ++ reword 62fc20d
                     create test1.txt
 
@@ -825,7 +825,7 @@ This is a template!
                     # Rewording: Please enter the commit messages to apply to these 2 commits.
                     # Lines starting with '#' will be ignored, and an empty message aborts
                     # rewording.
-                    "###);
+                    ");
                     Ok(message.to_string())
                 },
             )?;
@@ -861,21 +861,23 @@ This is a template!
 
             // Convert the messages HashMap into the sorted map for testing
             let messages: BTreeMap<_, _> = result.messages.iter().collect();
-            insta::assert_debug_snapshot!(messages, @r###"
-                {
-                    NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e): "create test1.txt\n",
-                    NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f): "create test2.txt\n",
-                }"###
+            insta::assert_debug_snapshot!(messages, @r#"
+            {
+                NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e): "create test1.txt\n",
+                NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f): "create test2.txt\n",
+            }
+            "#
             );
 
             // clear the messages map b/c its contents have already been tested
             result.messages.clear();
-            insta::assert_debug_snapshot!(result, @r###"
-                ParseMessageResult {
-                    duplicates: [],
-                    messages: {},
-                    unexpected: [],
-                }"###
+            insta::assert_debug_snapshot!(result, @"
+            ParseMessageResult {
+                duplicates: [],
+                messages: {},
+                unexpected: [],
+            }
+            "
             );
         };
 
@@ -908,18 +910,19 @@ This is a template!
                 '#',
             )?;
 
-            insta::assert_debug_snapshot!(result, @r###"
-                ParseMessageResult {
-                    duplicates: [
-                        "62fc20d",
-                    ],
-                    messages: {
-                        NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e): "create test1.txt\n",
-                    },
-                    unexpected: [
-                        "abc123",
-                    ],
-                }"###
+            insta::assert_debug_snapshot!(result, @r#"
+            ParseMessageResult {
+                duplicates: [
+                    "62fc20d",
+                ],
+                messages: {
+                    NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e): "create test1.txt\n",
+                },
+                unexpected: [
+                    "abc123",
+                ],
+            }
+            "#
             );
         };
 

--- a/git-branchless-smartlog/tests/test_smartlog.rs
+++ b/git-branchless-smartlog/tests/test_smartlog.rs
@@ -8,8 +8,7 @@ fn test_init_smartlog() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     Ok(())
@@ -25,11 +24,11 @@ fn test_show_reachable_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 3df4b93 (> initial-branch) create test.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -48,13 +47,13 @@ fn test_tree() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         @ fe65c1f (> initial) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -74,13 +73,13 @@ fn test_rebase() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d (test1) create test1.txt
         |
         @ f8d9985 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -97,10 +96,10 @@ fn test_sequential_master_commits() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 70deb1e (> master) create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -127,7 +126,7 @@ fn test_merge_commit() -> eyre::Result<()> {
     {
         // Rendering here is arbitrary and open to change.
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d (test1) create test1.txt
@@ -140,7 +139,7 @@ fn test_merge_commit() -> eyre::Result<()> {
         | & (merge) 62fc20d (test1) create test1.txt
         |/
         @ fa4e4e1 (> test2and3) Merge branch 'test1' into test2and3
-        "###);
+        ");
     }
 
     git.run(&["checkout", "-b", "test4", "master"])?;
@@ -150,7 +149,7 @@ fn test_merge_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d (test1) create test1.txt
@@ -172,7 +171,7 @@ fn test_merge_commit() -> eyre::Result<()> {
         | & (merge) fa4e4e1 (test2and3) Merge branch 'test1' into test2and3
         |/
         @ 36a25e8 (> test4) Merge branch 'test2and3' into test4
-        "###);
+        ");
     }
 
     Ok(())
@@ -198,7 +197,7 @@ fn test_merge_commit_reverse_order() -> eyre::Result<()> {
     )?;
 
     let (stdout, _) = git.branchless("smartlog", &[])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @ fa4e4e1 (> test2and3) Merge branch 'test1' into test2and3
     |\
     | & (merge) 62fc20d (test1) create test1.txt
@@ -211,7 +210,7 @@ fn test_merge_commit_reverse_order() -> eyre::Result<()> {
     | o 62fc20d (test1) create test1.txt
     |/
     O f777ecc (master) create initial.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -239,13 +238,13 @@ fn test_rebase_conflict() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 88646b5 (branch1) create test.txt
         |
         @ 4549af3 (> branch2) create test.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -266,7 +265,7 @@ fn test_non_adjacent_commits() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         : o 62fc20d create test1.txt
@@ -274,7 +273,7 @@ fn test_non_adjacent_commits() -> eyre::Result<()> {
         O 0206717 (master) create test3.txt
         |
         @ 8e62740 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -296,7 +295,7 @@ fn test_non_adjacent_commits2() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         : o 62fc20d create test1.txt
@@ -306,7 +305,7 @@ fn test_non_adjacent_commits2() -> eyre::Result<()> {
         O 2b633ed (master) create test4.txt
         |
         @ 1393298 create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -330,7 +329,7 @@ fn test_non_adjacent_commits3() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -341,7 +340,7 @@ fn test_non_adjacent_commits3() -> eyre::Result<()> {
         : o a248207 create test4.txt
         :
         @ 500c9b3 (> master) create test6.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -360,12 +359,12 @@ fn test_custom_main_branch() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (main) create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -385,7 +384,7 @@ fn test_show_rewritten_commit_hash() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 2ebe095 test1 version 2
@@ -396,7 +395,7 @@ fn test_show_rewritten_commit_hash() -> eyre::Result<()> {
         hint: there is 1 abandoned commit in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
     }
 
     Ok(())
@@ -414,10 +413,10 @@ fn test_smartlog_orphaned_root() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("smartlog", &[])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -440,7 +439,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
 
     let hint_command = {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ ae94dc2 amended test1
@@ -451,7 +450,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
         hint: there is 1 abandoned commit in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
         extract_hint_command(&stdout)
     };
 
@@ -459,7 +458,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ ae94dc2 amended test1
@@ -467,7 +466,7 @@ fn test_smartlog_hint_abandoned() -> eyre::Result<()> {
         x 62fc20d (rewritten as ae94dc2a) create test1.txt
         |
         o 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -488,13 +487,13 @@ fn test_smartlog_hint_abandoned_except_current_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | % 62fc20d (rewritten as ae94dc2a) create test1.txt
         |
         O ae94dc2 (master) amended test1
-        "###);
+        ");
     }
 
     Ok(())
@@ -518,7 +517,7 @@ fn test_smartlog_hint_abandoned_reverse_order() -> eyre::Result<()> {
     git.run(&["commit", "--amend", "-m", "amended test1"])?;
 
     let (stdout, _) = git.branchless("smartlog", &[])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     o 96d1c37 create test2.txt
     |
     x 62fc20d (rewritten as ae94dc2a) create test1.txt
@@ -529,7 +528,7 @@ fn test_smartlog_hint_abandoned_reverse_order() -> eyre::Result<()> {
     hint: there is 1 abandoned commit in your commit graph
     hint: to fix this, run: git restack
     hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-    "###);
+    ");
 
     Ok(())
 }
@@ -549,12 +548,12 @@ fn test_smartlog_sparse() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &["none()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 0206717 (master) create test3.txt
         |
         @ 8e62740 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -576,7 +575,7 @@ fn test_smartlog_sparse_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[&test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         : # 1 omitted commit
@@ -586,7 +585,7 @@ fn test_smartlog_sparse_branch() -> eyre::Result<()> {
         O 2b633ed (master) create test4.txt
         |
         @ 1393298 create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -609,7 +608,7 @@ fn test_smartlog_sparse_false_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[&test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | # 1 omitted commit
@@ -623,7 +622,7 @@ fn test_smartlog_sparse_false_head() -> eyre::Result<()> {
         # 1 omitted commit
         :
         @ 68975e5 create test6.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -641,12 +640,12 @@ fn test_smartlog_sparse_main_false_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &["none()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
         :
         # 1 omitted descendant commit
-        "###);
+        ");
     }
 
     Ok(())
@@ -663,13 +662,13 @@ fn test_smartlog_hidden() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &["--hidden"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ ae94dc2 amended test1
         |
         x 62fc20d (rewritten as ae94dc2a) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -690,7 +689,7 @@ fn test_smartlog_sparse_vertical_ellipsis_sibling_commits() -> eyre::Result<()> 
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &["heads(draft())"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -700,7 +699,7 @@ fn test_smartlog_sparse_vertical_ellipsis_sibling_commits() -> eyre::Result<()> 
         # 1 omitted commit
         :
         @ 2b633ed create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -718,7 +717,7 @@ fn test_default_smartlog_revset() -> eyre::Result<()> {
 
     {
         let smartlog = git.smartlog()?;
-        insta::assert_snapshot!(smartlog, @r###"
+        insta::assert_snapshot!(smartlog, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -726,20 +725,20 @@ fn test_default_smartlog_revset() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     git.run(&["config", "branchless.smartlog.defaultRevset", "none()"])?;
 
     {
         let smartlog = git.smartlog()?;
-        insta::assert_snapshot!(smartlog, @r###"
+        insta::assert_snapshot!(smartlog, @"
         O f777ecc (master) create initial.txt
         :
         # 2 omitted commits
         :
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -764,7 +763,7 @@ fn test_exact() -> eyre::Result<()> {
     {
         // Here '--exact' doesn't change anything because draft() covers all these commits
         let (stdout, _stderr) = git.branchless("smartlog", &["--exact"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -777,7 +776,7 @@ fn test_exact() -> eyre::Result<()> {
         O ea7aa06 (master) create test5.txt
         |
         o da42aeb create test6.txt
-        "###);
+        ");
     }
 
     {
@@ -789,18 +788,18 @@ fn test_exact() -> eyre::Result<()> {
     {
         // Show one commit - no master or HEAD
         let (stdout, _stderr) = git.branchless("smartlog", &["--exact", "70deb1e"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         o 70deb1e create test3.txt
         :
         # 1 omitted descendant commit
-        "###);
+        ");
     }
 
     {
         // Show head commits and their common ancestor, which is not main.
         let (stdout, _stderr) = git.branchless("smartlog", &["--exact", "heads(draft())"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -809,7 +808,7 @@ fn test_exact() -> eyre::Result<()> {
         : o 355e173 create test4.txt
         :
         o da42aeb create test6.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless-submit/tests/test_phabricator_forge.rs
+++ b/git-branchless-submit/tests/test_phabricator_forge.rs
@@ -38,12 +38,12 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         This operation would modify the working copy, but you have uncommitted changes
         in your working copy which might be overwritten as a result.
         Commit your changes and then try again.
-        "###);
+        ");
     }
     git.run(&["checkout", "--", "."])?;
 
@@ -56,7 +56,7 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -76,18 +76,18 @@ fn test_submit_phabricator_strategy_working_copy() -> eyre::Result<()> {
         Using command execution strategy: working-copy
         branchless: running command: <git-executable> rebase --abort
         Submitted 2 commits: D0002, D0003
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 55af3db D0002 create test1.txt
         |
         @ ccb7fd5 D0003 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -107,13 +107,13 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     {
@@ -131,14 +131,14 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Previous HEAD position was 96d1c37 create test2.txt
         branchless: processing 1 update: ref HEAD
         HEAD is now at ccb7fd5 create test2.txt
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         Using command execution strategy: worktree
         Attempting rebase in-memory...
         [1/2] Committed as: 55af3db create test1.txt
@@ -150,18 +150,18 @@ fn test_submit_phabricator_strategy_worktree() -> eyre::Result<()> {
         Stacking D0003 on top of D0002
         Using command execution strategy: worktree
         Submitted 2 commits: D0002, D0003
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 55af3db D0002 create test1.txt
         |
         @ ccb7fd5 D0003 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -185,7 +185,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -205,7 +205,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
         Using command execution strategy: working-copy
         branchless: running command: <git-executable> rebase --abort
         Submitted 2 commits: D0002, D0003
-        "###);
+        ");
     }
 
     {
@@ -217,7 +217,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -225,7 +225,7 @@ fn test_submit_phabricator_update() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --abort
         Setting D0002 as stack root (no dependencies)
         Stacking D0003 on top of D0002
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless-test/tests/test_test.rs
+++ b/git-branchless-test/tests/test_test.rs
@@ -28,11 +28,11 @@ fn test_test() -> eyre::Result<()> {
 
     {
         let (stdout, stderr) = git.branchless("test", &["run", "-x", "exit 0"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 0206717 (create test3.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -42,7 +42,7 @@ fn test_test() -> eyre::Result<()> {
         ✓ Passed: 0206717 create test3.txt
         Ran command on 2 commits: exit 0
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -54,11 +54,11 @@ fn test_test() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 0206717 (create test3.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -68,7 +68,7 @@ fn test_test() -> eyre::Result<()> {
         X Failed (exit code 1): 0206717 create test3.txt
         Ran command on 2 commits: exit 1
         0 passed, 2 failed, 0 skipped
-        "###);
+        ");
     }
 
     Ok(())
@@ -94,12 +94,12 @@ fn test_test_abort() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
         Using command execution strategy: working-copy
-        "###);
+        ");
     }
 
     {
@@ -111,33 +111,33 @@ fn test_test_abort() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         A rebase operation is already in progress.
         Run git rebase --continue or git rebase --abort to resolve it and proceed.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ fe65c1f create test2.txt
         |
         o 0206717 create test3.txt
-        "###);
+        ");
     }
 
     git.run(&["rebase", "--abort"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o fe65c1f create test2.txt
         |
         @ 0206717 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -155,7 +155,7 @@ fn test_test_cached_results() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", "exit 0"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -169,12 +169,12 @@ fn test_test_cached_results() -> eyre::Result<()> {
         hint: there was 1 cached test result
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", "exit 0"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -188,7 +188,7 @@ fn test_test_cached_results() -> eyre::Result<()> {
         hint: there were 3 cached test results
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -209,7 +209,7 @@ fn test_test_verbosity() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", short_command, "-v"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -231,12 +231,12 @@ fn test_test_verbosity() -> eyre::Result<()> {
         <no output>
         Ran command on 1 commit: bash test.sh 10
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", short_command, "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -261,12 +261,12 @@ fn test_test_verbosity() -> eyre::Result<()> {
         hint: there was 1 cached test result
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", long_command, "-v"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -289,12 +289,12 @@ fn test_test_verbosity() -> eyre::Result<()> {
         <no output>
         Ran command on 1 commit: bash test.sh 15
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", long_command, "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -324,7 +324,7 @@ fn test_test_verbosity() -> eyre::Result<()> {
         hint: there was 1 cached test result
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -341,7 +341,7 @@ fn test_test_show() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", "echo hi", "."])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -350,39 +350,39 @@ fn test_test_show() -> eyre::Result<()> {
         ✓ Passed: 96d1c37 create test2.txt
         Ran command on 1 commit: echo hi
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("test", &["show", "-x", "echo hi"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No cached test data for 62fc20d create test1.txt
         ✓ Passed (cached): 96d1c37 create test2.txt
         hint: to see more detailed output, re-run with -v/--verbose
         hint: disable this hint by running: git config --global branchless.hint.testShowVerbose false
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("test", &["clean"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Cleaning results for 62fc20d create test1.txt
         Cleaning results for 96d1c37 create test2.txt
         Cleaned 2 cached test results.
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("test", &["show", "-x", "echo hi"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No cached test data for 62fc20d create test1.txt
         No cached test data for 96d1c37 create test2.txt
         hint: to see more detailed output, re-run with -v/--verbose
         hint: disable this hint by running: git config --global branchless.hint.testShowVerbose false
-        "###);
+        ");
     }
 
     Ok(())
@@ -402,14 +402,14 @@ fn test_test_command_alias() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Could not determine test command to run. No test command was provided with -c/--command or
         -x/--exec, and the configuration value 'branchless.test.alias.default' was not set.
 
         To configure a default test command, run: git config branchless.test.alias.default <command>
         To run a specific test command, run: git test run -x <command>
         To run a specific command alias, run: git test run -c <alias>
-        "###);
+        ");
     }
 
     git.run(&["config", "branchless.test.alias.foo", "echo foo"])?;
@@ -422,7 +422,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         Could not determine test command to run. No test command was provided with -c/--command or
         -x/--exec, and the configuration value 'branchless.test.alias.default' was not set.
 
@@ -432,7 +432,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
 
         These are the currently-configured command aliases:
         - branchless.test.alias.foo = "echo foo"
-        "###);
+        "#);
     }
 
     {
@@ -444,7 +444,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         The test command alias "nonexistent" was not defined.
 
         To create it, run: git config branchless.test.alias.nonexistent <command>
@@ -452,13 +452,13 @@ fn test_test_command_alias() -> eyre::Result<()> {
 
         These are the currently-configured command aliases:
         - branchless.test.alias.foo = "echo foo"
-        "###);
+        "#);
     }
 
     git.run(&["config", "branchless.test.alias.default", "echo default"])?;
     {
         let (stdout, _stderr) = git.branchless("test", &["run"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -467,12 +467,12 @@ fn test_test_command_alias() -> eyre::Result<()> {
         ✓ Passed: f777ecc create initial.txt
         Ran command on 1 commit: echo default
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "-c", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -481,7 +481,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
         ✓ Passed: f777ecc create initial.txt
         Ran command on 1 commit: echo foo
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -493,7 +493,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         The test command alias "foo bar baz" was not defined.
 
         To create it, run: git config branchless.test.alias.foo bar baz <command>
@@ -502,7 +502,7 @@ fn test_test_command_alias() -> eyre::Result<()> {
         These are the currently-configured command aliases:
         - branchless.test.alias.foo = "echo foo"
         - branchless.test.alias.default = "echo default"
-        "###);
+        "#);
     }
 
     Ok(())
@@ -527,12 +527,12 @@ fn test_test_worktree_strategy() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         This operation would modify the working copy, but you have uncommitted changes
         in your working copy which might be overwritten as a result.
         Commit your changes and then try again.
-        "###);
+        ");
     }
 
     {
@@ -549,7 +549,7 @@ fn test_test_worktree_strategy() -> eyre::Result<()> {
             ],
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Using command execution strategy: worktree
         ✓ Passed: 62fc20d create test1.txt
         Stdout: <repo-path>/.git/branchless/test/8108c01b1930423879f106c1ebf725fcbfedccda/echo__hello/stdout
@@ -558,7 +558,7 @@ fn test_test_worktree_strategy() -> eyre::Result<()> {
         <no output>
         Ran command on 1 commit: echo hello
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -575,7 +575,7 @@ fn test_test_worktree_strategy() -> eyre::Result<()> {
             ],
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         Using command execution strategy: worktree
         ✓ Passed (cached): 62fc20d create test1.txt
         Stdout: <repo-path>/.git/branchless/test/8108c01b1930423879f106c1ebf725fcbfedccda/echo__hello/stdout
@@ -587,7 +587,7 @@ fn test_test_worktree_strategy() -> eyre::Result<()> {
         hint: there was 1 cached test result
         hint: to clear these cached results, run: git test clean "@"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -623,19 +623,19 @@ echo hello
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         This operation would modify the working copy, but you have uncommitted changes
         in your working copy which might be overwritten as a result.
         Commit your changes and then try again.
-        "###);
+        ");
     }
 
     git.run(&["config", "branchless.test.strategy", "worktree"])?;
     {
         let (stdout, stderr) = git.branchless("test", &["run", "-vv", "@"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Using command execution strategy: worktree
         ✓ Passed: c82ebfa create test2.txt
         Stdout: <repo-path>/.git/branchless/test/a3ae41e24abf7537423d8c72d07df7af456de6dd/bash__test.sh/stdout
@@ -644,7 +644,7 @@ echo hello
         <no output>
         Ran command on 1 commit: bash test.sh
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     git.run(&["config", "branchless.test.strategy", "invalid-value"])?;
@@ -658,10 +658,10 @@ echo hello
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Invalid value for config value branchless.test.strategy: invalid-value
         Expected one of: working-copy, worktree
-        "###);
+        ");
     }
 
     Ok(())
@@ -691,9 +691,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        The --jobs option can only be used with --strategy worktree, but --strategy working-copy was provided instead.
-        "###);
+        insta::assert_snapshot!(stdout, @"The --jobs option can only be used with --strategy worktree, but --strategy working-copy was provided instead.");
     }
 
     {
@@ -702,7 +700,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
             "test",
             &["run", "--strategy", "working-copy", "--jobs", "1"],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -712,7 +710,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
         ✓ Passed: 96d1c37 create test2.txt
         Ran command on 2 commits: exit 0
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -725,15 +723,13 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        The --jobs option can only be used with --strategy worktree, but --strategy working-copy was provided instead.
-        "###);
+        insta::assert_snapshot!(stdout, @"The --jobs option can only be used with --strategy worktree, but --strategy working-copy was provided instead.");
     }
 
     {
         let (stdout, stderr) = git.branchless("test", &["run", "--jobs", "2"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         Using command execution strategy: worktree
         ✓ Passed (cached): 62fc20d create test1.txt
         ✓ Passed (cached): 96d1c37 create test2.txt
@@ -742,7 +738,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
         hint: there were 2 cached test results
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     {
@@ -750,11 +746,11 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
             "test",
             &["run", "--exec", "true", "--interactive", "--jobs", "1"],
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 96d1c37 (create test2.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -773,7 +769,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
         ✓ Passed (interactive): 96d1c37 create test2.txt
         Ran command on 2 commits: true
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -786,20 +782,18 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        The --jobs option cannot be used with the --interactive option.
-        "###);
+        insta::assert_snapshot!(stdout, @"The --jobs option cannot be used with the --interactive option.");
     }
 
     git.run(&["config", "branchless.test.jobs", "2"])?;
 
     {
         let (stdout, stderr) = git.branchless("test", &["run", "--strategy", "working-copy"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 96d1c37 (create test2.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -812,7 +806,7 @@ fn test_test_jobs_argument_handling() -> eyre::Result<()> {
         hint: there were 2 cached test results
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -830,7 +824,7 @@ fn test_test_fix() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -838,7 +832,7 @@ fn test_test_fix() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     git.write_file(
@@ -851,7 +845,7 @@ done
     )?;
     {
         let (stdout, _stderr) = git.branchless("test", &["fix", "-x", "bash test.sh"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -873,12 +867,12 @@ done
         62fc20d -> 300cb54 create test1.txt
         96d1c37 -> 2ee3aea create test2.txt
         70deb1e -> 6f48e0a create test3.txt
-        "###);
+        ");
     }
 
     let original_log_output = {
         let (stdout, _stderr) = git.run(&["log", "--patch"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 6f48e0a628753731739619f27107c57f5d0cc1e0
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0300
@@ -941,13 +935,13 @@ done
         +++ b/initial.txt
         @@ -0,0 +1 @@
         +initial contents
-        "###);
+        ");
         stdout
     };
 
     let updated_smartlog = {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 300cb54 create test1.txt
@@ -955,7 +949,7 @@ done
         o 2ee3aea create test2.txt
         |
         @ 6f48e0a create test3.txt
-        "###);
+        ");
         stdout
     };
 
@@ -963,7 +957,7 @@ done
     // it was idempotent.
     {
         let (stdout, _stderr) = git.branchless("test", &["fix", "-x", "bash test.sh"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -975,7 +969,7 @@ done
         Ran command on 3 commits: bash test.sh
         3 passed, 0 failed, 0 skipped
         No commits to fix.
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["log", "--patch"])?;
@@ -1022,7 +1016,7 @@ done
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1033,7 +1027,7 @@ done
         X Failed (exit code 1): 70deb1e create test3.txt
         Ran command on 3 commits: bash test.sh
         1 passed, 2 failed, 0 skipped
-        "###);
+        ");
     }
     Ok(())
 }
@@ -1062,7 +1056,7 @@ done
 
     {
         let (stdout, _stderr) = git.run(&["log", "--patch"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 75e728fb17f6952287302c3e76d88aa737dd99d1
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -1111,12 +1105,12 @@ done
         +++ b/initial.txt
         @@ -0,0 +1 @@
         +initial contents
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["fix", "-x", "bash test.sh"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1135,12 +1129,12 @@ done
         Fixed 2 commits with bash test.sh:
         62fc20d -> 300cb54 create test1.txt
         75e728f -> f15b423 descendant commit
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["log", "--patch"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit f15b423404bbebfe4b09e305e074b525d008f44a
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 +0000
@@ -1189,7 +1183,7 @@ done
         +++ b/initial.txt
         @@ -0,0 +1 @@
         +initial contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -1212,9 +1206,7 @@ fn test_test_forbid_on_disk_rebase() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
-        The --on-disk option cannot be provided for fixes. Use the --in-memory option instead.
-        "###);
+        insta::assert_snapshot!(stdout, @"The --on-disk option cannot be provided for fixes. Use the --in-memory option instead.");
     }
 
     Ok(())
@@ -1243,7 +1235,7 @@ fn test_test_search_binary() -> eyre::Result<()> {
                 "! git grep -q 'test4'",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1259,7 +1251,7 @@ fn test_test_search_binary() -> eyre::Result<()> {
         - 70deb1e create test3.txt
         First failing commit:
         - 355e173 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1273,7 +1265,7 @@ fn test_test_run_none() -> eyre::Result<()> {
     {
         // Shouldn't time out.
         let (stdout, _stderr) = git.branchless("test", &["run", "-x", "true", "none()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1281,7 +1273,7 @@ fn test_test_run_none() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --abort
         Ran command on 0 commits: true
         0 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     Ok(())
@@ -1304,7 +1296,7 @@ fn test_test_search_skip_indeterminate() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("test", &["run", "--search", "binary", "--exec", "exit 125"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1322,14 +1314,14 @@ fn test_test_search_skip_indeterminate() -> eyre::Result<()> {
         0 passed, 0 failed, 7 skipped
         There were no passing commits in the provided set.
         There were no failing commits in the provided set.
-        "###);
+        ");
     }
 
     // Confirm that we treat exit code 125 as indeterminate even when cached.
     {
         let (stdout, _stderr) =
             git.branchless("test", &["run", "--search", "binary", "--exec", "exit 125"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1347,7 +1339,7 @@ fn test_test_search_skip_indeterminate() -> eyre::Result<()> {
         0 passed, 0 failed, 7 skipped
         There were no passing commits in the provided set.
         There were no failing commits in the provided set.
-        "###);
+        ");
     }
 
     git.write_file(
@@ -1368,7 +1360,7 @@ fi
             "test",
             &["run", "--search", "linear", "--exec", "bash test.sh"],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1387,7 +1379,7 @@ fi
         Last passing commit:
         - 70deb1e create test3.txt
         There were no failing commits in the provided set.
-        "###);
+        ");
     }
 
     {
@@ -1395,7 +1387,7 @@ fi
             "test",
             &["run", "--search", "binary", "--exec", "bash test.sh"],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1415,7 +1407,7 @@ fi
         hint: there was 1 cached test result
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -1443,7 +1435,7 @@ fn test_test_interactive() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1462,7 +1454,7 @@ fn test_test_interactive() -> eyre::Result<()> {
         ✓ Passed (interactive): 96d1c37 create test2.txt
         Ran command on 2 commits: true
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -1475,7 +1467,7 @@ fn test_test_interactive() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1494,7 +1486,7 @@ fn test_test_interactive() -> eyre::Result<()> {
         X Failed (exit code 1, interactive): 96d1c37 create test2.txt
         Ran command on 2 commits: false
         0 passed, 2 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -1507,11 +1499,11 @@ fn test_test_interactive() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 96d1c37 (create test2.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1531,7 +1523,7 @@ fn test_test_interactive() -> eyre::Result<()> {
         ✓ Passed (interactive): 96d1c37 create test2.txt
         Ran command on 2 commits: bash
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
@@ -1544,7 +1536,7 @@ fn test_test_interactive() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1556,7 +1548,7 @@ fn test_test_interactive() -> eyre::Result<()> {
         hint: there were 2 cached test results
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())
@@ -1594,11 +1586,11 @@ fi
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 96d1c37 (create test2.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1613,7 +1605,7 @@ fi
         - 62fc20d create test1.txt
         There were no failing commits in the provided set.
         Aborted running commands with exit code 127 at commit: 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     // Check aborting when results are cached.
@@ -1626,7 +1618,7 @@ fi
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1644,7 +1636,7 @@ fi
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
         Aborted running commands with exit code 127 at commit: 96d1c37 create test2.txt
-        "###);
+        "#);
     }
 
     Ok(())
@@ -1666,7 +1658,7 @@ echo "Command is: $BRANCHLESS_TEST_COMMAND"
     {
         let (stdout, _stderr) =
             git.branchless("test", &["run", "--exec", "bash test.sh", "HEAD", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1680,7 +1672,7 @@ echo "Command is: $BRANCHLESS_TEST_COMMAND"
         <no output>
         Ran command on 1 commit: bash test.sh
         1 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     Ok(())
@@ -1710,9 +1702,7 @@ fn test_test_revsets() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
-        Evaluation error for expression 'tests.passed()': there was no latest command run with `git test`; try running `git test` first
-        "###);
+        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'tests.passed()': there was no latest command run with `git test`; try running `git test` first");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -1751,11 +1741,11 @@ esac
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Stopped at 355e173 (create test4.txt)
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1767,48 +1757,44 @@ esac
         ✓ Passed: 355e173 create test4.txt
         Ran command on 4 commits: bash test.sh
         2 passed, 1 failed, 1 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("query", &["tests.passed()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         62fc20d create test1.txt
         355e173 create test4.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("query", &["tests.failed()"])?;
-        insta::assert_snapshot!(stdout, @r###"
-        96d1c37 create test2.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"96d1c37 create test2.txt");
     }
 
     {
         let (stdout, _stderr) = git.branchless("query", &["tests.fixable()"])?;
-        insta::assert_snapshot!(stdout, @r###"
-        62fc20d create test1.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"62fc20d create test1.txt");
     }
 
     git.branchless("test", &["run", "--exec", "exit 0"])?;
     {
         let (stdout, _stderr) = git.branchless("query", &["tests.passed()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         62fc20d create test1.txt
         96d1c37 create test2.txt
         70deb1e create test3.txt
         355e173 create test4.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("query", &["tests.passed('bash test.sh')"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         62fc20d create test1.txt
         355e173 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1836,7 +1822,7 @@ fn test_test_no_cache() -> eyre::Result<()> {
     )?;
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "--exec", "bash test.sh"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1846,7 +1832,7 @@ fn test_test_no_cache() -> eyre::Result<()> {
         ✓ Passed: 96d1c37 create test2.txt
         Ran command on 2 commits: bash test.sh
         2 passed, 0 failed, 0 skipped
-        "###);
+        ");
     }
 
     git.write_file(
@@ -1864,7 +1850,7 @@ fn test_test_no_cache() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1874,12 +1860,12 @@ fn test_test_no_cache() -> eyre::Result<()> {
         X Failed (exit code 1): 96d1c37 create test2.txt
         Ran command on 2 commits: bash test.sh
         0 passed, 2 failed, 0 skipped
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("test", &["run", "--exec", "bash test.sh"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -1892,7 +1878,7 @@ fn test_test_no_cache() -> eyre::Result<()> {
         hint: there were 2 cached test results
         hint: to clear these cached results, run: git test clean "stack() | @"
         hint: disable this hint by running: git config --global branchless.hint.cleanCachedTestResults false
-        "###);
+        "#);
     }
 
     Ok(())

--- a/git-branchless-undo/src/lib.rs
+++ b/git-branchless-undo/src/lib.rs
@@ -1073,7 +1073,7 @@ mod tests {
                 message: None,
             },
         ];
-        insta::assert_debug_snapshot!(extract_checkout_target(&input)?, @r###"
+        insta::assert_debug_snapshot!(extract_checkout_target(&input)?, @r#"
         (
             Some(
                 UndoCheckoutTarget {
@@ -1092,7 +1092,7 @@ mod tests {
             ),
             [],
         )
-        "###);
+        "#);
         Ok(())
     }
 }

--- a/git-branchless/tests/test_amend.rs
+++ b/git-branchless/tests/test_amend.rs
@@ -28,11 +28,11 @@ fn test_amend_with_children() -> eyre::Result<()> {
 
     {
         let (stdout, stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         branchless: processing 1 update: ref HEAD
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 7ac317b9d1dd1bbdf46e8ee692b9b9e280f28a50 --
         Attempting rebase in-memory...
         [1/1] Committed as: b51f01b create test3.txt
@@ -40,7 +40,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
         In-memory rebase succeeded.
         Restacked 1 commit.
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     git.write_file_txt("test3", "create merge conflict")?;
@@ -48,7 +48,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         HEAD detached from 96d1c37
         Changes to be committed:
           (use "git restore --staged <file>..." to unstage)
@@ -63,14 +63,14 @@ fn test_amend_with_children() -> eyre::Result<()> {
         @@ -0,0 +1 @@
         +create merge conflict
         \ No newline at end of file
-        "###);
+        "#);
     }
 
     {
         let git = git.duplicate_repo()?;
         {
             let (stdout, _stderr) = git.branchless("amend", &[])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> reset 7c5e8578f402b6b77afa143283b65fcdc9614233 --
             Attempting rebase in-memory...
             This operation would cause a merge conflict:
@@ -78,20 +78,20 @@ fn test_amend_with_children() -> eyre::Result<()> {
             To resolve merge conflicts, run: git restack --merge
             Amending without restacking descendant commits: 7ac317b create test2.txt
             Amended with 1 staged change.
-            "###);
+            ");
         }
 
         {
             let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             HEAD detached from 96d1c37
             nothing to commit, working tree clean
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc (master) create initial.txt
             |
             o 62fc20d create test1.txt
@@ -104,7 +104,7 @@ fn test_amend_with_children() -> eyre::Result<()> {
             hint: there is 1 abandoned commit in your commit graph
             hint: to fix this, run: git restack
             hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-            "###);
+            ");
         }
     }
 
@@ -123,28 +123,28 @@ fn test_amend_rename() -> eyre::Result<()> {
     git.run(&["mv", "test1.txt", "moved.txt"])?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f6b255388219264f4bcd258a3020d262c2d7b03e --
         Amended with 2 staged changes.
-        "###);
+        ");
     }
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ f6b2553 create test2.txt
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         f6b2553 create test2.txt
         :100644 100644 7432a8f 7432a8f R100	test1.txt	moved.txt
         :000000 100644 0000000 4e512d2 A	test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -162,28 +162,28 @@ fn test_amend_delete() -> eyre::Result<()> {
     git.delete_file("test1")?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ f0f0727 create test2.txt
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         f0f0727 create test2.txt
         :100644 000000 7432a8f 0000000 D	test1.txt
         :000000 100644 0000000 4e512d2 A	test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -201,33 +201,32 @@ fn test_amend_delete_only_in_index() -> eyre::Result<()> {
     git.run(&["rm", "--cached", "test1.txt"])?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f0f07277a6448cac370e6023ab379ec0c601ccfe --
         Amended with 1 staged change.
-        "###);
+        ");
     }
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ f0f0727 create test2.txt
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         f0f0727 create test2.txt
         :100644 000000 7432a8f 0000000 D	test1.txt
         :000000 100644 0000000 4e512d2 A	test2.txt
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
-        insta::assert_snapshot!(stdout, @"? test1.txt
-");
+        insta::assert_snapshot!(stdout, @"? test1.txt");
     }
 
     Ok(())
@@ -252,7 +251,7 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         HEAD detached from f777ecc
         Changes to be committed:
           (use "git restore --staged <file>..." to unstage)
@@ -282,33 +281,33 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
         -test2 contents
         +updated contents
         \ No newline at end of file
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f8e4ba1be5cefcf22e831f51b1525b0be8215a31 --
         Unstaged changes after reset:
         M	test2.txt
         Amended with 1 staged change. (Some uncommitted changes were not amended.)
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ f8e4ba1 create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         HEAD detached from f777ecc
         Changes not staged for commit:
           (use "git add <file>..." to update what will be committed)
@@ -326,34 +325,34 @@ fn test_amend_with_working_copy() -> eyre::Result<()> {
         +updated contents
         \ No newline at end of file
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 2e69581cb466962fa85e5918f29af6d2925fdd6f --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ 2e69581 create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         HEAD detached from f777ecc
         nothing to commit, working tree clean
-        "###);
+        ");
     }
 
     Ok(())
@@ -374,46 +373,44 @@ fn test_amend_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 3b98a960e6ebde39a933c25413b43bce8c0fd128 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 3b98a96 create test1.txt
-        "###);
+        ");
     }
 
     // Amend should only update tracked files.
     git.write_file_txt("newfile", "some new file")?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-        There are no uncommitted or staged changes. Nothing to amend.
-        "###);
+        insta::assert_snapshot!(stdout, @"There are no uncommitted or staged changes. Nothing to amend.");
     }
 
     git.run(&["add", "."])?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 685ef311b070a460b7c86a9aed068be563978021 --
         Amended with 1 staged change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 685ef31 create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -434,19 +431,19 @@ fn test_amend_head_with_file_with_space() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 5ccdda3c1e0dca9aa58634b37cfa9cac09e3975b --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 5ccdda3 create test file with space.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -474,8 +471,8 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -485,15 +482,15 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test2", "test2 new")?;
 
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 7e3c3a90f4d173b07747712f9c8fb7b3bb9902e3 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -503,17 +500,17 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         // test2 should still be considered "new" because last run was disabled
 
         let (stdout, _stderr) = git.branchless("amend", &["--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Including 1 new untracked file: test2.txt
         branchless: running command: <git-executable> reset c6ba988a5528776b74f8eb23d067b399762358e6 --
         Amended with 2 uncommitted changes.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
@@ -523,20 +520,20 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test3", "test3 new")?;
 
         let (stdout, _stderr) = git.branchless("amend", &["--untracked", "skip"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 new untracked file: test3.txt
         hint: this file will remain skipped and will not be automatically reconsidered
         hint: to add it yourself: git add
         hint: disable this hint by running: git config --global branchless.hint.addSkippedFiles false
         branchless: running command: <git-executable> reset 7fa9d6e9747d464c52ebf08b2477237e9685ff11 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
@@ -555,10 +552,10 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test4.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test4.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -569,20 +566,20 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test5", "test5 new")?;
 
         let (stdout, _stderr) = git.branchless("amend", &["--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 previously skipped file: test3.txt
         Including 1 new untracked file: test5.txt
         branchless: running command: <git-executable> reset dc6825a5feb1d36a022a432bc5f992ead8748a00 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test4.txt | 1 +
-            test5.txt | 1 +
-            4 files changed, 4 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test4.txt | 1 +
+        test5.txt | 1 +
+        4 files changed, 4 insertions(+)
         ");
     }
 
@@ -593,18 +590,18 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.run(&["add", "test5.txt"])?;
 
         let (stdout, _stderr) = git.branchless("amend", &["--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f734544d45f317a2ce0304ea45c3d62e0e50b1a2 --
         Amended with 1 staged change.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test4.txt | 1 +
-            test5.txt | 2 ++
-            4 files changed, 5 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test4.txt | 1 +
+        test5.txt | 2 ++
+        4 files changed, 5 insertions(+)
         ");
     }
 
@@ -613,18 +610,18 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test1", "test1 updated\n7")?; // using \n to indicate 2 added lines, below
 
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 93af47a41ecad2de9b2ffe67586df62f6850ace8 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 ++
-            test2.txt | 1 +
-            test4.txt | 1 +
-            test5.txt | 2 ++
-            4 files changed, 6 insertions(+)
+        test1.txt | 2 ++
+        test2.txt | 1 +
+        test4.txt | 1 +
+        test5.txt | 2 ++
+        4 files changed, 6 insertions(+)
         ");
     }
 
@@ -635,21 +632,21 @@ fn test_amend_with_new_untracked_files() -> eyre::Result<()> {
         git.write_file_txt("test1", "test1 updated 8")?;
 
         let (stdout, _stderr) = git.branchless("amend", &["--untracked", "add"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Skipping 1 previously skipped file: test3.txt
         Including 1 new untracked file: test6.txt
         branchless: running command: <git-executable> reset d52a98c726910a75f2b9163665d849236c918442 --
         Amended with 2 uncommitted changes.
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test4.txt | 1 +
-            test5.txt | 2 ++
-            test6.txt | 1 +
-            5 files changed, 6 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test4.txt | 1 +
+        test5.txt | 2 ++
+        test6.txt | 1 +
+        5 files changed, 6 insertions(+)
         ");
     }
 
@@ -675,28 +672,28 @@ fn test_amend_executable() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset f00ec4b5a81438f4e792ca5576a290b16fed8fdb --
         Amended with 1 staged change.
-        "###);
+        ");
     }
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ f00ec4b create test2.txt
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["show", "--raw", "--oneline", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         f00ec4b create test2.txt
         :000000 100755 0000000 0839b2e A	executable_file.txt
         :000000 100644 0000000 4e512d2 A	test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -732,8 +729,7 @@ fn test_amend_unresolved_merge_conflict() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @"Cannot amend, because there are unresolved merge conflicts. Resolve the merge conflicts and try again.
-");
+        insta::assert_snapshot!(stdout, @"Cannot amend, because there are unresolved merge conflicts. Resolve the merge conflicts and try again.");
     }
 
     Ok(())
@@ -754,7 +750,7 @@ fn test_amend_undo() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch foo
         Changes not staged for commit:
           (use "git add <file>..." to update what will be committed)
@@ -771,39 +767,39 @@ fn test_amend_undo() -> eyre::Result<()> {
         -file1 contents
         +new contents
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: processing 1 update: branch foo
         branchless: running command: <git-executable> reset foo --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         On branch foo
         nothing to commit, working tree clean
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 94b1077 (> foo) create file1.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("undo", &["-y"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Move branch foo from 94b1077 create file1.txt
                              to 94b1077 create file1.txt
@@ -832,12 +828,12 @@ fn test_amend_undo() -> eyre::Result<()> {
         |
         @ c0bdfb5 (> foo) create file1.txt
         Applied 6 inverse events.
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch foo
         Changes not staged for commit:
           (use "git add <file>..." to update what will be committed)
@@ -854,16 +850,16 @@ fn test_amend_undo() -> eyre::Result<()> {
         -file1 contents
         +new contents
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ c0bdfb5 (> foo) create file1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -884,24 +880,24 @@ fn test_amend_undo_detached_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 94b10776514a5a182d920265fc3c42f2147b1201 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 94b1077 create file1.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("undo", &["-y"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Check out from 94b1077 create file1.txt
                        to c0bdfb5 create file1.txt
@@ -922,7 +918,7 @@ fn test_amend_undo_detached_head() -> eyre::Result<()> {
         |
         @ c0bdfb5 create file1.txt
         Applied 4 inverse events.
-        "###);
+        ");
     }
 
     Ok(())
@@ -939,13 +935,13 @@ fn test_amend_reparent() -> eyre::Result<()> {
     git.run(&["checkout", "HEAD~"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
         |
         o 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     git.write_file_txt("test2", "Conflicting contents\n")?;
@@ -959,7 +955,7 @@ fn test_amend_reparent() -> eyre::Result<()> {
                 "--debug-dump-rebase-plan",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526 --
         Rebase constraints before adding descendants: [
             (
@@ -1005,23 +1001,23 @@ fn test_amend_reparent() -> eyre::Result<()> {
         In-memory rebase succeeded.
         Restacked 1 commit.
         Amended with 1 staged change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 3d8543b create test1.txt
         |
         o e0d5305 create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 3d8543b87d55c5b7995935e18e05cb6c399fb526
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0100
@@ -1042,13 +1038,13 @@ fn test_amend_reparent() -> eyre::Result<()> {
         +++ b/test2.txt
         @@ -0,0 +1 @@
         +Conflicting contents
-        "###);
+        ");
     }
 
     git.branchless("next", &[])?;
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit e0d53059b0c1f7fa277f8206a3ec45b93d82ad4f
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0200
@@ -1062,7 +1058,7 @@ fn test_amend_reparent() -> eyre::Result<()> {
         @@ -1 +1 @@
         -Conflicting contents
         +test2 contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -1083,7 +1079,7 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
     git.run(&["merge", &test3_oid.to_string(), "--strategy-option=ours"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -1098,11 +1094,11 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         | & (merge) 402c2e6 create test3.txt
         |/
         @ 90403aa Merge commit '402c2e6c16e2861d57d7fb6a20cbc5559bd00d44' into HEAD
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["diff", "HEAD^^"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         diff --git a/conflicting.txt b/conflicting.txt
         new file mode 100644
         index 0000000..076e8e3
@@ -1124,7 +1120,7 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         +++ b/test3.txt
         @@ -0,0 +1 @@
         +test3 contents
-        "###);
+        ");
     }
 
     git.run(&["checkout", &conflicting_oid.to_string()])?;
@@ -1132,7 +1128,7 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("amend", &["--reparent", "--debug-dump-rebase-plan"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> reset d517a648915434edf38114da4efd820ec6f513cf --
         Rebase plan: Some(
             RebasePlan {
@@ -1188,12 +1184,12 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         In-memory rebase succeeded.
         Restacked 2 commits.
         Amended with 1 uncommitted change.
-        "###);
+        "#);
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -1208,11 +1204,11 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         | & (merge) 99a19d2 create test3.txt
         |/
         o f66b478 Merge commit '402c2e6c16e2861d57d7fb6a20cbc5559bd00d44' into HEAD
-        "###);
+        ");
     }
     {
         let (stdout, _stderr) = git.run(&["diff", "master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         diff --git a/conflicting.txt b/conflicting.txt
         new file mode 100644
         index 0000000..e43ab8e
@@ -1227,7 +1223,7 @@ fn test_amend_reparent_merge() -> eyre::Result<()> {
         +++ b/test1.txt
         @@ -0,0 +1 @@
         +test1 contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -1246,20 +1242,20 @@ fn test_amend_no_detach_branch() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d (> foo) create test1.txt
         |
         o 96d1c37 (bar) create test2.txt
-        "###);
+        ");
     }
 
     git.write_file_txt("test1", "new contents\n")?;
 
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: processing 1 update: branch foo
         branchless: running command: <git-executable> reset foo --
         Attempting rebase in-memory...
@@ -1270,18 +1266,18 @@ fn test_amend_no_detach_branch() -> eyre::Result<()> {
         In-memory rebase succeeded.
         Restacked 1 commit.
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 7143ebc (> foo) create test1.txt
         |
         o fc597fa (bar) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1314,7 +1310,7 @@ fn test_amend_merge() -> eyre::Result<()> {
             },
         )?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 3d8543b87d55c5b7995935e18e05cb6c399fb526 --
         Attempting rebase in-memory...
         Failed to merge in-memory, trying again on-disk...
@@ -1322,12 +1318,12 @@ fn test_amend_merge() -> eyre::Result<()> {
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
         CONFLICT (add/add): Merge conflict in test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 3d8543b create test1.txt
@@ -1338,7 +1334,7 @@ fn test_amend_merge() -> eyre::Result<()> {
         hint: there is 1 abandoned commit in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
     }
 
     git.write_file_txt("test2", "Resolved contents\n")?;
@@ -1347,13 +1343,13 @@ fn test_amend_merge() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["smartlog"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 3d8543b create test1.txt
         |
         o 47a1f4a create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1375,20 +1371,20 @@ fn test_amend_move_detached_branch() -> eyre::Result<()> {
     git.write_file_txt("test1", "new contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: processing 1 update: branch foo
         branchless: running command: <git-executable> reset 7143ebcc44407b0553d9f50eaf29e0e4f0f0d6c0 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 7143ebc (foo) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1411,15 +1407,15 @@ fn test_amend_merge_commit() -> eyre::Result<()> {
     git.write_file_txt("test1", "new test1 contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset 3ebbc8fdaff7b5d5d0f1101feb3640d06b0297a2 --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -1430,12 +1426,12 @@ fn test_amend_merge_commit() -> eyre::Result<()> {
         | & (merge) 62fc20d create test1.txt
         |/
         @ 3ebbc8f Merge commit '62fc20d2a290daea0d52bdc2ed2ad4be6491010e' into HEAD
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 3ebbc8fdaff7b5d5d0f1101feb3640d06b0297a2
         Merge: fe65c1f 62fc20d
         Author: Testy McTestface <test@example.com>
@@ -1451,7 +1447,7 @@ fn test_amend_merge_commit() -> eyre::Result<()> {
         @@@ -1,0 -1,1 +1,1 @@@
          -test1 contents
         ++new test1 contents
-        "###);
+        ");
     }
 
     Ok(())
@@ -1473,29 +1469,27 @@ fn test_amend_with_branch_name_matching_file() -> eyre::Result<()> {
     // Try to amend - this should work despite the file name matching the branch name
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-        There are no uncommitted or staged changes. Nothing to amend.
-        "###);
+        insta::assert_snapshot!(stdout, @"There are no uncommitted or staged changes. Nothing to amend.");
     }
 
     // Now modify test1 and amend - this should also work
     git.write_file_txt("test1", "modified contents\n")?;
     {
         let (stdout, _stderr) = git.branchless("amend", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: processing 1 update: branch foo
         branchless: running command: <git-executable> reset foo --
         Amended with 1 uncommitted change.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ d408d49 (> foo) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1576,12 +1570,12 @@ fn test_amend_with_dirty_submodule() -> eyre::Result<()> {
             ]
         },
         {
-            insta::assert_snapshot!(stdout, @r###"
-                branchless: running command: <git-executable> reset REDACTED_SHA --
-                Unstaged changes after reset:
-                M	sm
-                Amended with 2 uncommitted changes.
-            "###);
+            insta::assert_snapshot!(stdout, @"
+            branchless: running command: <git-executable> reset REDACTED_SHA --
+            Unstaged changes after reset:
+            M	sm
+            Amended with 2 uncommitted changes.
+            ");
         }
     );
 

--- a/git-branchless/tests/test_branchless.rs
+++ b/git-branchless/tests/test_branchless.rs
@@ -14,50 +14,50 @@ fn test_commands() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 3df4b93 (master) create test.txt
         |
         @ 73b746c create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("hide", &["HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Hid commit: 73b746c create test2.txt
         To unhide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("unhide", &["HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Unhid commit: 73b746c create test2.txt
         To hide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("prev", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout master --
         :
         @ 3df4b93 (> master) create test.txt
         |
         o 73b746c create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("next", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 73b746ca864a21fc0c3dedbc937eaa9e279b73eb --
         :
         O 3df4b93 (master) create test.txt
         |
         @ 73b746c create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -102,14 +102,11 @@ fn test_sparse_checkout() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["config", "extensions.worktreeConfig"])?;
-        insta::assert_snapshot!(stdout, @r###"
-        true
-        "###);
+        insta::assert_snapshot!(stdout, @"true");
     }
 
     if let Ok(stdout) = git.smartlog() {
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     } else {
         let (stdout, _stderr) = git.branchless_with_options(
             "smartlog",
@@ -152,17 +149,15 @@ fn test_index_version_4() -> eyre::Result<()> {
     git.run(&["update-index", "--index-version=4"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc (> master) create initial.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     {
         let (stdout, _stderr) = git.branchless("switch", &["HEAD"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout HEAD --
         @ f777ecc (> master) create initial.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_bug_report.rs
+++ b/git-branchless/tests/test_bug_report.rs
@@ -35,7 +35,7 @@ fn test_bug_report() -> eyre::Result<()> {
         };
         let stdout = stdout.trim();
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         Hooks directory: `<repo-path>/.git/hooks`
 
         <details>
@@ -163,7 +163,7 @@ fn test_bug_report() -> eyre::Result<()> {
         ```
 
         </details>
-        "###);
+        "#);
     }
 
     Ok(())

--- a/git-branchless/tests/test_eventlog.rs
+++ b/git-branchless/tests/test_eventlog.rs
@@ -29,7 +29,7 @@ fn test_git_v2_31_events() -> eyre::Result<()> {
         .cloned()
         .map(redact_event_timestamp)
         .collect();
-    insta::assert_debug_snapshot!(events, @r###"
+    insta::assert_debug_snapshot!(events, @r#"
     [
         RefUpdateEvent {
             timestamp: 0.0,
@@ -149,7 +149,7 @@ fn test_git_v2_31_events() -> eyre::Result<()> {
             message: None,
         },
     ]
-    "###);
+    "#);
 
     Ok(())
 }

--- a/git-branchless/tests/test_gc.rs
+++ b/git-branchless/tests/test_gc.rs
@@ -21,27 +21,26 @@ fn test_gc() -> eyre::Result<()> {
     git.run(&["gc", "--prune=now"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     git.branchless("hide", &["62fc20d2"])?;
     {
         let (stdout, _stderr) = git.branchless("gc", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: collecting garbage
         branchless: 1 dangling reference deleted
-        "###);
+        ");
     }
 
     git.run(&["gc", "--prune=now"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (master) create initial.txt");
     }
 
     {
@@ -76,10 +75,10 @@ fn test_gc_reference_transaction() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("gc", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: collecting garbage
         branchless: 1 dangling reference deleted
-        "###);
+        ");
     }
 
     git.run(&["gc", "--prune=now"])?;
@@ -91,7 +90,7 @@ fn test_gc_reference_transaction() -> eyre::Result<()> {
         .into_iter()
         .map(redact_event_timestamp)
         .collect_vec();
-    insta::assert_debug_snapshot!(events, @r###"
+    insta::assert_debug_snapshot!(events, @r#"
     [
         RefUpdateEvent {
             timestamp: 0.0,
@@ -223,7 +222,7 @@ fn test_gc_reference_transaction() -> eyre::Result<()> {
             message: None,
         },
     ]
-    "###);
+    "#);
 
     Ok(())
 }
@@ -245,11 +244,11 @@ fn test_gc_no_init() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     git.run(&["checkout", "HEAD~"])?;
@@ -262,11 +261,11 @@ fn test_gc_no_init() -> eyre::Result<()> {
     git.run(&["checkout", &test1_oid.to_string()])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     git.run(&["checkout", "HEAD~"])?;
@@ -280,11 +279,11 @@ fn test_gc_no_init() -> eyre::Result<()> {
     git.run(&["checkout", &test1_oid.to_string()])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_git.rs
+++ b/git-branchless/tests/test_git.rs
@@ -18,9 +18,7 @@ fn test_git_is_not_a_wrapper() -> eyre::Result<()> {
 as the HOME environment variable is not set. \
 Check that the Git executable is not being wrapped in a shell script.",
             )?;
-        insta::assert_snapshot!(stderr, @r###"
-        fatal: $HOME not set
-        "###);
+        insta::assert_snapshot!(stderr, @"fatal: $HOME not set");
     }
     Ok(())
 }

--- a/git-branchless/tests/test_hide.rs
+++ b/git-branchless/tests/test_hide.rs
@@ -15,30 +15,30 @@ fn test_hide_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("hide", &[&test1_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Hid commit: 62fc20d create test1.txt
         To unhide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -59,8 +59,7 @@ fn test_hide_bad_commit() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'abc123': no commit, branch, or reference with the name 'abc123' could be found
-");
+        insta::assert_snapshot!(stderr, @"Evaluation error for expression 'abc123': no commit, branch, or reference with the name 'abc123' could be found");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -78,11 +77,11 @@ fn test_hide_already_hidden_commit() -> eyre::Result<()> {
     git.branchless("hide", &[&test1_oid.to_string()])?;
     {
         let (stdout, _stderr) = git.branchless("hide", &[&test1_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Hid commit: 62fc20d create test1.txt
         (It was already hidden, so this operation had no effect.)
         To unhide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     Ok(())
@@ -99,11 +98,11 @@ fn test_hide_current_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         % 3df4b93 (manually hidden) create test.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -125,13 +124,13 @@ fn test_hidden_commit_with_head_as_child() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         x 62fc20d (manually hidden) create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -153,10 +152,10 @@ fn test_hide_master_commit_with_hidden_children() -> eyre::Result<()> {
     git.branchless("hide", &[&test3_oid.to_string()])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 20230db (> master) create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -174,29 +173,28 @@ fn test_branches_always_visible() -> eyre::Result<()> {
     git.run(&["checkout", "master"])?;
 
     let (stdout, _stderr) = git.branchless("hide", &["--no-delete-branches", "test", "test^"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     Hid commit: 62fc20d create test1.txt
     Hid commit: 96d1c37 create test2.txt
     Abandoned 1 branch: test
     To unhide these 2 commits, run: git undo
-    "###);
+    ");
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         x 62fc20d (manually hidden) create test1.txt
         |
         x 96d1c37 (manually hidden) (test) create test2.txt
-        "###);
+        ");
     }
 
     git.run(&["branch", "-D", "test"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     Ok(())
@@ -214,19 +212,17 @@ fn test_hide_delete_branches() -> eyre::Result<()> {
     git.run(&["checkout", "master"])?;
 
     let (stdout, _stderr) = git.branchless("hide", &["test", "test^"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     Hid commit: 62fc20d create test1.txt
     Hid commit: 96d1c37 create test2.txt
     branchless: processing 1 update: branch test
     Deleted 1 branch: test
     To unhide these 2 commits and restore 1 branch, run: git undo
-    "###);
+    ");
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc (> master) create initial.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     git.branchless_with_options(
@@ -240,13 +236,13 @@ fn test_hide_delete_branches() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         o 96d1c37 (test) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -269,30 +265,28 @@ fn test_hide_delete_multiple_branches() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @ f777ecc (> master) create initial.txt
         |\
         | o 62fc20d (test-def) create test1.txt
         |
         o fe65c1f (test-abc) create test2.txt
-        "###);
+        ");
     }
 
     let (stdout, _stderr) =
         git.branchless("hide", &[&test1_oid.to_string(), &test2_oid.to_string()])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     Hid commit: 62fc20d create test1.txt
     Hid commit: fe65c1f create test2.txt
     branchless: processing 2 updates: branch test-abc, branch test-def
     Deleted 2 branches: test-abc, test-def
     To unhide these 2 commits and restore 2 branches, run: git undo
-    "###);
+    ");
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
-        @ f777ecc (> master) create initial.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     Ok(())
@@ -308,22 +302,22 @@ fn test_hide_delete_checked_out_branch() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let (stdout, _stderr) = git.branchless("hide", &["test"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     Hid commit: 96d1c37 create test2.txt
     branchless: processing 1 update: branch test
     Deleted 1 branch: test
     To unhide this 1 commit and restore 1 branch, run: git undo
-    "###);
+    ");
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         % 96d1c37 (manually hidden) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -341,40 +335,40 @@ fn test_unhide() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("unhide", &[&test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Unhid commit: 96d1c37 create test2.txt
         (It was not hidden, so this operation had no effect.)
         To hide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     git.branchless("hide", &[&test2_oid.to_string()])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("unhide", &[&test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Unhid commit: 96d1c37 create test2.txt
         To hide this 1 commit, run: git undo
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         o 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -393,7 +387,7 @@ fn test_hide_recursive() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -401,39 +395,39 @@ fn test_hide_recursive() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         o 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("hide", &["-r", &test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Hid commit: 96d1c37 create test2.txt
         Hid commit: 70deb1e create test3.txt
         To unhide these 2 commits, run: git undo
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("unhide", &["-r", &test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Unhid commit: 96d1c37 create test2.txt
         Unhid commit: 70deb1e create test3.txt
         To hide these 2 commits, run: git undo
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc (> master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -441,7 +435,7 @@ fn test_hide_recursive() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         o 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -476,10 +470,10 @@ fn test_smartlog_active_non_head_main_branch_commit() -> eyre::Result<()> {
         cloned_repo.branchless("unhide", &[&test1_oid.to_string()])?;
 
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 70deb1e (> master) create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -507,14 +501,14 @@ fn test_smartlog_show_hidden_commits() -> eyre::Result<()> {
             ],
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         @ 62fc20d (master) create test1.txt
         |\
         | x cb8137a (manually hidden) amended test2
         |
         x 96d1c37 (rewritten as cb8137ad) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -552,7 +546,7 @@ fn test_smartlog_show_only_branches() -> eyre::Result<()> {
     // branch, hidden branch and non-branch head are visible; hidden non-branch head is not
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -567,13 +561,13 @@ fn test_smartlog_show_only_branches() -> eyre::Result<()> {
         | o e8b6a38 create test8.txt
         |
         @ 1b854ed (> master) create test9.txt
-        "###);
+        ");
     }
 
     // just branches (normal and hidden) but no non-branch heads
     {
         let (stdout, _stderr) = git.branchless("smartlog", &["branches()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -584,7 +578,7 @@ fn test_smartlog_show_only_branches() -> eyre::Result<()> {
         : x a248207 (manually hidden) (branch-4) create test4.txt
         :
         @ 1b854ed (> master) create test9.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_hooks.rs
+++ b/git-branchless/tests/test_hooks.rs
@@ -21,11 +21,11 @@ fn test_abandoned_commit_message() -> eyre::Result<()> {
 
     {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 2 updates: branch master, ref HEAD
         branchless: processed commit: 9e8dbe9 amend test1
         branchless: processing 1 rewritten commit
-        "###);
+        ");
     }
 
     git.commit_file("test2", 2)?;
@@ -34,7 +34,7 @@ fn test_abandoned_commit_message() -> eyre::Result<()> {
 
     {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1 again"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: c1e22fd amend test1 again
         branchless: processing 1 rewritten commit
@@ -46,7 +46,7 @@ fn test_abandoned_commit_message() -> eyre::Result<()> {
         branchless:   - git hide [<commit>...]: hide the commits from the smartlog
         branchless:   - git undo: undo the operation
         hint: disable this hint by running: git config --global branchless.hint.restackWarnAbandoned false
-        "###);
+        ");
     }
 
     Ok(())
@@ -67,7 +67,7 @@ fn test_abandoned_branch_message() -> eyre::Result<()> {
 
     {
         let (_stdout, stderr) = git.run(&["commit", "--amend", "-m", "amend test1"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: ref HEAD
         branchless: processed commit: 9e8dbe9 amend test1
         branchless: processing 1 rewritten commit
@@ -79,7 +79,7 @@ fn test_abandoned_branch_message() -> eyre::Result<()> {
         branchless:   - git hide [<commit>...]: hide the commits from the smartlog
         branchless:   - git undo: undo the operation
         hint: disable this hint by running: git config --global branchless.hint.restackWarnAbandoned false
-        "###);
+        ");
     }
 
     Ok(())
@@ -105,12 +105,12 @@ fn test_fixup_no_abandoned_commit_message() -> eyre::Result<()> {
     {
         let (_stdout, stderr) = git.run(&["rebase", "-i", "master", "--autosquash"])?;
         if git_version < GitVersion(2, 35, 0) {
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
             branchless: processing 3 rewritten commits
             Successfully rebased and updated detached HEAD.
-            "###);
+            ");
         }
     }
 
@@ -135,7 +135,7 @@ fn test_rebase_individual_commit() -> eyre::Result<()> {
     {
         let (_stdout, stderr) = git.run(&["rebase", "master", "HEAD^"])?;
         if git_version < GitVersion(2, 35, 0) {
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 rewritten commit
             branchless: This operation abandoned 1 commit!
@@ -147,7 +147,7 @@ fn test_rebase_individual_commit() -> eyre::Result<()> {
             branchless:   - git undo: undo the operation
             hint: disable this hint by running: git config --global branchless.hint.restackWarnAbandoned false
             Successfully rebased and updated detached HEAD.
-            "###);
+            ");
         }
     }
 
@@ -167,8 +167,7 @@ fn test_interactive_rebase_noop() -> eyre::Result<()> {
     {
         let (_stdout, stderr) = git.run(&["rebase", "-i", "master"])?;
         if git_version < GitVersion(2, 35, 0) {
-            insta::assert_snapshot!(stderr, @"Successfully rebased and updated detached HEAD.
-");
+            insta::assert_snapshot!(stderr, @"Successfully rebased and updated detached HEAD.");
         }
     }
 
@@ -210,10 +209,10 @@ fn test_pre_auto_gc() -> eyre::Result<()> {
         stdout,
         stderr
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     branchless: collecting garbage
     branchless: 0 dangling references deleted
-    "###);
+    ");
 
     Ok(())
 }
@@ -242,7 +241,7 @@ fn test_merge_commit_recorded() -> eyre::Result<()> {
         .cloned()
         .map(redact_event_timestamp)
         .collect();
-    insta::assert_debug_snapshot!(events, @r###"
+    insta::assert_debug_snapshot!(events, @r#"
     [
         RefUpdateEvent {
             timestamp: 0.0,
@@ -338,7 +337,7 @@ fn test_merge_commit_recorded() -> eyre::Result<()> {
             commit_oid: NonZeroOid(91a5ccb4feefba38b0ffa4911c5c3f6c225f662e),
         },
     ]
-    "###);
+    "#);
 
     Ok(())
 }
@@ -355,32 +354,30 @@ fn test_git_am_recorded() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["am", "0001-create-test1.txt.patch"])?;
-        insta::assert_snapshot!(stdout, @r###"
-        Applying: create test1.txt
-        "###);
+        insta::assert_snapshot!(stdout, @"Applying: create test1.txt");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 047b7ad create test1.txt
         |
         o 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     git.run(&["reset", "--hard", "HEAD^"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @ f777ecc (master) create initial.txt
         |\
         | o 047b7ad create test1.txt
         |
         o 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -405,11 +402,11 @@ fn test_symbolic_transaction_ref() -> eyre::Result<()> {
         // An upcoming version post-2.45.x introduces symbolic transaction refs;
         // before the commit that introduces the fix along with this test,
         // they were not properly handled.
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: branch newbranch
         Switched to a new branch 'newbranch'
         branchless: processing checkout
-        "###);
+        ");
     }
 
     Ok(())
@@ -445,11 +442,11 @@ fn test_git_rebase_multiple_fixup_does_not_strand_commits() -> eyre::Result<()> 
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 8777bab create test1.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -49,13 +49,12 @@ echo Hello, world
 
     {
         let (stdout, stderr) = git.run(&["commit", "--allow-empty", "-m", "test"])?;
-        insta::assert_snapshot!(stdout, @"[master 4cd1a9b] test
-");
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stdout, @"[master 4cd1a9b] test");
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 2 updates: branch master, ref HEAD
         Hello, world
         branchless: processed commit: 4cd1a9b test
-        "###);
+        ");
     }
 
     Ok(())
@@ -69,14 +68,12 @@ fn test_alias_installed() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     {
         let (stdout, _stderr) = git.run(&["sl"])?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> master) create initial.txt");
     }
 
     Ok(())
@@ -179,7 +176,7 @@ fn test_old_git_version_warning() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("init", &[])?;
         let (version_str, _stderr) = git.run(&["version"])?;
         let stdout = stdout.replace(version_str.trim(), "<git version output>");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Created config file at <repo-path>/.git/branchless/config
         Auto-detected your main branch as: master
         If this is incorrect, run: git branchless init --main-branch <branch>
@@ -197,7 +194,7 @@ fn test_old_git_version_warning() -> eyre::Result<()> {
         the branchless workflow will work properly.
         Successfully installed git-branchless.
         To uninstall, run: git branchless init --uninstall
-        "###);
+        ");
     }
 
     Ok(())
@@ -220,14 +217,14 @@ fn test_init_basic() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("init", &[])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Created config file at <repo-path>/.git/branchless/config
         Auto-detected your main branch as: master
         If this is incorrect, run: git branchless init --main-branch <branch>
         Installing hooks: post-applypatch, post-checkout, post-commit, post-merge, post-rewrite, pre-auto-gc, reference-transaction
         Successfully installed git-branchless.
         To uninstall, run: git branchless init --uninstall
-        "###);
+        ");
     }
 
     Ok(())
@@ -259,7 +256,7 @@ fn test_init_prompt_for_main_branch() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Created config file at <repo-path>/.git/branchless/config
         Your main branch name could not be auto-detected!
         Examples of a main branch: master, main, trunk, etc.
@@ -267,13 +264,12 @@ fn test_init_prompt_for_main_branch() -> eyre::Result<()> {
         Enter the name of your main branch: Installing hooks: post-applypatch, post-checkout, post-commit, post-merge, post-rewrite, pre-auto-gc, reference-transaction
         Successfully installed git-branchless.
         To uninstall, run: git branchless init --uninstall
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ f777ecc (> bespoke) create initial.txt
-");
+        insta::assert_snapshot!(stdout, @"@ f777ecc (> bespoke) create initial.txt");
     }
 
     Ok(())
@@ -305,7 +301,7 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
     let stderr = trim_lines(stderr);
     let stderr = console::strip_ansi_codes(&stderr);
     let stderr = location_trace_re.replace_all(&stderr, "some/file/path.rs:123");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     The application panicked (crashed).
     Message:  A fatal error occurred:
        0: Could not find repository main branch
@@ -339,7 +335,7 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
     Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
     Run with RUST_BACKTRACE=full to include source snippets.
-    "###);
+    "#);
     insta::assert_snapshot!(stdout, @"");
 
     Ok(())
@@ -355,10 +351,10 @@ fn test_init_uninstall() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("init", &["--uninstall"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Removing config file: <repo-path>/.git/branchless/config
         Uninstalling hooks: post-applypatch, post-checkout, post-commit, post-merge, post-rewrite, pre-auto-gc, reference-transaction
-        "###);
+        ");
     }
 
     Ok(())
@@ -410,11 +406,11 @@ fn test_help_flag() -> eyre::Result<()> {
             },
         )?;
         let first_line = stdout.lines().next();
-        insta::assert_debug_snapshot!(first_line, @r###"
+        insta::assert_debug_snapshot!(first_line, @r#"
         Some(
             "`smartlog` command",
         )
-        "###);
+        "#);
     }
 
     {
@@ -427,11 +423,11 @@ fn test_help_flag() -> eyre::Result<()> {
             },
         )?;
         let first_line = stdout.lines().next();
-        insta::assert_debug_snapshot!(first_line, @r###"
+        insta::assert_debug_snapshot!(first_line, @r#"
         Some(
             "Initialize the branchless workflow for this repository",
         )
-        "###);
+        "#);
     }
 
     Ok(())
@@ -457,10 +453,10 @@ fn test_init_explicit_main_branch_name() -> eyre::Result<()> {
         git.commit_file("test1", 1)?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (> foo) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -484,10 +480,10 @@ fn test_init_repo_default_branch() -> eyre::Result<()> {
         git.commit_file("test1", 1)?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (> repo-default-branch) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -507,7 +503,7 @@ fn test_hide_branchless_refs_from_git_log() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["log", "--decorate"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e (HEAD -> master, refs/foo/bar)
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0100
@@ -519,7 +515,7 @@ fn test_hide_branchless_refs_from_git_log() -> eyre::Result<()> {
         Date:   Thu Oct 29 12:34:56 2020 +0000
 
             create initial.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -542,7 +538,7 @@ fn test_init_core_hooks_path_warning() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("init", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Created config file at <repo-path>/.git/branchless/config
         Auto-detected your main branch as: master
         If this is incorrect, run: git branchless init --main-branch <branch>
@@ -552,7 +548,7 @@ fn test_init_core_hooks_path_warning() -> eyre::Result<()> {
         The Git hooks above may have been installed to an unexpected global location.
         Successfully installed git-branchless.
         To uninstall, run: git branchless init --uninstall
-        "###);
+        ");
     }
 
     Ok(())
@@ -634,10 +630,10 @@ fn test_init_worktree() -> eyre::Result<()> {
             .and_then(|name| name.to_str())
             .unwrap();
         let stdout = stdout.replace(repo_name, "<repo-name>");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -663,124 +659,124 @@ fn test_install_man_pages() -> eyre::Result<()> {
             ]
         },
         {
-            insta::assert_snapshot!(man_page_contents, @r###"
-                .ie \n(.g .ds Aq \(aq
-                .el .ds Aq '
-                .TH git-branchless 1  "git-branchless REDACTED_VERSION" 
-                .SH NAME
-                git\-branchless \- Branchless workflow for Git
-                .SH SYNOPSIS
-                \fBgit\-branchless\fR [\fB\-C \fR] [\fB\-\-color\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
-                .SH DESCRIPTION
-                Branchless workflow for Git.
-                .PP
-                See the documentation at https://github.com/arxanas/git\-branchless/wiki.
-                .SH OPTIONS
-                .TP
-                \fB\-C\fR \fI<WORKING_DIRECTORY>\fR
-                Change to the given directory before executing the rest of the program. (The option is called `\-C` for symmetry with Git.)
-                .TP
-                \fB\-\-color\fR \fI<COLOR>\fR
-                Flag to force enable or disable terminal colors
-                .br
+            insta::assert_snapshot!(man_page_contents, @r#"
+            .ie \n(.g .ds Aq \(aq
+            .el .ds Aq '
+            .TH git-branchless 1  "git-branchless REDACTED_VERSION" 
+            .SH NAME
+            git\-branchless \- Branchless workflow for Git
+            .SH SYNOPSIS
+            \fBgit\-branchless\fR [\fB\-C \fR] [\fB\-\-color\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+            .SH DESCRIPTION
+            Branchless workflow for Git.
+            .PP
+            See the documentation at https://github.com/arxanas/git\-branchless/wiki.
+            .SH OPTIONS
+            .TP
+            \fB\-C\fR \fI<WORKING_DIRECTORY>\fR
+            Change to the given directory before executing the rest of the program. (The option is called `\-C` for symmetry with Git.)
+            .TP
+            \fB\-\-color\fR \fI<COLOR>\fR
+            Flag to force enable or disable terminal colors
+            .br
 
-                .br
-                \fIPossible values:\fR
-                .RS 14
-                .IP \(bu 2
-                auto: Automatically determine whether to display colors from the terminal and environment variables. This is the default behavior
-                .IP \(bu 2
-                always: Always display terminal colors
-                .IP \(bu 2
-                never: Never display terminal colors
-                .RE
-                .TP
-                \fB\-h\fR, \fB\-\-help\fR
-                Print help (see a summary with \*(Aq\-h\*(Aq)
-                .TP
-                \fB\-V\fR, \fB\-\-version\fR
-                Print version
-                .SH SUBCOMMANDS
-                .TP
-                git\-branchless\-amend(1)
-                Amend the current HEAD commit
-                .TP
-                git\-branchless\-bug\-report(1)
-                Gather information about recent operations to upload as part of a bug report
-                .TP
-                git\-branchless\-difftool(1)
-                Use the partial commit selector UI as a Git\-compatible difftool; see git\-difftool(1) for more information on Git difftools
-                .TP
-                git\-branchless\-gc(1)
-                Run internal garbage collection
-                .TP
-                git\-branchless\-hide(1)
-                Hide the provided commits from the smartlog
-                .TP
-                git\-branchless\-init(1)
-                Initialize the branchless workflow for this repository
-                .TP
-                git\-branchless\-install\-man\-pages(1)
-                Install git\-branchless\*(Aqs man\-pages to the given path
-                .TP
-                git\-branchless\-move(1)
-                Move a subtree of commits from one location to another
-                .TP
-                git\-branchless\-next(1)
-                Move to a later commit in the current stack
-                .TP
-                git\-branchless\-prev(1)
-                Move to an earlier commit in the current stack
-                .TP
-                git\-branchless\-query(1)
-                Query the commit graph using the "revset" language and print matching commits
-                .TP
-                git\-branchless\-repair(1)
-                Restore internal invariants by reconciling the internal operation log with the state of the Git repository
-                .TP
-                git\-branchless\-restack(1)
-                Fix up commits abandoned by a previous rewrite operation
-                .TP
-                git\-branchless\-record(1)
-                Create a commit by interactively selecting which changes to include
-                .TP
-                git\-branchless\-reword(1)
-                Reword commits
-                .TP
-                git\-branchless\-smartlog(1)
-                `smartlog` command
-                .TP
-                git\-branchless\-split(1)
-                Split commits
-                .TP
-                git\-branchless\-submit(1)
-                Push commits to a remote
-                .TP
-                git\-branchless\-switch(1)
-                Switch to the provided branch or commit
-                .TP
-                git\-branchless\-sync(1)
-                Move any local commit stacks on top of the main branch
-                .TP
-                git\-branchless\-test(1)
-                Run a command on each commit in a given set and aggregate the results
-                .TP
-                git\-branchless\-undo(1)
-                Browse or return to a previous state of the repository
-                .TP
-                git\-branchless\-unhide(1)
-                Unhide previously\-hidden commits from the smartlog
-                .TP
-                git\-branchless\-wrap(1)
-                Wrap a Git command inside a branchless transaction
-                .TP
-                git\-branchless\-help(1)
-                Print this message or the help of the given subcommand(s)
-                .SH VERSION
-                REDACTED_VERSION
-                .SH AUTHORS
-                Waleed Khan <me@waleedkhan.name>
-                "###);
+            .br
+            \fIPossible values:\fR
+            .RS 14
+            .IP \(bu 2
+            auto: Automatically determine whether to display colors from the terminal and environment variables. This is the default behavior
+            .IP \(bu 2
+            always: Always display terminal colors
+            .IP \(bu 2
+            never: Never display terminal colors
+            .RE
+            .TP
+            \fB\-h\fR, \fB\-\-help\fR
+            Print help (see a summary with \*(Aq\-h\*(Aq)
+            .TP
+            \fB\-V\fR, \fB\-\-version\fR
+            Print version
+            .SH SUBCOMMANDS
+            .TP
+            git\-branchless\-amend(1)
+            Amend the current HEAD commit
+            .TP
+            git\-branchless\-bug\-report(1)
+            Gather information about recent operations to upload as part of a bug report
+            .TP
+            git\-branchless\-difftool(1)
+            Use the partial commit selector UI as a Git\-compatible difftool; see git\-difftool(1) for more information on Git difftools
+            .TP
+            git\-branchless\-gc(1)
+            Run internal garbage collection
+            .TP
+            git\-branchless\-hide(1)
+            Hide the provided commits from the smartlog
+            .TP
+            git\-branchless\-init(1)
+            Initialize the branchless workflow for this repository
+            .TP
+            git\-branchless\-install\-man\-pages(1)
+            Install git\-branchless\*(Aqs man\-pages to the given path
+            .TP
+            git\-branchless\-move(1)
+            Move a subtree of commits from one location to another
+            .TP
+            git\-branchless\-next(1)
+            Move to a later commit in the current stack
+            .TP
+            git\-branchless\-prev(1)
+            Move to an earlier commit in the current stack
+            .TP
+            git\-branchless\-query(1)
+            Query the commit graph using the "revset" language and print matching commits
+            .TP
+            git\-branchless\-repair(1)
+            Restore internal invariants by reconciling the internal operation log with the state of the Git repository
+            .TP
+            git\-branchless\-restack(1)
+            Fix up commits abandoned by a previous rewrite operation
+            .TP
+            git\-branchless\-record(1)
+            Create a commit by interactively selecting which changes to include
+            .TP
+            git\-branchless\-reword(1)
+            Reword commits
+            .TP
+            git\-branchless\-smartlog(1)
+            `smartlog` command
+            .TP
+            git\-branchless\-split(1)
+            Split commits
+            .TP
+            git\-branchless\-submit(1)
+            Push commits to a remote
+            .TP
+            git\-branchless\-switch(1)
+            Switch to the provided branch or commit
+            .TP
+            git\-branchless\-sync(1)
+            Move any local commit stacks on top of the main branch
+            .TP
+            git\-branchless\-test(1)
+            Run a command on each commit in a given set and aggregate the results
+            .TP
+            git\-branchless\-undo(1)
+            Browse or return to a previous state of the repository
+            .TP
+            git\-branchless\-unhide(1)
+            Unhide previously\-hidden commits from the smartlog
+            .TP
+            git\-branchless\-wrap(1)
+            Wrap a Git command inside a branchless transaction
+            .TP
+            git\-branchless\-help(1)
+            Print this message or the help of the given subcommand(s)
+            .SH VERSION
+            REDACTED_VERSION
+            .SH AUTHORS
+            Waleed Khan <me@waleedkhan.name>
+            "#);
         }
     );
     Ok(())

--- a/git-branchless/tests/test_move.rs
+++ b/git-branchless/tests/test_move.rs
@@ -35,7 +35,7 @@ fn test_move_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -44,7 +44,7 @@ fn test_move_stick() -> eyre::Result<()> {
         | @ a248207 create test4.txt
         |
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -60,7 +60,7 @@ fn test_move_stick() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e),
@@ -106,10 +106,10 @@ fn test_move_stick() -> eyre::Result<()> {
         |
         O 96d1c37 (master) create test2.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
@@ -118,7 +118,7 @@ fn test_move_stick() -> eyre::Result<()> {
         | @ a248207 create test4.txt
         |
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -141,7 +141,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
     git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -150,7 +150,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
     o 70deb1e create test3.txt
     |
     @ 355e173 create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -168,7 +168,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -177,7 +177,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
         @ a248207 create test4.txt
         |
         o 5a436ed create test2.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -195,7 +195,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e),
@@ -251,10 +251,10 @@ fn test_move_insert_stick() -> eyre::Result<()> {
         |
         o 5a436ed create test2.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -263,7 +263,7 @@ fn test_move_insert_stick() -> eyre::Result<()> {
         @ a248207 create test4.txt
         |
         o 5a436ed create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -283,7 +283,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
     git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -292,7 +292,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
     o 70deb1e create test3.txt
     |
     @ 355e173 create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -309,7 +309,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -318,7 +318,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
         | @ f57e36f create test4.txt
         |
         o 4838e49 create test3.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -335,7 +335,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -344,7 +344,7 @@ fn test_move_exact_single_stick() -> eyre::Result<()> {
         | @ f57e36f create test4.txt
         |
         o 4838e49 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -364,7 +364,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
     let test4_oid = git.commit_file("test4", 4)?;
     git.commit_file("test5", 5)?;
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -375,7 +375,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
     o 355e173 create test4.txt
     |
     @ f81d55c create test5.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -392,7 +392,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -403,7 +403,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
         | o cf5eb24 create test3.txt
         |
         @ 848121c create test5.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -420,7 +420,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -431,7 +431,7 @@ fn test_move_exact_range_stick() -> eyre::Result<()> {
         | o cf5eb24 create test3.txt
         |
         @ 848121c create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -455,7 +455,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
     git.commit_file("test8", 8)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -472,7 +472,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
     o c8933b3 create test7.txt
     |
     @ 1edbaa1 create test8.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -489,7 +489,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -506,7 +506,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
         o b1f9efa create test5.txt
         |
         o 8577a96 create test7.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -523,7 +523,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -540,7 +540,7 @@ fn test_move_exact_noncontiguous_commits_stick() -> eyre::Result<()> {
         o b1f9efa create test5.txt
         |
         o 8577a96 create test7.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -567,7 +567,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
     git.commit_file("test11", 11)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -590,7 +590,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
     o 52ebfa0 create test10.txt
     |
     @ b22a15b create test11.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -609,7 +609,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -632,7 +632,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         o 9c7387c create test9.txt
         |
         o fed2ec4 create test10.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -651,7 +651,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -674,7 +674,7 @@ fn test_move_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         o 9c7387c create test9.txt
         |
         o fed2ec4 create test10.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -697,7 +697,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
     git.commit_file("test7", 7)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -712,7 +712,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
     o 2831fb5 create test6.txt
     |
     @ c8933b3 create test7.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -729,7 +729,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -744,7 +744,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
         o b1f9efa create test5.txt
         |
         o 500c9b3 create test6.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -761,7 +761,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -776,7 +776,7 @@ fn test_move_exact_contiguous_and_noncontiguous_stick() -> eyre::Result<()> {
         o b1f9efa create test5.txt
         |
         o 500c9b3 create test6.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -796,7 +796,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
     git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -805,7 +805,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
     o 70deb1e create test3.txt
     |
     @ 355e173 create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -823,7 +823,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -832,7 +832,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -850,7 +850,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -859,7 +859,7 @@ fn test_move_exact_insert_stick() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -880,7 +880,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
     git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -889,7 +889,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
     o 70deb1e create test3.txt
     |
     @ 355e173 create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -907,7 +907,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -916,7 +916,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -934,7 +934,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -943,7 +943,7 @@ fn test_move_exact_insert_swap() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -964,7 +964,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
     git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -973,7 +973,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
     | o 70deb1e create test3.txt
     |
     @ f57e36f create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -991,7 +991,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1000,7 +1000,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -1018,7 +1018,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1027,7 +1027,7 @@ fn test_move_exact_insert_with_siblings() -> eyre::Result<()> {
         o d742fb9 create test2.txt
         |
         @ 8fcf7dd create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1048,7 +1048,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
     git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1059,7 +1059,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
     o 355e173 create test4.txt
     |
     @ f81d55c create test5.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1077,7 +1077,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1088,7 +1088,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
         o cf5eb24 create test3.txt
         |
         @ 4acfdad create test5.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -1106,7 +1106,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1117,7 +1117,7 @@ fn test_move_insert_range_stick() -> eyre::Result<()> {
         o cf5eb24 create test3.txt
         |
         @ 4acfdad create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1144,7 +1144,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
     git.commit_file("test11", 11)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1167,7 +1167,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
     o 52ebfa0 create test10.txt
     |
     @ b22a15b create test11.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1187,7 +1187,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1210,7 +1210,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         o acad4bd create test8.txt
         |
         @ 85ceeac create test11.txt
-        "###);
+        ");
     }
 
     // --in-memory
@@ -1230,7 +1230,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1253,7 +1253,7 @@ fn test_move_insert_exact_noncontiguous_ranges_stick() -> eyre::Result<()> {
         o acad4bd create test8.txt
         |
         @ 85ceeac create test11.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1292,7 +1292,7 @@ fn test_move_tree() -> eyre::Result<()> {
         )?;
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
@@ -1303,7 +1303,7 @@ fn test_move_tree() -> eyre::Result<()> {
             | @ b1f9efa create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -1315,7 +1315,7 @@ fn test_move_tree() -> eyre::Result<()> {
         )?;
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
@@ -1326,7 +1326,7 @@ fn test_move_tree() -> eyre::Result<()> {
             | @ b1f9efa create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -1347,14 +1347,14 @@ fn test_move_insert_in_place() -> eyre::Result<()> {
     git.commit_file("test3", 3)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
     | o 96d1c37 create test2.txt
     |
     @ 4838e49 create test3.txt
-    "###);
+    ");
 
     git.branchless(
         "move",
@@ -1368,14 +1368,14 @@ fn test_move_insert_in_place() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1399,7 +1399,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
     let test4_oid = git.commit_file("test4", 4)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -1408,7 +1408,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
     o 4838e49 create test3.txt
     |
     @ a248207 create test4.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1426,7 +1426,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
         )?;
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d (master) create test1.txt
             |
@@ -1435,7 +1435,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
             | o 44352d0 create test2.txt
             |
             o 0a4a701 create test3.txt
-            "###);
+            ");
         }
     }
 
@@ -1453,7 +1453,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
         )?;
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d (master) create test1.txt
             |
@@ -1462,7 +1462,7 @@ fn test_move_insert_tree() -> eyre::Result<()> {
             | o 44352d0 create test2.txt
             |
             o 0a4a701 create test3.txt
-            "###);
+            ");
         }
     }
 
@@ -1485,7 +1485,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
     git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1496,7 +1496,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
     | o 355e173 create test4.txt
     |
     @ 9ea1b36 create test5.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1513,7 +1513,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -1524,7 +1524,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
         | o cf5eb24 create test3.txt
         |
         @ ea7aa06 create test5.txt
-        "###);
+        ");
     }
 
     // in-memory
@@ -1540,7 +1540,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -1551,7 +1551,7 @@ fn test_move_exact_range_tree() -> eyre::Result<()> {
         | o cf5eb24 create test3.txt
         |
         @ ea7aa06 create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1573,7 +1573,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
     let test5_oid = git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1584,7 +1584,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
     | o 355e173 create test4.txt
     |
     @ 9ea1b36 create test5.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1601,7 +1601,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1612,7 +1612,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
         | @ 9ea1b36 create test5.txt
         |
         o f57e36f create test4.txt
-        "###);
+        ");
     }
 
     // in-memory
@@ -1628,7 +1628,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1639,7 +1639,7 @@ fn test_move_exact_range_with_leaves() -> eyre::Result<()> {
         | @ 9ea1b36 create test5.txt
         |
         o f57e36f create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1661,7 +1661,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
     let test5_oid = git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1672,7 +1672,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
     | o 355e173 create test4.txt
     |
     @ 9ea1b36 create test5.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1689,7 +1689,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1700,7 +1700,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
         | o f57e36f create test4.txt
         |
         @ d2e18e3 create test5.txt
-        "###);
+        ");
     }
 
     // in-memory
@@ -1716,7 +1716,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1727,7 +1727,7 @@ fn test_move_exact_range_just_leaves() -> eyre::Result<()> {
         | o f57e36f create test4.txt
         |
         @ d2e18e3 create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1751,7 +1751,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
     git.commit_file("test7", 7)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1766,7 +1766,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
     o eaf39e9 create test6.txt
     |
     @ 0094d46 create test7.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1783,7 +1783,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1798,7 +1798,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
         | o d2e18e3 create test5.txt
         |
         @ 66602bc create test7.txt
-        "###);
+        ");
     }
 
     // in-memory
@@ -1814,7 +1814,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1829,7 +1829,7 @@ fn test_move_exact_range_with_multiple_heads() -> eyre::Result<()> {
         | o d2e18e3 create test5.txt
         |
         @ 66602bc create test7.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1852,7 +1852,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
     let test6_oid = git.commit_file("test6", 6)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -1865,7 +1865,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
     | o f81d55c create test5.txt
     |
     @ eaf39e9 create test6.txt
-    "###);
+    ");
 
     // --on-disk
     {
@@ -1882,7 +1882,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1895,7 +1895,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
         | @ eaf39e9 create test6.txt
         |
         o f57e36f create test4.txt
-        "###);
+        ");
     }
 
     // in-memory
@@ -1911,7 +1911,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
         )?;
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |
@@ -1924,7 +1924,7 @@ fn test_move_exact_range_with_leaves_and_descendent_components() -> eyre::Result
         | @ eaf39e9 create test6.txt
         |
         o f57e36f create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1948,7 +1948,7 @@ fn test_move_exact_ranges_with_merge_commits_betwixt_not_supported() -> eyre::Re
     let test6_oid = git.commit_file("test6", 6)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -1966,7 +1966,7 @@ fn test_move_exact_ranges_with_merge_commits_betwixt_not_supported() -> eyre::Re
     o 01a3b9b Merge commit '70deb1e28791d8e7dd5a1f0c871a51b91282562f' into HEAD
     |
     @ 8fb4e4a create test6.txt
-    "###);
+    ");
 
     let (stdout, stderr) = git.branchless_with_options(
         "move",
@@ -1982,11 +1982,11 @@ fn test_move_exact_ranges_with_merge_commits_betwixt_not_supported() -> eyre::Re
         },
     )?;
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     This operation cannot be completed because the commit at 8fb4e4aded06dd3b97723794474832a928370f9a
     has multiple possible parents also being moved. Please retry this operation
     without this commit, or with only 1 possible parent.
-    "###);
+    ");
 
     Ok(())
 }
@@ -2010,7 +2010,7 @@ fn test_move_exact_range_one_side_of_merged_stack_without_base_and_merge_commits
     git.run(&["merge", &test4_oid.to_string()])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -2028,7 +2028,7 @@ fn test_move_exact_range_one_side_of_merged_stack_without_base_and_merge_commits
     | & (merge) 355e173 create test4.txt
     |/
     @ 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-    "###);
+    ");
 
     git.branchless(
         "move",
@@ -2043,7 +2043,7 @@ fn test_move_exact_range_one_side_of_merged_stack_without_base_and_merge_commits
     let stdout = git.smartlog()?;
     // FIXME: This output is correct except for a known issue involving moving
     // merge commits. (See `test_move_merge_commit_both_parents`.)
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -2068,7 +2068,7 @@ fn test_move_exact_range_one_side_of_merged_stack_without_base_and_merge_commits
     hint: there is 1 abandoned commit in your commit graph
     hint: to fix this, run: git restack
     hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-    "###);
+    ");
 
     Ok(())
 }
@@ -2092,7 +2092,7 @@ fn test_move_exact_range_one_side_of_merged_stack_including_base_and_merge_commi
     git.run(&["merge", &test4_oid.to_string()])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -2110,7 +2110,7 @@ fn test_move_exact_range_one_side_of_merged_stack_including_base_and_merge_commi
     | & (merge) 355e173 create test4.txt
     |/
     @ 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-    "###);
+    ");
 
     git.branchless(
         "move",
@@ -2124,7 +2124,7 @@ fn test_move_exact_range_one_side_of_merged_stack_including_base_and_merge_commi
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -2142,7 +2142,7 @@ fn test_move_exact_range_one_side_of_merged_stack_including_base_and_merge_commi
     | & (merge) 355e173 create test4.txt
     |/
     @ 3774d8f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-    "###);
+    ");
 
     Ok(())
 }
@@ -2165,7 +2165,7 @@ fn test_move_exact_range_two_partial_components_of_merged_stack() -> eyre::Resul
     git.run(&["merge", &test4_oid.to_string()])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |
@@ -2183,7 +2183,7 @@ fn test_move_exact_range_two_partial_components_of_merged_stack() -> eyre::Resul
     | & (merge) 355e173 create test4.txt
     |/
     @ 178e00f Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-    "###);
+    ");
 
     git.branchless(
         "move",
@@ -2197,7 +2197,7 @@ fn test_move_exact_range_two_partial_components_of_merged_stack() -> eyre::Resul
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -2215,7 +2215,7 @@ fn test_move_exact_range_two_partial_components_of_merged_stack() -> eyre::Resul
     | & (merge) d15eb08 Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
     |
     o ea7aa06 create test5.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -2253,14 +2253,14 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
             : o 96d1c37 create test2.txt
             :
             @ a248207 (> master) create test4.txt
-            "###);
+            ");
         }
     }
 
@@ -2279,7 +2279,7 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
                     &test1_oid.to_string(),
                 ],
             )?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             Rebase plan: Some(
                 RebasePlan {
                     first_dest_oid: NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e),
@@ -2324,19 +2324,19 @@ fn test_move_with_source_not_in_smartlog() -> eyre::Result<()> {
             :
             @ a248207 (> master) create test4.txt
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
             : o 96d1c37 create test2.txt
             :
             @ a248207 (> master) create test4.txt
-            "###);
+            ");
         }
     }
 
@@ -2367,12 +2367,12 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
         - (1 conflicting file) e85d25c create conflict.txt
         To resolve merge conflicts, retry this operation with the --merge option.
-        "###);
+        ");
     }
 
     {
@@ -2391,7 +2391,7 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
         )?;
         let stdout = remove_rebase_lines(stdout);
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(202143f2fdfc785285ab097422f6a695ff1d93cb),
@@ -2420,28 +2420,28 @@ fn test_move_merge_conflict() -> eyre::Result<()> {
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
         CONFLICT (add/add): Merge conflict in conflict.txt
-        "###);
+        ");
     }
 
     git.resolve_file("conflict", "resolved")?;
     {
         let (stdout, _stderr) = git.run(&["rebase", "--continue"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD 42951b5] create conflict.txt
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ 202143f create conflict.txt
         |
         o 42951b5 create conflict.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -2465,7 +2465,7 @@ fn test_move_base() -> eyre::Result<()> {
             "move",
             &["--debug-dump-rebase-plan", "--base", &test3_oid.to_string()],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(bf0d52a607f693201512a43b6b5a70b2a275e0ad),
@@ -2509,19 +2509,19 @@ fn test_move_base() -> eyre::Result<()> {
         |
         o cf5eb24 create test3.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ bf0d52a (> master) create test4.txt
         |
         o 44352d0 create test2.txt
         |
         o cf5eb24 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -2548,14 +2548,14 @@ fn test_move_base_shared() -> eyre::Result<()> {
     {
         let (stdout, stderr) =
             git.branchless("move", &["-b", "HEAD", "-d", &test2_oid.to_string()])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Previous HEAD position was a248207 create test4.txt
         branchless: processing 1 update: ref HEAD
         HEAD is now at 355e173 create test4.txt
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 70deb1e create test3.txt
         [2/2] Committed as: 355e173 create test4.txt
@@ -2571,12 +2571,12 @@ fn test_move_base_shared() -> eyre::Result<()> {
         |
         @ 355e173 create test4.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -2586,7 +2586,7 @@ fn test_move_base_shared() -> eyre::Result<()> {
         o 70deb1e create test3.txt
         |
         @ 355e173 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -2605,7 +2605,7 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("move", &["--debug-dump-rebase-plan", "-d", "master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e),
@@ -2637,17 +2637,17 @@ fn test_move_checkout_new_head() -> eyre::Result<()> {
         |
         @ 96d1c37 create test2.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -2681,7 +2681,7 @@ fn test_move_branch() -> eyre::Result<()> {
                 "-f",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(96d1c37a3d4363611c49f7e52186e189a04c531f),
@@ -2712,15 +2712,15 @@ fn test_move_branch() -> eyre::Result<()> {
         :
         @ 70deb1e (> master) create test3.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 70deb1e (> master) create test3.txt
-        "###);
+        ");
     }
 
     {
@@ -2755,24 +2755,24 @@ fn test_move_base_onto_head() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         This operation failed because it would introduce a cycle:
         ,-> 70deb1e create test3.txt
         |   96d1c37 create test2.txt
         `-- 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -2802,12 +2802,12 @@ fn test_move_force_in_memory() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
         - (1 conflicting file) 081b474 conflicting test2
         To resolve merge conflicts, retry this operation with the --merge option.
-        "###);
+        ");
     }
 
     {
@@ -2819,13 +2819,13 @@ fn test_move_force_in_memory() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         error: the argument '--in-memory' cannot be used with '--merge'
 
         Usage: git-branchless move --dest <DEST> --in-memory
 
         For more information, try '--help'.
-        "###);
+        ");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -2846,34 +2846,34 @@ fn test_move_force_in_memory_dry_run() -> eyre::Result<()> {
         git.commit_file("test3", 3)?;
 
         let starting_smartlog = git.smartlog()?;
-        insta::assert_snapshot!(starting_smartlog, @r###"
-            :
-            O 62fc20d create test1.txt
-            |\
-            | @ 4838e49 create test3.txt
-            |
-            O 96d1c37 (master) create test2.txt
-            "###
+        insta::assert_snapshot!(starting_smartlog, @r"
+        :
+        O 62fc20d create test1.txt
+        |\
+        | @ 4838e49 create test3.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "
         );
 
         let (stdout, _stderr) =
             git.branchless("move", &["-d", "master", "--in-memory", "--dry-run"])?;
-        insta::assert_snapshot!(stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: 70deb1e create test3.txt
-            In-memory rebase would succeed.
-            (This was a dry-run; no commits were moved. Re-run without --dry-run to actually move commits.)
-        "###);
+        insta::assert_snapshot!(stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 70deb1e create test3.txt
+        In-memory rebase would succeed.
+        (This was a dry-run; no commits were moved. Re-run without --dry-run to actually move commits.)
+        ");
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
-            :
-            O 62fc20d create test1.txt
-            |\
-            | @ 4838e49 create test3.txt
-            |
-            O 96d1c37 (master) create test2.txt
-            "###
+        insta::assert_snapshot!(stdout, @r"
+        :
+        O 62fc20d create test1.txt
+        |\
+        | @ 4838e49 create test3.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "
         );
         assert_eq!(stdout, starting_smartlog);
     }
@@ -2885,16 +2885,16 @@ fn test_move_force_in_memory_dry_run() -> eyre::Result<()> {
         git.run(&["commit", "-m", "conflicting test2"])?;
 
         let starting_smartlog = git.smartlog()?;
-        insta::assert_snapshot!(starting_smartlog, @r###"
-            :
-            O 62fc20d create test1.txt
-            |\
-            | @ 081b474 conflicting test2
-            |\
-            | o 4838e49 create test3.txt
-            |
-            O 96d1c37 (master) create test2.txt
-            "###
+        insta::assert_snapshot!(starting_smartlog, @r"
+        :
+        O 62fc20d create test1.txt
+        |\
+        | @ 081b474 conflicting test2
+        |\
+        | o 4838e49 create test3.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "
         );
 
         let (stdout, _stderr) = git.branchless_with_options(
@@ -2905,25 +2905,25 @@ fn test_move_force_in_memory_dry_run() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
-            Attempting rebase in-memory...
-            This operation would cause a merge conflict:
-            - (1 conflicting file) 081b474 conflicting test2
-            To resolve merge conflicts, retry this operation with the --merge option.
-            "###
+        insta::assert_snapshot!(stdout, @"
+        Attempting rebase in-memory...
+        This operation would cause a merge conflict:
+        - (1 conflicting file) 081b474 conflicting test2
+        To resolve merge conflicts, retry this operation with the --merge option.
+        "
         );
 
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
-            :
-            O 62fc20d create test1.txt
-            |\
-            | @ 081b474 conflicting test2
-            |\
-            | o 4838e49 create test3.txt
-            |
-            O 96d1c37 (master) create test2.txt
-            "###
+        insta::assert_snapshot!(stdout, @r"
+        :
+        O 62fc20d create test1.txt
+        |\
+        | @ 081b474 conflicting test2
+        |\
+        | o 4838e49 create test3.txt
+        |
+        O 96d1c37 (master) create test2.txt
+        "
         );
         assert_eq!(stdout, starting_smartlog);
     }
@@ -2987,14 +2987,14 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
                 "--in-memory",
             ],
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Previous HEAD position was 96d1c37 create test2.txt
         branchless: processing 1 update: ref HEAD
         HEAD is now at fe65c1f create test2.txt
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @r"
         Rebase plan: Some(
             RebasePlan {
                 first_dest_oid: NonZeroOid(f777ecc9b0db5ed372b2615695191a8a17f79f24),
@@ -3027,7 +3027,7 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
         |
         @ fe65c1f create test2.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     git.run(&["checkout", &test1_oid.to_string()])?;
@@ -3035,13 +3035,13 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("smartlog", &[])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 62fc20d create test1.txt
         |
         o fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     git.run(&["gc", "--prune=now"])?;
@@ -3049,13 +3049,13 @@ fn test_move_in_memory_gc() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("smartlog", &[])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 62fc20d create test1.txt
         |
         o fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -3088,7 +3088,7 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Attempting rebase in-memory...
         [1/3] Committed as: 4838e49 create test3.txt
         [2/3] Committed as: a248207 create test4.txt
@@ -3103,24 +3103,24 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
         :
         @ 566e434 (> master) create test5.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d create test1.txt
         |\
         : o 96d1c37 create test2.txt
         :
         @ 566e434 (> master) create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["log"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         commit 566e4341a4a9a930fc2bf7ccdfa168e9f266c34a
         Author: Testy McTestface <test@example.com>
         Date:   Thu Oct 29 12:34:56 2020 -0500
@@ -3150,7 +3150,7 @@ fn test_move_main_branch_commits() -> eyre::Result<()> {
         Date:   Thu Oct 29 12:34:56 2020 +0000
 
             create initial.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -3190,7 +3190,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
                 "move",
                 &["--on-disk", "-s", "foo", "-d", &test1_oid.to_string()],
             )?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
@@ -3202,17 +3202,17 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             branchless: processing 3 rewritten commits
             branchless: processing 2 updates: branch bar, branch foo
             Successfully rebased and updated detached HEAD.
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
-        branchless: running command: <git-executable> diff --quiet
-        Calling Git for on-disk rebase...
-        branchless: running command: <git-executable> rebase --continue
-        "###);
+            ");
+            insta::assert_snapshot!(stdout, @"
+            branchless: running command: <git-executable> diff --quiet
+            Calling Git for on-disk rebase...
+            branchless: running command: <git-executable> rebase --continue
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
@@ -3223,7 +3223,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             | @ 566e434 (bar) create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
 
         {
@@ -3234,7 +3234,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
         {
             // There should be no branches left to restack.
             let (stdout, _stderr) = git.branchless("restack", &[])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             No abandoned commits to restack.
             No abandoned branches to restack.
             :
@@ -3247,7 +3247,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             | @ 566e434 (bar) create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -3257,13 +3257,13 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
                 "move",
                 &["--in-memory", "-s", "foo", "-d", &test1_oid.to_string()],
             )?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: creating working copy snapshot
             Previous HEAD position was f81d55c create test5.txt
             Switched to branch 'bar'
             branchless: processing checkout
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @r"
             Attempting rebase in-memory...
             [1/3] Committed as: 4838e49 create test3.txt
             [2/3] Committed as: a248207 create test4.txt
@@ -3282,12 +3282,12 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             |
             O 96d1c37 (master) create test2.txt
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             :
             O 62fc20d create test1.txt
             |\
@@ -3298,13 +3298,13 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             | @ 566e434 (> bar) create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
 
         {
             // There should be no branches left to restack.
             let (stdout, _stderr) = git.branchless("restack", &[])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             No abandoned commits to restack.
             No abandoned branches to restack.
             :
@@ -3317,7 +3317,7 @@ fn test_move_branches_after_move() -> eyre::Result<()> {
             | @ 566e434 (> bar) create test5.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -3349,7 +3349,7 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
         {
             let (stdout, stderr) =
                 git.branchless("move", &["--on-disk", "-b", "HEAD", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-skip-upstream-applied-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             branchless: processing 1 update: ref HEAD
@@ -3358,23 +3358,23 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
             branchless: processing 2 rewritten commits
             branchless: processing 1 update: branch should-be-deleted
             Successfully rebased and updated detached HEAD.
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> diff --quiet
             Calling Git for on-disk rebase...
             branchless: running command: <git-executable> rebase --continue
             Skipping commit (was already applied upstream): 62fc20d create test1.txt
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             O 047b7ad (master) create test1.txt
             |
             @ fa46633 create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -3383,14 +3383,14 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
         {
             let (stdout, stderr) =
                 git.branchless("move", &["--in-memory", "-b", "HEAD", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: creating working copy snapshot
             Previous HEAD position was 96d1c37 create test2.txt
             branchless: processing 1 update: ref HEAD
             HEAD is now at fa46633 create test2.txt
             branchless: processing checkout
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             Attempting rebase in-memory...
             [1/2] Skipped commit (was already applied upstream): 62fc20d create test1.txt
             [2/2] Committed as: fa46633 create test2.txt
@@ -3402,17 +3402,17 @@ fn test_move_no_reapply_upstream_commits() -> eyre::Result<()> {
             |
             @ fa46633 create test2.txt
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             O 047b7ad (master) create test1.txt
             |
             @ fa46633 create test2.txt
-            "###);
+            ");
         }
     }
     Ok(())
@@ -3443,7 +3443,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc create initial.txt
             |\
             | o 62fc20d create test1.txt
@@ -3451,7 +3451,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             | o 96d1c37 create test2.txt
             |
             @ de4a1fe (> master) squashed test1 and test2
-            "###);
+            ");
         }
 
         {
@@ -3464,7 +3464,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
                 "move",
                 &["--on-disk", "-b", &test2_oid.to_string(), "-d", "master"],
             )?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-detect-empty-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
@@ -3479,8 +3479,8 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             :
             @ de4a1fe (> master) squashed test1 and test2
             Successfully rebased and updated detached HEAD.
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             hint: you can omit the --dest flag in this case, as it defaults to HEAD
             hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
             branchless: running command: <git-executable> diff --quiet
@@ -3488,15 +3488,15 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             branchless: running command: <git-executable> rebase --continue
             Skipped now-empty commit: e7bcdd6 create test1.txt
             Skipped now-empty commit: 12d361a create test2.txt
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             @ de4a1fe (> master) squashed test1 and test2
-            "###);
+            ");
         }
 
         {
@@ -3509,7 +3509,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
     {
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc create initial.txt
             |\
             | o 62fc20d create test1.txt
@@ -3517,7 +3517,7 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             | o 96d1c37 create test2.txt
             |
             @ de4a1fe (> master) squashed test1 and test2
-            "###);
+            ");
         }
 
         {
@@ -3525,12 +3525,12 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
                 "move",
                 &["--in-memory", "-b", &test2_oid.to_string(), "-d", "master"],
             )?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: creating working copy snapshot
             Switched to branch 'master'
             branchless: processing checkout
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             hint: you can omit the --dest flag in this case, as it defaults to HEAD
             hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
             Attempting rebase in-memory...
@@ -3541,15 +3541,15 @@ fn test_move_no_reapply_squashed_commits() -> eyre::Result<()> {
             :
             @ de4a1fe (> master) squashed test1 and test2
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             @ de4a1fe (> master) squashed test1 and test2
-            "###);
+            ");
         }
     }
     Ok(())
@@ -3579,7 +3579,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         : o 62fc20d create test1.txt
@@ -3589,7 +3589,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
         : o ffcba55 (more-work) create test3.txt
         :
         @ 91c5ce6 (> master) create test2.txt
-        "###);
+        ");
     }
 
     // --on-disk
@@ -3600,7 +3600,7 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             git.run(&["checkout", "work"])?;
             let (stdout, stderr) =
                 git.branchless("move", &["--on-disk", "-b", "HEAD", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-skip-upstream-applied-commit 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
             Executing: git branchless hook-skip-upstream-applied-commit 96d1c37a3d4363611c49f7e52186e189a04c531f
@@ -3619,24 +3619,24 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             |
             o 012efd6 (more-work) create test3.txt
             Successfully rebased and updated detached HEAD.
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> diff --quiet
             Calling Git for on-disk rebase...
             branchless: running command: <git-executable> rebase --continue
             Skipping commit (was already applied upstream): 62fc20d create test1.txt
             Skipping commit (was already applied upstream): 96d1c37 create test2.txt
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             @ 91c5ce6 (> master) create test2.txt
             |
             o 012efd6 (more-work) create test3.txt
-            "###);
+            ");
         }
     }
     // --in-memory
@@ -3645,13 +3645,13 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             git.run(&["checkout", "work"])?;
             let (stdout, stderr) =
                 git.branchless("move", &["--in-memory", "-b", "HEAD", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: creating working copy snapshot
             Previous HEAD position was 96d1c37 create test2.txt
             Switched to branch 'master'
             branchless: processing checkout
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             Attempting rebase in-memory...
             [1/3] Skipped commit (was already applied upstream): 62fc20d create test1.txt
             [2/3] Skipped commit (was already applied upstream): 96d1c37 create test2.txt
@@ -3664,17 +3664,17 @@ fn test_move_delete_checked_out_branch() -> eyre::Result<()> {
             |
             o 012efd6 (more-work) create test3.txt
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             @ 91c5ce6 (> master) create test2.txt
             |
             o 012efd6 (more-work) create test3.txt
-            "###);
+            ");
         }
     }
 
@@ -3704,12 +3704,12 @@ fn test_move_with_unstaged_changes() -> eyre::Result<()> {
             },
         )?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         This operation would modify the working copy, but you have uncommitted changes
         in your working copy which might be overwritten as a result.
         Commit your changes and then try again.
-        "###);
+        ");
     }
 
     Ok(())
@@ -3734,7 +3734,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
     git.run(&["checkout", &test3_oid.to_string()])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o fe65c1f create test2.txt
@@ -3747,7 +3747,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
         | o 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
         |
         O 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     // --on-disk
@@ -3768,7 +3768,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                     "master",
                 ],
             )?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r#"
             Rebase constraints before adding descendants: [
                 (
                     NonZeroOid(62fc20d2a290daea0d52bdc2ed2ad4be6491010e),
@@ -3843,8 +3843,8 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             branchless: running command: <git-executable> diff --quiet
             Calling Git for on-disk rebase...
             branchless: running command: <git-executable> rebase --continue
-            "###);
-            insta::assert_snapshot!(stderr, @r###"
+            "#);
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-detect-empty-commit fe65c1fe15584744e649b2c79d4cf9b0d878f92e
@@ -3855,12 +3855,12 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             branchless: processing 2 rewritten commits
             Successfully rebased and updated detached HEAD.
             branchless: processing 1 update: ref refs/rewritten/parent-3
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc create initial.txt
             |\
             | @ 98b9119 create test3.txt
@@ -3873,7 +3873,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             |
             o 96d1c37 create test2.txt
             & (merge) 5a6a761 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-            "###);
+            ");
         }
     }
 
@@ -3897,13 +3897,13 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                     ..Default::default()
                 },
             )?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             error: the argument '--in-memory' cannot be used with '--merge'
 
             Usage: git-branchless move --in-memory --source <SOURCE> --dest <DEST>
 
             For more information, try '--help'.
-            "###);
+            ");
             insta::assert_snapshot!(stdout, @"");
         }
     }
@@ -3919,18 +3919,18 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                     ..Default::default()
                 },
             )?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             Attempting rebase in-memory...
             Merge commits currently can't be rebased in-memory.
             The merge commit was: 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             To resolve merge conflicts, retry this operation with the --merge option.
-            "###);
+            ");
             insta::assert_snapshot!(stderr, @"");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             O f777ecc create initial.txt
             |\
             | o fe65c1f create test2.txt
@@ -3943,7 +3943,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
             | o 28790c7 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
             |
             O 62fc20d (master) create test1.txt
-            "###);
+            ");
         }
 
         // --merge with no other flag
@@ -3953,14 +3953,14 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                     "move",
                     &["--merge", "-s", &test2_oid.to_string(), "-d", "master"],
                 )?;
-                insta::assert_snapshot!(stdout, @r###"
+                insta::assert_snapshot!(stdout, @"
                 Attempting rebase in-memory...
                 Failed to merge in-memory, trying again on-disk...
                 branchless: running command: <git-executable> diff --quiet
                 Calling Git for on-disk rebase...
                 branchless: running command: <git-executable> rebase --continue
-                "###);
-                insta::assert_snapshot!(stderr, @r###"
+                ");
+                insta::assert_snapshot!(stderr, @"
                 branchless: processing 1 update: ref HEAD
                 branchless: processing 1 update: ref HEAD
                 Executing: git branchless hook-detect-empty-commit fe65c1fe15584744e649b2c79d4cf9b0d878f92e
@@ -3971,12 +3971,12 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                 branchless: processing 2 rewritten commits
                 Successfully rebased and updated detached HEAD.
                 branchless: processing 1 update: ref refs/rewritten/parent-3
-                "###);
+                ");
             }
 
             {
                 let stdout = git.smartlog()?;
-                insta::assert_snapshot!(stdout, @r###"
+                insta::assert_snapshot!(stdout, @r"
                 O f777ecc create initial.txt
                 |\
                 | @ 98b9119 create test3.txt
@@ -3989,7 +3989,7 @@ fn test_move_merge_commit() -> eyre::Result<()> {
                 |
                 o 96d1c37 create test2.txt
                 & (merge) 5a6a761 Merge commit 'fe65c1fe15584744e649b2c79d4cf9b0d878f92e' into HEAD
-                "###);
+                ");
             }
         }
     }
@@ -4017,7 +4017,7 @@ fn test_move_merge_commit_both_parents() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -4034,7 +4034,7 @@ fn test_move_merge_commit_both_parents() -> eyre::Result<()> {
         | & (merge) 355e173 create test4.txt
         |/
         @ 8fb706a Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-        "###);
+        ");
     }
 
     {
@@ -4048,18 +4048,18 @@ fn test_move_merge_commit_both_parents() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         Failed to merge in-memory, trying again on-disk...
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -4076,7 +4076,7 @@ fn test_move_merge_commit_both_parents() -> eyre::Result<()> {
         | & (merge) a248207 create test4.txt
         |/
         @ d9a0a04 Merge commit '355e173bf9c5d2efac2e451da0cdad3fb82b869a' into HEAD
-        "###);
+        ");
     }
 
     Ok(())
@@ -4104,7 +4104,7 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O d59c43f create A.txt
         |\
@@ -4122,7 +4122,7 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
         | @ 7f5857e create F.txt
         |
         O 33790e1 (master) create B.txt
-        "###);
+        ");
     }
 
     {
@@ -4138,7 +4138,7 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
                 "--debug-dump-rebase-plan",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         Rebase constraints before adding descendants: [
             (
                 NonZeroOid(33790e10045c924645cd69f7819de927eb1a42a0),
@@ -4266,12 +4266,12 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
-        "###);
+        "#);
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 33790e1 (master) create B.txt
         |
@@ -4287,7 +4287,7 @@ fn test_move_merge_commit_issue_912() -> eyre::Result<()> {
         o f7c3c92 Merge D and E
         |
         @ 235027c create F.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -4310,10 +4310,10 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
     git.run(&["checkout", "--orphan", "new-root"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     git.run(&["commit", "-m", "new root"])?;
@@ -4321,11 +4321,11 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
         let stdout = git.smartlog()?;
         // FIXME: the smartlog handling for unrelated roots is wrong. There
         // should be no relation between these two commits.
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ da90168 (> new-root) new root
         :
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     git.commit_file("test3", 3)?;
@@ -4336,7 +4336,7 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
 
         {
             let (stdout, stderr) = git.branchless("move", &["--on-disk", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: processing 1 update: ref HEAD
             branchless: processing 1 update: ref HEAD
             Executing: git branchless hook-detect-empty-commit da90168b4835f97f1a10bcc12833140056df9157
@@ -4354,23 +4354,23 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             |
             @ 70deb1e (> new-root) create test3.txt
             Successfully rebased and updated detached HEAD.
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> diff --quiet
             Calling Git for on-disk rebase...
             branchless: running command: <git-executable> rebase --continue
             Skipped now-empty commit: 270b681 new root
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             O 96d1c37 (master) create test2.txt
             |
             @ 70deb1e (> new-root) create test3.txt
-            "###);
+            ");
         }
 
         {
@@ -4383,13 +4383,13 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
     {
         {
             let (stdout, stderr) = git.branchless("move", &["--in-memory", "-d", "master"])?;
-            insta::assert_snapshot!(stderr, @r###"
+            insta::assert_snapshot!(stderr, @"
             branchless: creating working copy snapshot
             Previous HEAD position was fc09f3d create test3.txt
             Switched to branch 'new-root'
             branchless: processing checkout
-            "###);
-            insta::assert_snapshot!(stdout, @r###"
+            ");
+            insta::assert_snapshot!(stdout, @"
             Attempting rebase in-memory...
             [1/2] Skipped now-empty commit: 270b681 new root
             [2/2] Committed as: 70deb1e create test3.txt
@@ -4401,17 +4401,17 @@ fn test_move_orphaned_root() -> eyre::Result<()> {
             |
             @ 70deb1e (> new-root) create test3.txt
             In-memory rebase succeeded.
-            "###);
+            ");
         }
 
         {
             let stdout = git.smartlog()?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             :
             O 96d1c37 (master) create test2.txt
             |
             @ 70deb1e (> new-root) create test3.txt
-            "###);
+            ");
         }
     }
 
@@ -4431,25 +4431,25 @@ fn test_move_no_extra_checkout() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("move", &["--in-memory", "-s", "HEAD", "-d", "HEAD^"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         git.run(&["branch", "foo"])?;
         let (stdout, _stderr) =
             git.branchless("move", &["--in-memory", "-s", "HEAD", "-d", "HEAD^"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 96d1c37 create test2.txt
         branchless: processing 1 update: branch foo
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4482,7 +4482,7 @@ fn test_move_dest_not_in_dag() -> eyre::Result<()> {
 
         let (stdout, _stderr) = cloned_repo.branchless("move", &["-d", "origin/master", "-f"])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 update: branch other-branch
@@ -4493,7 +4493,7 @@ fn test_move_dest_not_in_dag() -> eyre::Result<()> {
         :
         @ 70deb1e (> other-branch) create test3.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4524,12 +4524,12 @@ fn test_move_abort_rebase_check_out_old_branch() -> eyre::Result<()> {
         )?;
         let stdout = remove_rebase_lines(stdout);
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
         CONFLICT (add/add): Merge conflict in test2.txt
-        "###);
+        ");
     }
 
     git.run(&["rebase", "--abort"])?;
@@ -4559,10 +4559,10 @@ fn test_move_orig_head_no_symbolic_reference() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 96d1c37 (foo, master) create test2.txt
-        "###);
+        ");
     }
 
     // Get `git reset` to write a new value to `ORIG_HEAD`. If `ORIG_HEAD` is a
@@ -4575,11 +4575,11 @@ fn test_move_orig_head_no_symbolic_reference() -> eyre::Result<()> {
         let stdout = git.smartlog()?;
         // `foo` should be unmoved here, rather than moved to
         // `create test1.txt`.
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc create initial.txt
         :
         O 96d1c37 (foo, master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -4599,19 +4599,18 @@ fn test_move_standalone_create_gc_refs() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show-ref"])?;
-        insta::assert_snapshot!(stdout, @"62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/heads/master
-");
+        insta::assert_snapshot!(stdout, @"62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/heads/master");
     }
 
     git.branchless("move", &["-d", &test1_oid.to_string()])?;
 
     {
         let (stdout, _stderr) = git.run(&["show-ref"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/branchless/62fc20d2a290daea0d52bdc2ed2ad4be6491010e
         96d1c37a3d4363611c49f7e52186e189a04c531f refs/branchless/96d1c37a3d4363611c49f7e52186e189a04c531f
         62fc20d2a290daea0d52bdc2ed2ad4be6491010e refs/heads/master
-        "###);
+        ");
     }
 
     Ok(())
@@ -4646,7 +4645,7 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
 
     {
         let (stdout, stderr) = git.run(&["rebase", "--continue"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         branchless: processing 1 update: ref HEAD
         Executing: git branchless hook-detect-empty-commit aec59174640c3e3dbb92fdade0bc44ca31552a85
         Executing: git branchless hook-register-extra-post-rewrite-hook
@@ -4663,23 +4662,23 @@ fn test_move_branch_on_merge_conflict_resolution() -> eyre::Result<()> {
         |
         o 3632ef4 create test1.txt
         Successfully rebased and updated detached HEAD.
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         [detached HEAD 3632ef4] create test1.txt
          1 file changed, 1 insertion(+), 1 deletion(-)
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         @ 62fc20d (> master) create test1.txt
         |\
         | o 6002762 create test1.txt
         |
         o 3632ef4 create test1.txt
-        "###);
+        ");
     }
 
     {
@@ -4710,7 +4709,7 @@ fn test_move_revset() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("move", &["-s", "draft()", "-d", "master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         hint: you can omit the --dest flag in this case, as it defaults to HEAD
         hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
         Attempting rebase in-memory...
@@ -4728,7 +4727,7 @@ fn test_move_revset() -> eyre::Result<()> {
         |
         o 9cb6a30 create test4.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4754,7 +4753,7 @@ fn test_move_revset_non_continguous() -> eyre::Result<()> {
             "move",
             &["-s", &format!("{test2_oid} | {test4_oid}"), "-d", "master^"],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Attempting rebase in-memory...
         [1/3] Committed as: 8f7aef5 create test4.txt
         [2/3] Committed as: fe65c1f create test2.txt
@@ -4771,7 +4770,7 @@ fn test_move_revset_non_continguous() -> eyre::Result<()> {
         |
         O 62fc20d (master) create test1.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4798,14 +4797,14 @@ fn test_move_hint() -> eyre::Result<()> {
         let dest_hint_command = {
             let (stdout, _stderr) =
                 git.branchless("move", &["-s", &test3_oid.to_string(), "-d", "."])?;
-            insta::assert_snapshot!(stdout, @r###"
-        hint: you can omit the --dest flag in this case, as it defaults to HEAD
-        hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
-        Attempting rebase in-memory...
-        [1/1] Committed as: 4838e49 create test3.txt
-        branchless: processing 1 rewritten commit
-        In-memory rebase succeeded.
-        "###);
+            insta::assert_snapshot!(stdout, @"
+            hint: you can omit the --dest flag in this case, as it defaults to HEAD
+            hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
+            Attempting rebase in-memory...
+            [1/1] Committed as: 4838e49 create test3.txt
+            branchless: processing 1 rewritten commit
+            In-memory rebase succeeded.
+            ");
             extract_hint_command(&stdout)
         };
 
@@ -4813,21 +4812,21 @@ fn test_move_hint() -> eyre::Result<()> {
             git.branchless("next", &["--newest"])?;
             let (stdout, _stderr) =
                 git.branchless("move", &["-b", ".", "-d", &test2_oid.to_string()])?;
-            insta::assert_snapshot!(stdout, @r###"
-        hint: you can omit the --base flag in this case, as it defaults to HEAD
-        hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
-        Attempting rebase in-memory...
-        [1/1] Committed as: 70deb1e create test3.txt
-        branchless: processing 1 rewritten commit
-        branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
-        :
-        O 62fc20d (master) create test1.txt
-        |
-        o 96d1c37 create test2.txt
-        |
-        @ 70deb1e create test3.txt
-        In-memory rebase succeeded.
-        "###);
+            insta::assert_snapshot!(stdout, @"
+            hint: you can omit the --base flag in this case, as it defaults to HEAD
+            hint: disable this hint by running: git config --global branchless.hint.moveImplicitHeadArgument false
+            Attempting rebase in-memory...
+            [1/1] Committed as: 70deb1e create test3.txt
+            branchless: processing 1 rewritten commit
+            branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
+            :
+            O 62fc20d (master) create test1.txt
+            |
+            o 96d1c37 create test2.txt
+            |
+            @ 70deb1e create test3.txt
+            In-memory rebase succeeded.
+            ");
             extract_hint_command(&stdout)
         };
 
@@ -4840,18 +4839,18 @@ fn test_move_hint() -> eyre::Result<()> {
     {
         let (stdout, _stderr) =
             git.branchless("move", &["-s", &test3_oid.to_string(), "-d", "."])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 4838e49 create test3.txt
         branchless: processing 1 rewritten commit
         In-memory rebase succeeded.
-        "###);
+        ");
     }
     {
         git.branchless("next", &["--newest"])?;
         let (stdout, _stderr) =
             git.branchless("move", &["-b", ".", "-d", &test2_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 70deb1e create test3.txt
         branchless: processing 1 rewritten commit
@@ -4863,7 +4862,7 @@ fn test_move_hint() -> eyre::Result<()> {
         |
         @ 70deb1e create test3.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4890,17 +4889,17 @@ fn test_move_public_commit() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         You are trying to rewrite 2 public commits, such as: 96d1c37 create test2.txt
         It is generally not advised to rewrite public commits, because your
         collaborators will have difficulty merging your changes.
         Retry with -f/--force-rewrite to proceed anyways.
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("move", &["-x", ".^", "-f"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: fe65c1f create test2.txt
         [2/2] Committed as: 0770943 create test1.txt
@@ -4912,7 +4911,7 @@ fn test_move_public_commit() -> eyre::Result<()> {
         |
         o 0770943 create test1.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     Ok(())
@@ -4940,7 +4939,7 @@ fn test_move_delete_branch_config_entry() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("move", &["-d", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Skipped commit (was already applied upstream): 047b7ad create test1.txt
         branchless: processing 1 update: branch bar
@@ -4952,14 +4951,13 @@ fn test_move_delete_branch_config_entry() -> eyre::Result<()> {
         |
         @ 96d1c37 (> foo) create test2.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.run(&["config", "branch.foo.remote", "--default"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
-        "###);
+        insta::assert_snapshot!(stdout, @"");
     }
 
     Ok(())
@@ -4986,7 +4984,7 @@ fn test_move_fixup_head_into_parent() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 307a04c create test.txt
@@ -4994,15 +4992,15 @@ fn test_move_fixup_head_into_parent() -> eyre::Result<()> {
     o 6d92723 update 2 test.txt
     |
     @ da38dc8 update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,2 +1,3 @@
      line 1
      line 2
     +line 3
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5017,7 +5015,7 @@ fn test_move_fixup_head_into_parent() -> eyre::Result<()> {
                 &test2_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 8c3aa56 update 2 test.txt
         branchless: processing 2 rewritten commits
@@ -5028,15 +5026,15 @@ fn test_move_fixup_head_into_parent() -> eyre::Result<()> {
         |
         @ 8c3aa56 update 2 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1 +1,3 @@
         +line 1
          line 2
         +line 3
-        "###);
+        ");
     }
 
     Ok(())
@@ -5063,7 +5061,7 @@ fn test_move_fixup_parent_into_head() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 307a04c create test.txt
@@ -5071,15 +5069,15 @@ fn test_move_fixup_parent_into_head() -> eyre::Result<()> {
     o 6d92723 update 2 test.txt
     |
     @ da38dc8 update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,2 +1,3 @@
      line 1
      line 2
     +line 3
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5087,7 +5085,7 @@ fn test_move_fixup_parent_into_head() -> eyre::Result<()> {
             "move",
             &["--in-memory", "--fixup", "-x", &test2_oid.to_string()],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: ff6183f update 3 test.txt
         branchless: processing 2 rewritten commits
@@ -5098,15 +5096,15 @@ fn test_move_fixup_parent_into_head() -> eyre::Result<()> {
         |
         @ ff6183f update 3 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1 +1,3 @@
         +line 1
          line 2
         +line 3
-        "###);
+        ");
     }
 
     Ok(())
@@ -5134,7 +5132,7 @@ fn test_move_fixup_head_into_ancestor() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 307a04c create test.txt
@@ -5142,15 +5140,15 @@ fn test_move_fixup_head_into_ancestor() -> eyre::Result<()> {
     o 6d92723 (test) update 2 test.txt
     |
     @ da38dc8 update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,2 +1,3 @@
      line 1
      line 2
     +line 3
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5165,7 +5163,7 @@ fn test_move_fixup_head_into_ancestor() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 963fb93 create test.txt
         [2/2] Committed as: b9da1e0 update 2 test.txt
@@ -5178,21 +5176,21 @@ fn test_move_fixup_head_into_ancestor() -> eyre::Result<()> {
         |
         o b9da1e0 (test) update 2 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,2 @@
         +line 2
         +line 3
-        "###);
+        ");
         let diff = git.get_trimmed_diff("test.txt", "test")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1,2 +1,3 @@
         +line 1
          line 2
          line 3
-        "###);
+        ");
     }
 
     Ok(())
@@ -5225,7 +5223,7 @@ fn test_move_fixup_ancestor_into_head() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 307a04c create test.txt
@@ -5235,16 +5233,16 @@ fn test_move_fixup_ancestor_into_head() -> eyre::Result<()> {
     o 04a457d update 3 test.txt
     |
     @ b2a4062 update 4 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,3 +1,4 @@
      line 1
      line 2
      line 3
     +line 4
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5253,7 +5251,7 @@ fn test_move_fixup_ancestor_into_head() -> eyre::Result<()> {
             &["--in-memory", "--fixup", "-x", &test2_oid.to_string()],
         )?;
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: dbcd17a update 3 test.txt
         [2/2] Committed as: 2b97091 update 4 test.txt
@@ -5267,16 +5265,16 @@ fn test_move_fixup_ancestor_into_head() -> eyre::Result<()> {
         |
         @ 2b97091 update 4 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1,2 +1,4 @@
          line 1
          line 2
         +line 3
         +line 4
-        "###);
+        ");
     }
 
     Ok(())
@@ -5303,7 +5301,7 @@ fn test_move_fixup_multiple_into_head() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 1f31d98 create test.txt
@@ -5311,15 +5309,15 @@ fn test_move_fixup_multiple_into_head() -> eyre::Result<()> {
     o 73ae0c5 update 2 test.txt
     |
     @ 622207d update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,2 +1,3 @@
      line 1
      line 2
     +line 3
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5332,7 +5330,7 @@ fn test_move_fixup_multiple_into_head() -> eyre::Result<()> {
                 &format!("{}+{}", test1_oid, test2_oid),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: c4f6746 update 3 test.txt
         branchless: processing 3 rewritten commits
@@ -5341,15 +5339,15 @@ fn test_move_fixup_multiple_into_head() -> eyre::Result<()> {
         |
         @ c4f6746 update 3 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,3 @@
         +line 1
         +line 2
         +line 3
-        "###);
+        ");
     }
 
     Ok(())
@@ -5382,7 +5380,7 @@ fn test_move_fixup_multiple_into_ancestor_with_unmoved_head() -> eyre::Result<()
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 1f31d98 create test.txt
@@ -5392,23 +5390,23 @@ fn test_move_fixup_multiple_into_ancestor_with_unmoved_head() -> eyre::Result<()
     o 622207d update 3 test.txt
     |
     @ a392af0 update 4 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD~")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,2 +1,3 @@
      line 1
      line 2
     +line 3
-    "###);
+    ");
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,3 +1,4 @@
      line 1
      line 2
      line 3
     +line 4
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5423,7 +5421,7 @@ fn test_move_fixup_multiple_into_ancestor_with_unmoved_head() -> eyre::Result<()
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 23d4bdd create test.txt
         [2/2] Committed as: 797ef91 update 4 test.txt
@@ -5435,23 +5433,23 @@ fn test_move_fixup_multiple_into_ancestor_with_unmoved_head() -> eyre::Result<()
         |
         @ 797ef91 update 4 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD~")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,3 @@
         +line 1
         +line 2
         +line 3
-        "###);
+        ");
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1,3 +1,4 @@
          line 1
          line 2
          line 3
         +line 4
-        "###);
+        ");
     }
 
     Ok(())
@@ -5552,7 +5550,7 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 64eb9bf (test) create test.txt
@@ -5566,10 +5564,10 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
     o 1ff1932 update 5 test.txt
     |
     @ e982189 update 6 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "test")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -0,0 +1,7 @@
     +# Section A
     +.
@@ -5578,9 +5576,9 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
     +.
     +.
     +# Section C
-    "###);
+    ");
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -5,5 +5,5 @@ Line A-1
      Line B-1
      Line B-2
@@ -5588,7 +5586,7 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
     -# Section 3
     +# Section C
      Line C-1
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5603,7 +5601,7 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
                 "test",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/4] Committed as: 38caaaf create test.txt
         [2/4] Committed as: 6783c86 update 2 test.txt
@@ -5622,11 +5620,11 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
         |
         @ 472b70b update 6 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         // diff for "create test.txt"
         let diff = git.get_trimmed_diff("test.txt", "test")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,8 @@
         +# Section A
         +.
@@ -5636,9 +5634,9 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
         +.
         +# Section 3
         +Line C-1
-        "###);
+        ");
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -5,5 +5,5 @@ Line A-1
          Line B-1
          Line B-2
@@ -5646,7 +5644,7 @@ fn test_move_fixup_multiple_disconnected_into_ancestor() -> eyre::Result<()> {
         -# Section 3
         +# Section C
          Line C-1
-        "###);
+        ");
     }
 
     Ok(())
@@ -5747,7 +5745,7 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 64eb9bf create test.txt
@@ -5761,10 +5759,10 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
     o 1ff1932 update 5 test.txt
     |
     @ e982189 update 6 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "test")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -2,6 +2,7 @@
      Line A-1
      .
@@ -5774,9 +5772,9 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
     +Line B-2
      .
      # Section 3
-    "###);
+    ");
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -5,5 +5,5 @@ Line A-1
      Line B-1
      Line B-2
@@ -5784,7 +5782,7 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
     -# Section 3
     +# Section C
      Line C-1
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5797,7 +5795,7 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
                 &format!("{}+{}", test3_oid, test5_oid),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: c21e0d7 update 4 test.txt
         [2/2] Committed as: 237b381 update 6 test.txt
@@ -5814,11 +5812,11 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
         |
         @ 237b381 update 6 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         // diff for "update 4" should not include the changes from "update 3"
         let diff = git.get_trimmed_diff("test.txt", "test")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -2,6 +2,7 @@
          Line A-1
          .
@@ -5828,16 +5826,16 @@ fn test_move_fixup_multiple_disconnected_into_head() -> eyre::Result<()> {
         +Line B-2
          .
          # Section C
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -6,3 +6,4 @@ Line B-1
          Line B-2
          .
          # Section C
         +Line C-1
-        "###);
+        ");
     }
 
     Ok(())
@@ -5882,7 +5880,7 @@ fn test_move_fixup_squash_branch() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o a5407aa create test.txt
@@ -5890,17 +5888,17 @@ fn test_move_fixup_squash_branch() -> eyre::Result<()> {
     o 92c935b update 2 test.txt
     |
     @ 994e3c7 (> test) update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,4 +1,4 @@
     -function name()
     +function name(): int
      {
      return 123;
      }
-    "###);
+    ");
 
     // --in-memory
     {
@@ -5915,7 +5913,7 @@ fn test_move_fixup_squash_branch() -> eyre::Result<()> {
                 &test1_oid.to_string(),
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: c513440 create test.txt
         branchless: processing 1 update: branch test
@@ -5925,16 +5923,16 @@ fn test_move_fixup_squash_branch() -> eyre::Result<()> {
         |
         @ c513440 (> test) create test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,4 @@
         +function name(): int
         +{
         +return 123;
         +}
-        "###);
+        ");
     }
 
     Ok(())
@@ -5985,7 +5983,7 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
     git.run(&["switch", "-c", "test-3"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 3c5d257 (test-1) create test.txt
@@ -5993,20 +5991,20 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
     o a84e38f (test-2) update 2 test.txt
     |
     @ 732f40d (> test-3) update 3 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,4 +1,4 @@
     -#
     +# Just a function
      function name()
      {
      return 123;
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "test-2")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -1,3 +1,5 @@
      #
      function name()
@@ -6014,7 +6012,7 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
     +{
     +return 123;
     +}
-    "###);
+    ");
 
     // --in-memory
     {
@@ -6022,7 +6020,7 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
             "move",
             &["--in-memory", "--fixup", "-x", "test-3", "-d", "test-1"],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: f4321df create test.txt
         [2/2] Committed as: 2746e2a update 2 test.txt
@@ -6035,19 +6033,19 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
         |
         o 2746e2a (test-2) update 2 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -0,0 +1,3 @@
         +# Just a function
         +function name()
         +{}
-        "###);
+        ");
 
         // diff for "update 2"
         let diff = git.get_trimmed_diff("test.txt", "test-2")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1,3 +1,5 @@
          # Just a function
          function name()
@@ -6055,7 +6053,7 @@ fn test_move_fixup_branch_tip() -> eyre::Result<()> {
         +{
         +return 123;
         +}
-        "###);
+        ");
     }
 
     Ok(())
@@ -6170,7 +6168,7 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     O f777ecc (master) create initial.txt
     |
     o 64eb9bf create test.txt
@@ -6186,10 +6184,10 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
     o 5f84b2f update 6 test.txt
     |
     @ 49b63ec update 7 test.txt
-    "###);
+    ");
 
     let diff = git.get_trimmed_diff("test.txt", "test")?;
-    insta::assert_snapshot!(diff, @r###"
+    insta::assert_snapshot!(diff, @"
     @@ -3,5 +3,6 @@
      .
      # Section B
@@ -6197,7 +6195,7 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
     +Line B-2
      .
      # Section C
-    "###);
+    ");
     // --in-memory
     {
         let (stdout, _stderr) = git.branchless(
@@ -6211,7 +6209,7 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
                 "test",
             ],
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Attempting rebase in-memory...
         [1/3] Committed as: 5e6d3e4 update 7 test.txt
         [2/3] Committed as: 59a95b3 update 4 test.txt
@@ -6231,10 +6229,10 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
         |
         @ 5e6d3e4 update 7 test.txt
         In-memory rebase succeeded.
-        "###);
+        ");
 
         let diff = git.get_trimmed_diff("test.txt", "test")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -1,7 +1,8 @@
          # Section A
         +Line A-1
@@ -6246,15 +6244,15 @@ fn test_move_fixup_tree() -> eyre::Result<()> {
         +Line B-2
          .
          # Section C
-        "###);
+        ");
         let diff = git.get_trimmed_diff("test.txt", "HEAD")?;
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @"
         @@ -5,3 +5,4 @@
          Line B-1
          .
          # Section C
         +Line C-1
-        "###);
+        ");
     }
 
     Ok(())
@@ -6283,12 +6281,12 @@ fn test_move_fixup_conflict() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
         - (1 conflicting file) 91970eb update 3 test.txt
         To resolve merge conflicts, retry this operation with the --merge option.
-        "###);
+        ");
     }
 
     Ok(())
@@ -6308,7 +6306,7 @@ fn test_move_fixup_added_files() -> eyre::Result<()> {
         &["--in-memory", "--fixup", "-x", "HEAD", "-d", "HEAD~"],
     )?;
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     Attempting rebase in-memory...
     [1/1] Committed as: e9f8a2b create test1.txt
     branchless: processing 2 rewritten commits
@@ -6317,14 +6315,14 @@ fn test_move_fixup_added_files() -> eyre::Result<()> {
     |
     @ e9f8a2b create test1.txt
     In-memory rebase succeeded.
-    "###);
+    ");
 
     let (stdout, _stderr) = git.run(&["ls-files"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     initial.txt
     test1.txt
     test2.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -6346,7 +6344,7 @@ fn test_move_reparent() -> eyre::Result<()> {
     git.run(&["branch", test3_branch])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d (test1-branch) create test1.txt
@@ -6383,7 +6381,7 @@ fn test_move_reparent() -> eyre::Result<()> {
     git.branchless("prev", &[])?;
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         test1.txt                                         | 1 +
         test2_will_also_contain_test1_when_reparented.txt | 1 +
         2 files changed, 2 insertions(+)
@@ -6426,7 +6424,7 @@ fn test_move_reparent() -> eyre::Result<()> {
     git.branchless("prev", &[])?;
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         test1.txt                                         | 1 +
         test2_will_also_contain_test1_when_reparented.txt | 1 +
         test3_will_also_contain_test2_when_reparented.txt | 1 +
@@ -6437,7 +6435,7 @@ fn test_move_reparent() -> eyre::Result<()> {
     // the descendant test2 should come without test3 like before
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test2_branch])?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         test3_will_also_contain_test2_when_reparented.txt | 1 -
         1 file changed, 1 deletion(-)
         ");
@@ -6446,7 +6444,7 @@ fn test_move_reparent() -> eyre::Result<()> {
     // similarly the descendant test1 should come without test1 and test2
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test1_branch])?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         test2_will_also_contain_test1_when_reparented.txt | 1 -
         test3_will_also_contain_test2_when_reparented.txt | 1 -
         2 files changed, 2 deletions(-)
@@ -6478,7 +6476,7 @@ fn test_move_reparent() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", test2_branch])?;
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         test1.txt                                         | 1 +
         test2_will_also_contain_test1_when_reparented.txt | 1 +
         2 files changed, 2 insertions(+)
@@ -6509,26 +6507,26 @@ fn test_worktree_rebase_in_memory() -> eyre::Result<()> {
     git.run(&["checkout", "master"])?;
     {
         let stdout = worktree.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = worktree.branchless("move", &["-s", "@", "-d", "master"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Previous HEAD position was 70deb1e create test3.txt
         branchless: processing 1 update: ref HEAD
         HEAD is now at 4838e49 create test3.txt
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @r"
         Attempting rebase in-memory...
         [1/1] Committed as: 4838e49 create test3.txt
         branchless: processing 1 rewritten commit
@@ -6540,31 +6538,31 @@ fn test_worktree_rebase_in_memory() -> eyre::Result<()> {
         |
         @ 4838e49 create test3.txt
         In-memory rebase succeeded.
-        "###);
+        ");
     }
 
     {
         let stdout = worktree.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
         | o 96d1c37 create test2.txt
         |
         @ 4838e49 create test3.txt
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         @ 62fc20d (> master) create test1.txt
         |\
         | o 96d1c37 create test2.txt
         |
         o 4838e49 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_navigation.rs
+++ b/git-branchless/tests/test_navigation.rs
@@ -13,12 +13,12 @@ fn test_prev() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("prev", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
         @ f777ecc create initial.txt
         |
         O 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     {
@@ -30,18 +30,17 @@ fn test_prev() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @"No more parent commits to go to after traversing 0 parents.
-");
+        insta::assert_snapshot!(stdout, @"No more parent commits to go to after traversing 0 parents.");
         insta::assert_snapshot!(stderr, @"");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ f777ecc create initial.txt
         |
         O 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -57,12 +56,12 @@ fn test_prev_multiple() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
         @ f777ecc create initial.txt
         :
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -80,14 +79,14 @@ fn test_next_multiple() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("next", &["2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -117,18 +116,18 @@ fn test_next_ambiguous() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Found multiple possible child commits to go to after traversing 0 children:
           - 62fc20d create test1.txt (oldest)
           - fe65c1f create test2.txt
           - 98b9119 create test3.txt (newest)
         (Pass --oldest (-o), --newest (-n), or --interactive (-i) to select between ambiguous commits)
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("next", &["--oldest"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |\
@@ -137,13 +136,13 @@ fn test_next_ambiguous() -> eyre::Result<()> {
         | o fe65c1f create test2.txt
         |
         o 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     git.run(&["checkout", "master"])?;
     {
         let (stdout, _stderr) = git.branchless("next", &["--newest"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout 98b9119d16974f372e76cb64a3b77c528fc0b18b --
         O f777ecc (master) create initial.txt
         |\
@@ -152,7 +151,7 @@ fn test_next_ambiguous() -> eyre::Result<()> {
         | o fe65c1f create test2.txt
         |
         @ 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -189,7 +188,7 @@ fn test_next_ambiguous_interactive() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -197,7 +196,7 @@ fn test_next_ambiguous_interactive() -> eyre::Result<()> {
         | @ fe65c1f create test2.txt
         |
         o 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -216,13 +215,13 @@ fn test_next_on_master() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("next", &["2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 96d1c37 (master) create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -241,7 +240,7 @@ fn test_next_on_master2() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("next", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 62fc20d (master) create test1.txt
@@ -249,7 +248,7 @@ fn test_next_on_master2() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -268,14 +267,14 @@ fn test_next_no_more_children() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("next", &["3"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No more child commits to go to after traversing 2 children.
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         :
         O 96d1c37 (master) create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -308,7 +307,7 @@ fn test_switch_pty() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 62fc20d create test1.txt
@@ -316,7 +315,7 @@ fn test_switch_pty() -> eyre::Result<()> {
         | o 96d1c37 create test2.txt
         |
         o 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     run_in_pty(
@@ -333,7 +332,7 @@ fn test_switch_pty() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -341,7 +340,7 @@ fn test_switch_pty() -> eyre::Result<()> {
         | o 96d1c37 create test2.txt
         |
         @ 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -368,13 +367,13 @@ fn test_switch_abort() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ 142901d create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -393,7 +392,7 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["-a"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
@@ -402,12 +401,12 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         o 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("next", &["-a"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 70deb1e28791d8e7dd5a1f0c871a51b91282562f --
         O f777ecc (master) create initial.txt
         |
@@ -416,7 +415,7 @@ fn test_navigation_traverse_all_the_way() -> eyre::Result<()> {
         o 96d1c37 create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -438,7 +437,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["-b", "2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout foo --
         O f777ecc (master) create initial.txt
         |
@@ -451,10 +450,10 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         o 355e173 (bar) create test4.txt
         |
         o f81d55c create test5.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.branchless("prev", &["-a", "-b"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout foo --
         O f777ecc (master) create initial.txt
         |
@@ -467,10 +466,10 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         o 355e173 (bar) create test4.txt
         |
         o f81d55c create test5.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.branchless("prev", &["-b"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
         |
@@ -483,12 +482,12 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         o 355e173 (bar) create test4.txt
         |
         o f81d55c create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("next", &["-b", "2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout bar --
         O f777ecc (master) create initial.txt
         |
@@ -501,12 +500,12 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         @ 355e173 (> bar) create test4.txt
         |
         o f81d55c create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("next", &["-a", "-b"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout bar --
         O f777ecc (master) create initial.txt
         |
@@ -519,7 +518,7 @@ fn test_navigation_traverse_branches() -> eyre::Result<()> {
         @ 355e173 (> bar) create test4.txt
         |
         o f81d55c create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -538,14 +537,14 @@ fn test_traverse_branches_ambiguous() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["--all", "--branch"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d (bar, foo) create test1.txt
         |
         o 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -572,10 +571,10 @@ fn test_navigation_failed_to_check_out_commit() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
-        "###);
+        ");
     }
 
     Ok(())
@@ -606,14 +605,14 @@ fn test_switch_pty_branch() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         @ 62fc20d (> master) create test1.txt
         |\
         | o 96d1c37 create test2.txt
         |
         o 4838e49 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -640,13 +639,13 @@ fn test_switch_pty_initial_query() -> eyre::Result<()> {
     )?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
         |
         o 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -671,22 +670,22 @@ fn test_navigation_merge() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --
         Failed to check out commit: 25497cb08387d7d20aa741398b73ce7f924afdb5
-        "###);
-        insta::assert_snapshot!(stderr, @r###"
+        ");
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         error: Your local changes to the following files would be overwritten by checkout:
         	conflicting.txt
         Please commit your changes or stash them before you switch branches.
         Aborting
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["--merge"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --merge --
         M	conflicting.txt
         O f777ecc (master) create initial.txt
@@ -694,12 +693,12 @@ fn test_navigation_merge() -> eyre::Result<()> {
         @ 25497cb create conflicting.txt
         |
         o 6dd5091 create conflicting.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["diff"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         diff --cc conflicting.txt
         index 3bd1f0e,72594ed..0000000
         --- a/conflicting.txt
@@ -711,7 +710,7 @@ fn test_navigation_merge() -> eyre::Result<()> {
         ++=======
         + qux
         ++>>>>>>> local
-        "###);
+        ");
     }
 
     Ok(())
@@ -736,29 +735,29 @@ fn test_navigation_force() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --
         Failed to check out commit: 25497cb08387d7d20aa741398b73ce7f924afdb5
-        "###);
-        insta::assert_snapshot!(stderr, @r###"
+        ");
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         error: Your local changes to the following files would be overwritten by checkout:
         	conflicting.txt
         Please commit your changes or stash them before you switch branches.
         Aborting
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("prev", &["--force"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 25497cb08387d7d20aa741398b73ce7f924afdb5 --force --
         O f777ecc (master) create initial.txt
         |
         @ 25497cb create conflicting.txt
         |
         o 6dd5091 create conflicting.txt
-        "###);
+        ");
     }
 
     {
@@ -781,24 +780,24 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         let git = git.duplicate_repo()?;
         {
             let (stdout, _stderr) = git.branchless("switch", &["-c", "foo", "HEAD^"])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> checkout HEAD^ -b foo --
             :
             @ 62fc20d (> foo) create test1.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
 
         {
             let (stdout, _stderr) = git.branchless("switch", &["-c", "bar"])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> checkout foo -b bar --
             :
             @ 62fc20d (> bar, foo) create test1.txt
             |
             O 96d1c37 (master) create test2.txt
-            "###);
+            ");
         }
     }
 
@@ -808,13 +807,13 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
             git.commit_file_with_contents("test1", 3, "new contents")?;
             git.write_file_txt("test1", "conflicting\n")?;
             let (stdout, _stderr) = git.branchless("switch", &["-f", "HEAD~2"])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             branchless: running command: <git-executable> checkout HEAD~2 --force --
             :
             @ 62fc20d create test1.txt
             :
             O 5b738c1 (master) create test1.txt
-            "###);
+            ");
         }
     }
 
@@ -822,14 +821,14 @@ fn test_navigation_switch_flags() -> eyre::Result<()> {
         git.commit_file_with_contents("test1", 3, "new contents")?;
         git.write_file_txt("test1", "conflicting\n")?;
         let (stdout, _stderr) = git.branchless("switch", &["-m", "HEAD~2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout HEAD~2 --merge --
         M	test1.txt
         :
         @ 62fc20d create test1.txt
         :
         O 5b738c1 (master) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -842,10 +841,10 @@ fn test_navigation_switch_target_only() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("switch", &["master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -863,20 +862,20 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
     {
         {
             let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @"
             @ f777ecc (master) create initial.txt
             |
             o 62fc20d create test1.txt
-            "###);
+            ");
         }
 
         let (stdout, _stderr) = git.branchless("switch", &["descendants(master)"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout 62fc20d2a290daea0d52bdc2ed2ad4be6491010e --
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d create test1.txt
-        "###);
+        ");
     }
 
     git.run(&["checkout", "HEAD~"])?;
@@ -886,13 +885,13 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
     {
         {
             let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-            insta::assert_snapshot!(stdout, @r###"
+            insta::assert_snapshot!(stdout, @r"
             @ f777ecc (master) create initial.txt
             |\
             | o 62fc20d create test1.txt
             |
             o fe65c1f create test2.txt
-            "###);
+            ");
         }
 
         let (_stdout, stderr) = git.branchless_with_options(
@@ -903,36 +902,36 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         Cannot switch to target: expected 'descendants(master)' to contain 1 head, but found 2.
         Target should be a commit or a set of commits with exactly 1 head. Aborting.
-        "###);
+        ");
     }
 
     {
         // switching back to "last checkout"
         let (stdout, _stderr) = git.branchless("switch", &["@{-1}"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout @{-1} --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     {
         // switching back to "last checkout"
         let (stdout, _stderr) = git.branchless("switch", &["-"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout - --
         @ f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         o fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     {
@@ -940,34 +939,34 @@ fn test_navigation_switch_revset() -> eyre::Result<()> {
         // branch, if any
 
         let (stdout, _stderr) = git.branchless("switch", &["master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout master --
         @ f777ecc (> master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         o fe65c1f create test2.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.branchless("switch", &["@{-2}"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout @{-2} --
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.branchless("switch", &["-"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> checkout - --
         @ f777ecc (> master) create initial.txt
         |\
         | o 62fc20d create test1.txt
         |
         o fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -999,13 +998,13 @@ fn test_switch_auto_switch_interactive() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d (> test1) create test1.txt
         |
         o 96d1c37 (test2) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1043,13 +1042,13 @@ fn test_switch_auto_switch_interactive_disabled() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 62fc20d (test1) create test1.txt
         |
         o 96d1c37 (test2) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -1065,35 +1064,35 @@ fn test_switch_detach() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("switch", &["-d"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout master --detach --
         :
         O 62fc20d (foo) create test1.txt
         |
         @ 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("switch", &["-d", "foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout foo --detach --
         :
         @ 62fc20d (foo) create test1.txt
         |
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("switch", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> checkout foo --
         :
         @ 62fc20d (> foo) create test1.txt
         |
         O 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_repair.rs
+++ b/git-branchless/tests/test_repair.rs
@@ -20,7 +20,7 @@ fn test_repair_broken_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
@@ -28,24 +28,23 @@ fn test_repair_broken_commit() -> eyre::Result<()> {
         @ 96d1c37 create test2.txt
         |
         o 70deb1e <garbage collected>
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("repair", &["--no-dry-run"])?;
-        insta::assert_snapshot!(stdout, @"Found and repaired 1 broken commit: 70deb1e28791d8e7dd5a1f0c871a51b91282562f
-");
+        insta::assert_snapshot!(stdout, @"Found and repaired 1 broken commit: 70deb1e28791d8e7dd5a1f0c871a51b91282562f");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o 62fc20d create test1.txt
         |
         @ 96d1c37 create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -71,8 +70,7 @@ fn test_repair_broken_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("repair", &["--no-dry-run"])?;
-        insta::assert_snapshot!(stdout, @"Found and repaired 1 broken branch: foo
-");
+        insta::assert_snapshot!(stdout, @"Found and repaired 1 broken branch: foo");
     }
 
     {
@@ -80,10 +78,10 @@ fn test_repair_broken_branch() -> eyre::Result<()> {
         git.commit_file("test2", 2)?;
 
         let (stdout, _stderr) = git.branchless("smartlog", &["--event-id=-1"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 96d1c37 (> master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_restack.rs
+++ b/git-branchless/tests/test_restack.rs
@@ -19,7 +19,7 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | @ 024c35c amend test1.txt
@@ -32,13 +32,13 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
         hint: there is 1 abandoned commit in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("restack", &["--on-disk"])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -51,7 +51,7 @@ fn test_restack_amended_commit() -> eyre::Result<()> {
         o 8cd7de6 create test2.txt
         |
         o b9a0491 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -96,7 +96,7 @@ fn test_restack_reparent() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("restack", &["--reparent"])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 5acd93e create test2.txt
         [2/2] Committed as: 7a9000d create test3.txt
@@ -162,7 +162,7 @@ fn test_restack_consecutive_rewrites() -> eyre::Result<()> {
         let (stdout, _stderr) = git.branchless("restack", &["--on-disk"])?;
         let stdout = remove_rebase_lines(stdout);
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -175,7 +175,7 @@ fn test_restack_consecutive_rewrites() -> eyre::Result<()> {
         o 8e9bbde create test2.txt
         |
         o 9dc6dd0 create test3.txt
-        "###)
+        ")
     }
 
     Ok(())
@@ -195,13 +195,13 @@ fn test_move_abandoned_branch() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("restack", &[])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No abandoned commits to restack.
         branchless: processing 1 update: branch master
         Finished restacking branches.
         :
         @ 662b451 (master) amend test1.txt v2
-        "###);
+        ");
     }
 
     Ok(())
@@ -226,18 +226,18 @@ fn test_amended_initial_commit() -> eyre::Result<()> {
         // FIXME: there is no topological relationship between the new initial commit and `master`,
         // so they shouldn't be connected in the smartlog.
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         @ 9a9f929 new initial commit
         :
         O 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) =
             git.branchless("restack", &["--on-disk", "--force-rewrite", "all()"])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -246,7 +246,7 @@ fn test_amended_initial_commit() -> eyre::Result<()> {
         @ 9a9f929 new initial commit
         |
         O 6d85943 (master) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -272,7 +272,7 @@ fn test_restack_amended_master() -> eyre::Result<()> {
         let (stdout, _stderr) =
             git.branchless("restack", &["--on-disk", "--force-rewrite", "all()"])?;
         let stdout = remove_rebase_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -282,7 +282,7 @@ fn test_restack_amended_master() -> eyre::Result<()> {
         @ ae94dc2 amended test1
         |
         O 51452b5 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -311,12 +311,12 @@ fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         This operation would cause a merge conflict:
         - (1 conflicting file) 96d1c37 create test2.txt
         To resolve merge conflicts, retry this operation with the --merge option.
-        "###);
+        ");
     }
 
     {
@@ -330,7 +330,7 @@ fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
         )?;
         let stdout = remove_rebase_lines(stdout);
 
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         Failed to merge in-memory, trying again on-disk...
         branchless: running command: <git-executable> diff --quiet
@@ -339,7 +339,7 @@ fn test_restack_aborts_during_rebase_conflict() -> eyre::Result<()> {
         CONFLICT (add/add): Merge conflict in test2.txt
         Error: Could not restack commits (exit code 1).
         You can resolve the error and try running `git restack` again.
-        "###);
+        ");
     }
 
     Ok(())
@@ -368,7 +368,7 @@ fn test_restack_multiple_amended() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("restack", &["--on-disk"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -383,7 +383,7 @@ fn test_restack_multiple_amended() -> eyre::Result<()> {
         o 8e06b96 test3 amended
         |
         o f5644e3 create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -414,7 +414,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -432,12 +432,12 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         hint: there are 2 abandoned commits in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("restack", &["--on-disk", &test2_oid.to_string()])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: ref HEAD
         Executing: git branchless hook-detect-empty-commit 70deb1e28791d8e7dd5a1f0c871a51b91282562f
@@ -465,8 +465,8 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
         Successfully rebased and updated detached HEAD.
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @r"
         branchless: running command: <git-executable> diff --quiet
         Calling Git for on-disk rebase...
         branchless: running command: <git-executable> rebase --continue
@@ -487,7 +487,7 @@ fn test_restack_single_of_many_commits() -> eyre::Result<()> {
         hint: there is 1 abandoned commit in your commit graph
         hint: to fix this, run: git restack
         hint: disable this hint by running: git config --global branchless.hint.smartlogFixAbandoned false
-        "###);
+        ");
     }
 
     Ok(())
@@ -512,14 +512,14 @@ fn test_restack_unobserved_commit() -> eyre::Result<()> {
     git.branchless("init", &[])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         o 96d1c37 (foo) create test2.txt
         |
         @ 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     // Only abandon `test3` now that it's been observed by the DAG.
@@ -528,24 +528,24 @@ fn test_restack_unobserved_commit() -> eyre::Result<()> {
     git.run(&["commit", "--amend", "-m", "Updated test2"])?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 62fc20d (master) create test1.txt
         |
         @ f4229de (> foo) Updated test2
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("restack", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No abandoned commits to restack.
         No abandoned branches to restack.
         :
         O 62fc20d (master) create test1.txt
         |
         @ f4229de (> foo) Updated test2
-        "###);
+        ");
     }
 
     Ok(())
@@ -566,7 +566,7 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("restack", &["-f", "all()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 59e7581 create test2.txt
         branchless: processing 2 updates: branch foo, branch master
@@ -577,7 +577,7 @@ fn test_restack_checked_out_branch() -> eyre::Result<()> {
         No abandoned branches to restack.
         :
         @ 59e7581 (> foo, master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -599,7 +599,7 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("restack", &["-f", "all()"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 59e7581 create test2.txt
         branchless: processing 2 updates: branch foo, branch master
@@ -610,13 +610,13 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
         No abandoned branches to restack.
         :
         @ 59e7581 (> foo, master) create test2.txt
-        "###);
+        ");
     }
 
     git.run(&["reset", "--hard", &test2_oid.to_string()])?;
     {
         let (stdout, _stderr) = git.run(&["sl"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         : x 62fc20d (rewritten as 14042005) create test1.txt
@@ -624,7 +624,7 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
         : % 96d1c37 (rewritten as 59e75818) (> foo) create test2.txt
         :
         O 59e7581 (master) create test2.txt
-        "###);
+        ");
     }
 
     {
@@ -635,13 +635,13 @@ fn test_restack_non_observed_branch_commit() -> eyre::Result<()> {
         // of all descendant commits just because a branch pointed to one of
         // those descendants.
         let (stdout, _stderr) = git.branchless("restack", &["-f"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         No abandoned commits to restack.
         branchless: processing 1 update: branch foo
         Finished restacking branches.
         :
         @ 59e7581 (> foo, master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_reword.rs
+++ b/git-branchless/tests/test_reword.rs
@@ -13,22 +13,22 @@ fn test_reword_head() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (test1) create test1.txt
     |
     @ 96d1c37 (> master) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["--force-rewrite", "--message", "foo"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (test1) create test1.txt
     |
     @ c1f5400 (> master) foo
-    "###);
+    ");
 
     Ok(())
 }
@@ -47,22 +47,22 @@ fn test_reword_current_commit_not_head() -> eyre::Result<()> {
     git.run(&["checkout", "test1"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> test1) create test1.txt
     |
     O 96d1c37 (master) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["--force-rewrite", "--message", "foo"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ a6f8868 (> test1) foo
     |
     O 5207ad5 (master) create test2.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -78,21 +78,20 @@ fn test_reword_with_multiple_messages() -> eyre::Result<()> {
     git.commit_file("test1", 1)?;
 
     let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     62fc20d
     create test1.txt
-    "###);
+    ");
 
     git.branchless("reword", &["-f", "-m", "foo", "-m", "bar"])?;
 
     let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     34ae21e
     foo
 
     bar
-
-    "###);
+    ");
 
     Ok(())
 }
@@ -108,10 +107,10 @@ fn test_reword_preserves_comment_lines_for_messages_on_cli() -> eyre::Result<()>
     git.commit_file("test1", 1)?;
 
     let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     62fc20d
     create test1.txt
-    "###);
+    ");
 
     // try adding several messages that start w/ '#'
     git.branchless(
@@ -121,7 +120,7 @@ fn test_reword_preserves_comment_lines_for_messages_on_cli() -> eyre::Result<()>
 
     // confirm the '#' messages aren't present
     let (stdout, _stderr) = git.run(&["log", "-n", "1", "--format=%h%n%B"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     11a0c54
     foo
 
@@ -130,7 +129,7 @@ fn test_reword_preserves_comment_lines_for_messages_on_cli() -> eyre::Result<()>
     #
 
     buz
-    "###);
+    ");
 
     Ok(())
 }
@@ -148,22 +147,22 @@ fn test_reword_non_head_commit() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (test1) create test1.txt
     |
     @ 96d1c37 (> master) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["HEAD^", "--force-rewrite", "--message", "bar"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 8d4a670 (test1) bar
     |
     @ 8f7f70e (> master) create test2.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -181,12 +180,12 @@ fn test_reword_multiple_commits_on_same_branch() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (test1) create test1.txt
     |
     @ 96d1c37 (> master) create test2.txt
-    "###);
+    ");
 
     let (_stdout, _stderr) = git.branchless(
         "reword",
@@ -194,12 +193,12 @@ fn test_reword_multiple_commits_on_same_branch() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O a6f8868 (test1) foo
     |
     @ e2308b3 (> master) foo
-    "###);
+    ");
 
     Ok(())
 }
@@ -222,7 +221,7 @@ fn test_reword_tree() -> eyre::Result<()> {
     git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 96d1c37 (master) create test2.txt
     |
@@ -231,13 +230,13 @@ fn test_reword_tree() -> eyre::Result<()> {
     | o 355e173 create test4.txt
     |
     @ 9ea1b36 create test5.txt
-    "###);
+    ");
 
     let (_stdout, _stderr) =
         git.branchless("reword", &[&test3_oid.to_string(), "--message", "foo"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 96d1c37 (master) create test2.txt
     |
@@ -246,7 +245,7 @@ fn test_reword_tree() -> eyre::Result<()> {
     | o a367935 create test4.txt
     |
     @ 38f9ce9 create test5.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -269,7 +268,7 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     git.commit_file("test5", 5)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -280,7 +279,7 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     o bf0d52a create test4.txt
     |
     @ 848121c create test5.txt
-    "###);
+    ");
 
     let (_stdout, _stderr) = git.branchless(
         "reword",
@@ -293,7 +292,7 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     )?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     :
     O 62fc20d (master) create test1.txt
     |\
@@ -304,7 +303,7 @@ fn test_reword_across_branches() -> eyre::Result<()> {
     o 3c442fc foo
     |
     @ 8648fbd create test5.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -325,12 +324,12 @@ fn test_reword_exit_early_public_commit() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         You are trying to rewrite 1 public commit, such as: 62fc20d create test1.txt
         It is generally not advised to rewrite public commits, because your
         collaborators will have difficulty merging your changes.
         Retry with -f/--force-rewrite to proceed anyways.
-        "###);
+        ");
     }
 
     Ok(())
@@ -349,24 +348,24 @@ fn test_reword_fixup_head() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 96d1c37 (> test) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["--fixup", "HEAD^"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 9a86e82 (> test) fixup! create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -384,24 +383,24 @@ fn test_reword_fixup_non_head_commit() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 96d1c37 (> test) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["HEAD^", "--fixup", "roots(all())"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o aa7ed8f fixup! create initial.txt
     |
     @ 7e17323 (> test) create test2.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -419,24 +418,24 @@ fn test_reword_fixup_multiple_commits() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 96d1c37 (> test) create test2.txt
-    "###);
+    ");
 
     git.branchless("reword", &["stack()", "--fixup", "roots(all())"])?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o aa7ed8f fixup! create initial.txt
     |
     @ 5a30497 (> test) fixup! create initial.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -454,13 +453,13 @@ fn test_reword_fixup_only_accepts_single_commit() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 96d1c37 (> test) create test2.txt
-    "###);
+    ");
 
     let (_stdout, stderr) = git.branchless_with_options(
         "reword",
@@ -470,10 +469,10 @@ fn test_reword_fixup_only_accepts_single_commit() -> eyre::Result<()> {
             ..Default::default()
         },
     )?;
-    insta::assert_snapshot!(stderr, @r###"
-        --fixup expects exactly 1 commit, but 'ancestors(HEAD)' evaluated to 3.
-        Aborting.
-    "###);
+    insta::assert_snapshot!(stderr, @"
+    --fixup expects exactly 1 commit, but 'ancestors(HEAD)' evaluated to 3.
+    Aborting.
+    ");
 
     Ok(())
 }
@@ -491,13 +490,13 @@ fn test_reword_fixup_ancestry_issue() -> eyre::Result<()> {
     git.commit_file("test2", 2)?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     O f777ecc (master) create initial.txt
     |
     o 62fc20d create test1.txt
     |
     @ 96d1c37 (> test) create test2.txt
-    "###);
+    ");
 
     let (_stdout, stderr) = git.branchless_with_options(
         "reword",
@@ -507,10 +506,10 @@ fn test_reword_fixup_ancestry_issue() -> eyre::Result<()> {
             ..Default::default()
         },
     )?;
-    insta::assert_snapshot!(stderr, @r###"
-        The commit supplied to --fixup must be an ancestor of all commits being reworded.
-        Aborting.
-    "###);
+    insta::assert_snapshot!(stderr, @"
+    The commit supplied to --fixup must be an ancestor of all commits being reworded.
+    Aborting.
+    ");
 
     Ok(())
 }
@@ -533,7 +532,7 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -545,31 +544,31 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         | & (merge) 96d1c37 create test2.txt
         |/
         @ a4dd9b0 Merge commit '96d1c37a3d4363611c49f7e52186e189a04c531f' into HEAD
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("reword", &["-m", "new message"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Previous HEAD position was a4dd9b0 Merge commit '96d1c37a3d4363611c49f7e52186e189a04c531f' into HEAD
         branchless: processing 1 update: ref HEAD
         HEAD is now at 2fc54bd new message
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/1] Committed as: 2fc54bd new message
         branchless: processing 1 rewritten commit
         branchless: running command: <git-executable> checkout 2fc54bd59c79078e6d9012df241bcc90f0199596 --
         In-memory rebase succeeded.
         Reworded commit a4dd9b0 as 2fc54bd new message
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -581,12 +580,12 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         | & (merge) 96d1c37 create test2.txt
         |/
         @ 2fc54bd new message
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["diff", "master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         diff --git a/test2.txt b/test2.txt
         new file mode 100644
         index 0000000..4e512d2
@@ -601,12 +600,12 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         +++ b/test3.txt
         @@ -0,0 +1 @@
         +test3 contents
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("reword", &["draft()", "-m", "new message 2"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/3] Committed as: 11f31c5 new message 2
         [2/3] Committed as: 800dd6c new message 2
@@ -618,12 +617,12 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         Reworded commit 4838e49 as 11f31c5 new message 2
         Reworded commit 2fc54bd as 930244c new message 2
         Reworded 3 commits. If this was unintentional, run: git undo
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 62fc20d (master) create test1.txt
         |\
@@ -635,12 +634,12 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         | & (merge) 800dd6c new message 2
         |/
         @ 930244c new message 2
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["diff", "master"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         diff --git a/test2.txt b/test2.txt
         new file mode 100644
         index 0000000..4e512d2
@@ -655,7 +654,7 @@ fn test_reword_merge_commit() -> eyre::Result<()> {
         +++ b/test3.txt
         @@ -0,0 +1 @@
         +test3 contents
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_smartlog_worktree.rs
+++ b/git-branchless/tests/test_smartlog_worktree.rs
@@ -10,10 +10,10 @@ fn test_smartlog_hides_linked_worktrees_by_default() -> eyre::Result<()> {
     let _worktree = make_git_worktree(&git, "side")?;
 
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> master) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -27,10 +27,10 @@ fn test_smartlog_shows_detached_linked_worktree() -> eyre::Result<()> {
     let _worktree = make_git_worktree(&git, "side")?;
 
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> master) (> <repo-name>, wt side) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -45,10 +45,10 @@ fn test_smartlog_shows_current_and_home_worktree_annotations() -> eyre::Result<(
     let worktree = worktree_wrapper.worktree;
 
     let (stdout, _stderr) = worktree.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (master) (wt <repo-name>, > topic-wt) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -63,10 +63,10 @@ fn test_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
 
     git.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
     let stdout = git.smartlog()?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> master) (> <repo-name>, wt side) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -81,12 +81,12 @@ fn test_navigation_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
 
     git.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
     let (stdout, _stderr) = git.branchless("prev", &[])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     branchless: running command: <git-executable> checkout f777ecc9b0db5ed372b2615695191a8a17f79f24 --
     @ f777ecc (> <repo-name>) create initial.txt
     |
     O 62fc20d (master) (wt side) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -105,12 +105,12 @@ fn test_smartlog_shows_attached_linked_worktree_outside_default_selection() -> e
 
     git.run(&["config", "branchless.smartlog.defaultRevset", "none()"])?;
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     O 62fc20d (topic) (wt topic-wt) create test1.txt
     |
     @ 96d1c37 (> master) (> <repo-name>) create test2.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -135,7 +135,7 @@ fn test_move_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
     worktree.run(&["config", "branchless.smartlog.showWorktrees", "true"])?;
 
     let (stdout, _stderr) = worktree.branchless("move", &["-s", "@", "-d", "master"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Attempting rebase in-memory...
     [1/1] Committed as: 4838e49 create test3.txt
     branchless: processing 1 rewritten commit
@@ -147,7 +147,7 @@ fn test_move_smartlog_shows_worktrees_from_config() -> eyre::Result<()> {
     |
     @ 4838e49 (> topic-wt) create test3.txt
     In-memory rebase succeeded.
-    "###);
+    ");
 
     Ok(())
 }
@@ -177,11 +177,11 @@ fn test_smartlog_syncs_detached_linked_worktree_head_not_in_dag() -> eyre::Resul
     ])?;
 
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     o b1ee011 (wt outside-wt) outside
     :
     @ 62fc20d (> master) (> <repo-name>) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -196,10 +196,10 @@ fn test_smartlog_ignores_prunable_worktree() -> eyre::Result<()> {
     std::fs::remove_dir_all(&worktree_wrapper.worktree.repo_path)?;
 
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> master) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }
@@ -269,10 +269,10 @@ fn test_smartlog_disambiguates_duplicate_worktree_names() -> eyre::Result<()> {
     ])?;
 
     let (stdout, _stderr) = git.branchless("smartlog", &["--worktrees"])?;
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @"
     :
     @ 62fc20d (> master) (> <repo-name>, wt bugfix/topic, wt feature/topic) create test1.txt
-    "###);
+    ");
 
     Ok(())
 }

--- a/git-branchless/tests/test_snapshot.rs
+++ b/git-branchless/tests/test_snapshot.rs
@@ -21,7 +21,7 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch master
         Changes to be committed:
           (use "git restore --staged <file>..." to unstage)
@@ -49,40 +49,39 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +test1 new contents
-        "###);
+        "#);
     }
 
     let original_status = {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         1 .M N... 100644 100644 100644 7432a8fff25da8f35a9960893ad6155d1d150d39 7432a8fff25da8f35a9960893ad6155d1d150d39 test1.txt
         1 M. N... 100644 100644 100644 4e512d2fd80b9630225ca53f211aeff0544f8b36 4480ae41d60ff497031ec9d48870ed9604477173 test2.txt
-        "###);
+        ");
         stdout
     };
 
     let snapshot_oid = {
         let (snapshot_oid, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(snapshot_oid.trim())?
     };
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         On branch master
         nothing to commit, working tree clean
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: restoring from snapshot
         branchless: processing 2 updates: branch master, ref HEAD
         branchless: processing 1 update: ref HEAD
@@ -90,8 +89,8 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
         branchless: processing checkout
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: branch master
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 96d1c37 create test2.txt
         branchless: running command: <git-executable> checkout f7ec40d081d7fa358f5e283ebf42f06a1508084c --
@@ -101,13 +100,13 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
         M	test2.txt
         branchless: running command: <git-executable> update-ref refs/heads/master 96d1c37a3d4363611c49f7e52186e189a04c531f
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/master
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch master
         Changes to be committed:
           (use "git restore --staged <file>..." to unstage)
@@ -135,16 +134,16 @@ fn test_restore_snapshot_basic() -> eyre::Result<()> {
         @@ -1 +1 @@
         -test1 contents
         +test1 new contents
-        "###);
+        "#);
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         1 .M N... 100644 100644 100644 7432a8fff25da8f35a9960893ad6155d1d150d39 7432a8fff25da8f35a9960893ad6155d1d150d39 test1.txt
         1 M. N... 100644 100644 100644 4e512d2fd80b9630225ca53f211aeff0544f8b36 4480ae41d60ff497031ec9d48870ed9604477173 test2.txt
-        "###);
+        ");
         assert_eq!(original_status, stdout);
     }
 
@@ -168,17 +167,16 @@ fn test_restore_snapshot_deleted_files() -> eyre::Result<()> {
     let original_status = {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         1 .D N... 100644 100644 000000 7432a8fff25da8f35a9960893ad6155d1d150d39 7432a8fff25da8f35a9960893ad6155d1d150d39 test1.txt
         1 D. N... 100644 000000 000000 4e512d2fd80b9630225ca53f211aeff0544f8b36 0000000000000000000000000000000000000000 test2.txt
-        "###);
+        ");
         stdout
     };
 
     let snapshot_oid = {
         let (snapshot_oid, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(snapshot_oid.trim())?
     };
 
@@ -192,7 +190,7 @@ fn test_restore_snapshot_deleted_files() -> eyre::Result<()> {
         let (stdout, stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: restoring from snapshot
         branchless: processing 2 updates: branch master, ref HEAD
         branchless: processing 1 update: ref HEAD
@@ -200,8 +198,8 @@ fn test_restore_snapshot_deleted_files() -> eyre::Result<()> {
         branchless: processing checkout
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: branch master
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 96d1c37 create test2.txt
         branchless: running command: <git-executable> checkout 1935fedb3b0232849e52e44225b2e5bbe9de0ff7 --
@@ -211,16 +209,16 @@ fn test_restore_snapshot_deleted_files() -> eyre::Result<()> {
         D	test2.txt
         branchless: running command: <git-executable> update-ref refs/heads/master 96d1c37a3d4363611c49f7e52186e189a04c531f
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/master
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         1 .D N... 100644 100644 000000 7432a8fff25da8f35a9960893ad6155d1d150d39 7432a8fff25da8f35a9960893ad6155d1d150d39 test1.txt
         1 D. N... 100644 000000 000000 4e512d2fd80b9630225ca53f211aeff0544f8b36 0000000000000000000000000000000000000000 test2.txt
-        "###);
+        ");
         assert_eq!(original_status, stdout);
     }
 
@@ -242,16 +240,15 @@ fn test_restore_snapshot_delete_file_only_in_index() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         1 D. N... 100644 000000 000000 7432a8fff25da8f35a9960893ad6155d1d150d39 0000000000000000000000000000000000000000 test1.txt
         ? test1.txt
-        "###);
+        ");
     }
 
     let snapshot_oid = {
         let (snapshot_oid, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(snapshot_oid.trim())?
     };
 
@@ -265,7 +262,7 @@ fn test_restore_snapshot_delete_file_only_in_index() -> eyre::Result<()> {
         let (stdout, stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: restoring from snapshot
         branchless: processing 2 updates: branch master, ref HEAD
         branchless: processing 1 update: ref HEAD
@@ -273,8 +270,8 @@ fn test_restore_snapshot_delete_file_only_in_index() -> eyre::Result<()> {
         branchless: processing checkout
         branchless: processing 1 update: ref HEAD
         branchless: processing 1 update: branch master
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 62fc20d create test1.txt
         branchless: running command: <git-executable> checkout eb8b9eecf747c1aa08bb9dd0cbda15b9a90082af --
@@ -283,14 +280,13 @@ fn test_restore_snapshot_delete_file_only_in_index() -> eyre::Result<()> {
         D	test1.txt
         branchless: running command: <git-executable> update-ref refs/heads/master 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/master
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @"1 D. N... 100644 000000 000000 7432a8fff25da8f35a9960893ad6155d1d150d39 0000000000000000000000000000000000000000 test1.txt
-");
+        insta::assert_snapshot!(stdout, @"1 D. N... 100644 000000 000000 7432a8fff25da8f35a9960893ad6155d1d150d39 0000000000000000000000000000000000000000 test1.txt");
     }
 
     Ok(())
@@ -309,8 +305,7 @@ fn test_restore_snapshot_respect_untracked_changes() -> eyre::Result<()> {
 
     let snapshot_oid = {
         let (snapshot_oid, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(snapshot_oid.trim())?
     };
 
@@ -335,19 +330,19 @@ fn test_restore_snapshot_respect_untracked_changes() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: restoring from snapshot
         branchless: processing 1 update: ref HEAD
         error: The following untracked working tree files would be overwritten by checkout:
         	test1.txt
         Please move or remove them before you switch branches.
         Aborting
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at f777ecc create initial.txt
         branchless: running command: <git-executable> checkout cd8605eef8b78e22427fa3846f1a23f95e88aa7e --
-        "###);
+        ");
     }
 
     Ok(())
@@ -384,7 +379,7 @@ fn test_snapshot_merge_conflict() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch change
         You have unmerged paths.
           (fix conflicts and run "git commit")
@@ -396,42 +391,41 @@ fn test_snapshot_merge_conflict() -> eyre::Result<()> {
 
         * Unmerged path test2.txt
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     let snapshot_oid = {
         let (stdout, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(stdout.trim())?
     };
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         On branch change
         nothing to commit, working tree clean
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 588fac3 delete test2.txt
         branchless: running command: <git-executable> checkout 1ea5d7118ef363f3e4ed0ed6c250dd01b91bff2a --
         branchless: running command: <git-executable> reset 588fac31cba846f7278a95e1361c45118be90c6c --
         branchless: running command: <git-executable> update-ref refs/heads/change 588fac31cba846f7278a95e1361c45118be90c6c
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/change
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch change
         Unmerged paths:
           (use "git restore --staged <file>..." to unstage)
@@ -440,7 +434,7 @@ fn test_snapshot_merge_conflict() -> eyre::Result<()> {
 
         * Unmerged path test2.txt
         no changes added to commit (use "git add" and/or "git commit -a")
-        "###);
+        "#);
     }
 
     Ok(())
@@ -462,50 +456,48 @@ fn test_snapshot_restore_unborn_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch master
 
         No commits yet
 
         nothing to commit (create/copy files and use "git add" to track)
-        "###);
+        "#);
     }
 
     let snapshot_oid = {
         let (snapshot_oid, stderr) = git.branchless("snapshot", &["create"])?;
-        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot
-");
+        insta::assert_snapshot!(stderr, @"branchless: creating working copy snapshot");
         NonZeroOid::from_str(snapshot_oid.trim())?
     };
 
     git.commit_file("test1", 1)?;
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @"@ 6118a39 (> master) create test1.txt
-");
+        insta::assert_snapshot!(stdout, @"@ 6118a39 (> master) create test1.txt");
     }
 
     {
         let (stdout, _stderr) =
             git.branchless("snapshot", &["restore", &snapshot_oid.to_string()])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> reset --hard HEAD --
         HEAD is now at 6118a39 create test1.txt
         branchless: running command: <git-executable> checkout 20939f1f30f51ffaa6569d218cd7a50f24c956cf --
         branchless: running command: <git-executable> update-ref refs/heads/master 0000000000000000000000000000000000000000
         branchless: running command: <git-executable> symbolic-ref HEAD refs/heads/master
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["status", "-vv"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         On branch master
 
         No commits yet
 
         nothing to commit (create/copy files and use "git add" to track)
-        "###);
+        "#);
     }
 
     Ok(())

--- a/git-branchless/tests/test_split.rs
+++ b/git-branchless/tests/test_split.rs
@@ -16,24 +16,24 @@ fn test_split_detached_head() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ e48cdc5 first commit
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 2932db7 first commit
-            |
-            o 01523cc temp(split): test2.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 2932db7 first commit
+        |
+        o 01523cc temp(split): test2.txt (+1)
+        ");
     }
 
     {
@@ -41,15 +41,15 @@ fn test_split_detached_head() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -71,28 +71,28 @@ fn test_split_added_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 0f6059d first commit
-        "###);
+        insta::assert_snapshot!(stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 0f6059d first commit
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 2f9e232b389b1bc8035f4e5bde79f262c0af020c --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 2f9e232 first commit
-            |
-            o c4b067e temp(split): test2.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 2f9e232b389b1bc8035f4e5bde79f262c0af020c --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 2f9e232 first commit
+        |
+        o c4b067e temp(split): test2.txt (+1)
+        ");
     }
 
     {
@@ -100,14 +100,14 @@ fn test_split_added_file() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test1.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -128,28 +128,28 @@ fn test_split_modified_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 0f6059d first commit
-        "###);
+        insta::assert_snapshot!(stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 0f6059d first commit
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 495b4c0 first commit
-            |
-            o 5375cb6 temp(split): test1.txt (+1/-1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 495b4c0 first commit
+        |
+        o 5375cb6 temp(split): test1.txt (+1/-1)
+        ");
     }
 
     {
@@ -157,14 +157,14 @@ fn test_split_modified_file() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test1.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -186,37 +186,37 @@ fn test_split_deleted_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 94e9c28 first commit
-        "###);
+        insta::assert_snapshot!(stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 94e9c28 first commit
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 -
-            test2.txt | 1 +
-            2 files changed, 1 insertion(+), 1 deletion(-)
+        test1.txt | 1 -
+        test2.txt | 1 +
+        2 files changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test1.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 62fc20d create test1.txt
-            |
-            @ 495b4c0 first commit
-            |
-            o de6e4df temp(split): test1.txt (-1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 495b4c09b4cc1755847ba0fd42c903f9c7eecc00 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 62fc20d create test1.txt
+        |
+        @ 495b4c0 first commit
+        |
+        o de6e4df temp(split): test1.txt (-1)
+        ");
     }
 
     {
@@ -224,14 +224,14 @@ fn test_split_deleted_file() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 -
-            1 file changed, 1 deletion(-)
+        test1.txt | 1 -
+        1 file changed, 1 deletion(-)
         ");
     }
 
@@ -252,24 +252,24 @@ fn test_split_multiple_files() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ e48cdc5 first commit
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "test3.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 8e5c74b7a1f09fc7ee1754763c810e3f00fe9b05 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 8e5c74b first commit
-            |
-            o 57020b0 temp(split): 2 files (+2)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 8e5c74b7a1f09fc7ee1754763c810e3f00fe9b05 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 8e5c74b first commit
+        |
+        o 57020b0 temp(split): 2 files (+2)
+        ");
     }
 
     {
@@ -277,15 +277,15 @@ fn test_split_multiple_files() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test2.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
@@ -307,25 +307,25 @@ fn test_split_detached_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ e48cdc5 (branch-name) first commit
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: processing 1 update: branch branch-name
-            branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 2932db7 (branch-name) first commit
-            |
-            o 01523cc temp(split): test2.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: processing 1 update: branch branch-name
+        branchless: running command: <git-executable> checkout 2932db7d1099237d79cbd43e29707d70e545d471 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 2932db7 (branch-name) first commit
+        |
+        o 01523cc temp(split): test2.txt (+1)
+        ");
     }
 
     Ok(())
@@ -346,33 +346,33 @@ fn test_split_attached_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ e48cdc5 (> branch-name) first commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["status"])?;
         insta::assert_snapshot!(&stdout, @"
-            On branch branch-name
-            nothing to commit, working tree clean
+        On branch branch-name
+        nothing to commit, working tree clean
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: processing 1 update: branch branch-name
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            @ 01523cc (> branch-name) temp(split): test2.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: processing 1 update: branch branch-name
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 01523cc (> branch-name) temp(split): test2.txt (+1)
+        ");
 
         let (stdout, _stderr) = git.run(&["status", "--short"])?;
-        insta::assert_snapshot!(&stdout, @r#""#);
+        insta::assert_snapshot!(&stdout, @"");
     }
 
     Ok(())
@@ -394,45 +394,45 @@ fn test_split_restacks_descendents() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 3d220e0 create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: a629a22 create test3.txt
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            o 01523cc temp(split): test2.txt (+1)
-            |
-            @ a629a22 create test3.txt
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: a629a22 create test3.txt
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        o 01523cc temp(split): test2.txt (+1)
+        |
+        @ a629a22 create test3.txt
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -455,47 +455,47 @@ fn test_split_detach() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 3d220e0 create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--detach"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: f88fbe5 create test3.txt
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout f88fbe5901493ffe1c669cdb8aa5f056dc0bb605 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |\
-            | o 01523cc temp(split): test2.txt (+1)
-            |
-            @ f88fbe5 create test3.txt
-        "###);
+        insta::assert_snapshot!(&stdout, @r"
+        Attempting rebase in-memory...
+        [1/1] Committed as: f88fbe5 create test3.txt
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout f88fbe5901493ffe1c669cdb8aa5f056dc0bb605 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |\
+        | o 01523cc temp(split): test2.txt (+1)
+        |
+        @ f88fbe5 create test3.txt
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (split_commit, _stderr) = git.run(&["query", "--raw", "exactly(siblings(HEAD), 1)"])?;
         let (stdout, _stderr) =
             git.run(&["show", "--pretty=format:", "--stat", split_commit.trim()])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -522,94 +522,92 @@ fn test_split_discard() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 8c3edf7 second commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            test4.txt | 1 +
-            test5.txt | 1 +
-            3 files changed, 3 insertions(+), 1 deletion(-)
+        test3.txt | 2 +-
+        test4.txt | 1 +
+        test5.txt | 1 +
+        3 files changed, 3 insertions(+), 1 deletion(-)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--discard"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: 6e23d3d second commit
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 6e23d3dfe1baeb366ebc31a61c32a19ca6a4ab63 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            @ 6e23d3d second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 6e23d3d second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout 6e23d3dfe1baeb366ebc31a61c32a19ca6a4ab63 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 6e23d3d second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["ls-files"])?;
         insta::assert_snapshot!(&stdout, @"
-            initial.txt
-            test1.txt
-            test3.txt
-            test4.txt
-            test5.txt
+        initial.txt
+        test1.txt
+        test3.txt
+        test4.txt
+        test5.txt
         ");
     }
 
     {
         let (stdout, _stderr) =
             git.branchless("split", &["HEAD", "test3.txt", "test4.txt", "--discard"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 6128a569e64c77d8a847293b81ae8c96357b751c --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            @ 6128a56 second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 6128a569e64c77d8a847293b81ae8c96357b751c --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 6128a56 second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test5.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test5.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["ls-files"])?;
         insta::assert_snapshot!(&stdout, @"
-            initial.txt
-            test1.txt
-            test3.txt
-            test5.txt
+        initial.txt
+        test1.txt
+        test3.txt
+        test5.txt
         ");
 
         let (stdout, _stderr) = git.run(&["show", ":test3.txt"])?;
-        insta::assert_snapshot!(&stdout, @"
-            contents3
-        ");
+        insta::assert_snapshot!(&stdout, @"contents3");
     }
 
     Ok(())
@@ -635,28 +633,28 @@ fn test_split_reparent() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 8c3edf7 second commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            test4.txt | 1 +
-            test5.txt | 1 +
-            3 files changed, 3 insertions(+), 1 deletion(-)
+        test3.txt | 2 +-
+        test4.txt | 1 +
+        test5.txt | 1 +
+        3 files changed, 3 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -678,20 +676,20 @@ fn test_split_reparent() -> eyre::Result<()> {
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         // the discarded test2 is effectively squashed into the second commit
         // due to --reparent
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(&stdout, @r"
-            test2.txt | 1 +
-            test3.txt | 2 +-
-            test4.txt | 1 +
-            test5.txt | 1 +
-            4 files changed, 4 insertions(+), 1 deletion(-)
+        insta::assert_snapshot!(&stdout, @"
+        test2.txt | 1 +
+        test3.txt | 2 +-
+        test4.txt | 1 +
+        test5.txt | 1 +
+        4 files changed, 4 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -717,28 +715,28 @@ fn test_split_reparent() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
-        insta::assert_snapshot!(&stdout, @r"
-            test3.txt | 1 +
-            1 file changed, 1 insertion(+)
+        insta::assert_snapshot!(&stdout, @"
+        test3.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         // the detached test1 is effectively squashed into the second commit
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
-        insta::assert_snapshot!(&stdout, @r"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 2 +-
-            test4.txt | 1 +
-            test5.txt | 1 +
-            5 files changed, 5 insertions(+), 1 deletion(-)
+        insta::assert_snapshot!(&stdout, @"
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 2 +-
+        test4.txt | 1 +
+        test5.txt | 1 +
+        5 files changed, 5 insertions(+), 1 deletion(-)
         ");
 
         let (split_commit, _stderr) = git.run(&["query", "--raw", "exactly(siblings(HEAD), 1)"])?;
         let (stdout, _stderr) =
             git.run(&["show", "--pretty=format:", "--stat", split_commit.trim()])?;
-        insta::assert_snapshot!(&stdout, @r"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        insta::assert_snapshot!(&stdout, @"
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -769,28 +767,28 @@ fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
         // HEAD~ contains new test1-3
         // HEAD contains update test3 and new test4&5
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 8c3edf7 (> my-branch) second commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            test4.txt | 1 +
-            test5.txt | 1 +
-            3 files changed, 3 insertions(+), 1 deletion(-)
+        test3.txt | 2 +-
+        test4.txt | 1 +
+        test5.txt | 1 +
+        3 files changed, 3 insertions(+), 1 deletion(-)
         ");
     }
 
@@ -798,34 +796,34 @@ fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
         // discard test2 from HEAD~: should be removed from commit and disk
 
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--discard"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: 6e23d3d second commit
-            branchless: processing 1 update: branch my-branch
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout my-branch --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            @ 6e23d3d (> my-branch) second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 6e23d3d second commit
+        branchless: processing 1 update: branch my-branch
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout my-branch --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 6e23d3d (> my-branch) second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["ls-files"])?;
         insta::assert_snapshot!(&stdout, @"
-            initial.txt
-            test1.txt
-            test3.txt
-            test4.txt
-            test5.txt
+        initial.txt
+        test1.txt
+        test3.txt
+        test4.txt
+        test5.txt
         ");
     }
 
@@ -835,34 +833,32 @@ fn test_split_discard_bug_checked_out_branch() -> eyre::Result<()> {
 
         let (stdout, _stderr) =
             git.branchless("split", &["HEAD", "test3.txt", "test4.txt", "--discard"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: processing 1 update: branch my-branch
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            @ 6128a56 (> my-branch) second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: processing 1 update: branch my-branch
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        @ 6128a56 (> my-branch) second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test5.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test5.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["ls-files"])?;
         insta::assert_snapshot!(&stdout, @"
-            initial.txt
-            test1.txt
-            test3.txt
-            test5.txt
+        initial.txt
+        test1.txt
+        test3.txt
+        test5.txt
         ");
 
         let (stdout, _stderr) = git.run(&["show", ":test3.txt"])?;
-        insta::assert_snapshot!(&stdout, @"
-            contents3
-        ")
+        insta::assert_snapshot!(&stdout, @"contents3")
     }
 
     Ok(())
@@ -886,58 +882,58 @@ fn test_split_insert_before_added_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 3d220e0 create test3.txt
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test3.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt", "--before"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/2] Committed as: 7014c04 first commit
-            [2/2] Committed as: 22bd240 create test3.txt
-            branchless: processing 2 rewritten commits
-            branchless: running command: <git-executable> checkout 22bd2405a4660938b88615fb2b1283bfa2a52f8e --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o d02e8c5 temp(split): test2.txt (+1)
-            |
-            o 7014c04 first commit
-            |
-            @ 22bd240 create test3.txt
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/2] Committed as: 7014c04 first commit
+        [2/2] Committed as: 22bd240 create test3.txt
+        branchless: processing 2 rewritten commits
+        branchless: running command: <git-executable> checkout 22bd2405a4660938b88615fb2b1283bfa2a52f8e --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o d02e8c5 temp(split): test2.txt (+1)
+        |
+        o 7014c04 first commit
+        |
+        @ 22bd240 create test3.txt
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
@@ -965,57 +961,57 @@ fn test_split_insert_before_modified_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 7249f22 second commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 2 +-
-            test3.txt | 2 +-
-            2 files changed, 2 insertions(+), 2 deletions(-)
+        test2.txt | 2 +-
+        test3.txt | 2 +-
+        2 files changed, 2 insertions(+), 2 deletions(-)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: 38fe8b7 second commit
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout 38fe8b76f889772efd0dd5cc1acb6ac02c85f9fb --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o e48cdc5 first commit
-            |
-            o 188b0a1 temp(split): test2.txt (+1/-1)
-            |
-            @ 38fe8b7 second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: 38fe8b7 second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout 38fe8b76f889772efd0dd5cc1acb6ac02c85f9fb --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        o 188b0a1 temp(split): test2.txt (+1/-1)
+        |
+        @ 38fe8b7 second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test2.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test3.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -1043,57 +1039,57 @@ fn test_split_insert_before_deleted_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 98ebe2f second commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 -
-            test3.txt | 2 +-
-            2 files changed, 1 insertion(+), 2 deletions(-)
+        test2.txt | 1 -
+        test3.txt | 2 +-
+        2 files changed, 1 insertion(+), 2 deletions(-)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: f8502a2 second commit
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout f8502a26000b8f90597f6861d7f3c0330fdf4351 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o e48cdc5 first commit
-            |
-            o e5b771d temp(split): test2.txt (-1)
-            |
-            @ f8502a2 second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: f8502a2 second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout f8502a26000b8f90597f6861d7f3c0330fdf4351 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        o e5b771d temp(split): test2.txt (-1)
+        |
+        @ f8502a2 second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 -
-            1 file changed, 1 deletion(-)
+        test2.txt | 1 -
+        1 file changed, 1 deletion(-)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test3.txt | 2 +-
-            1 file changed, 1 insertion(+), 1 deletion(-)
+        test3.txt | 2 +-
+        1 file changed, 1 insertion(+), 1 deletion(-)
         ");
     }
 
@@ -1114,46 +1110,46 @@ fn test_split_insert_before_attached_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 4d11d02 (> branch-name) first commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: c678b65 first commit
-            branchless: processing 1 update: branch branch-name
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout branch-name --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o d02e8c5 temp(split): test2.txt (+1)
-            |
-            @ c678b65 (> branch-name) first commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: c678b65 first commit
+        branchless: processing 1 update: branch branch-name
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout branch-name --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o d02e8c5 temp(split): test2.txt (+1)
+        |
+        @ c678b65 (> branch-name) first commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -1174,46 +1170,46 @@ fn test_split_insert_before_detached_branch() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 4d11d02 (branch-name) first commit
-        "###);
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD", "test2.txt", "--before"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: c678b65 first commit
-            branchless: processing 1 update: branch branch-name
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout c678b6529d8f33a6903e25f70327464bd77f1ca1 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o d02e8c5 temp(split): test2.txt (+1)
-            |
-            @ c678b65 (branch-name) first commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: c678b65 first commit
+        branchless: processing 1 update: branch branch-name
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout c678b6529d8f33a6903e25f70327464bd77f1ca1 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o d02e8c5 temp(split): test2.txt (+1)
+        |
+        @ c678b65 (branch-name) first commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test1.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -1236,45 +1232,45 @@ fn test_split_undo_works() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         o e48cdc5 first commit
         |
         @ 3d220e0 create test3.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: a629a22 create test3.txt
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 2932db7 first commit
-            |
-            o 01523cc temp(split): test2.txt (+1)
-            |
-            @ a629a22 create test3.txt
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: a629a22 create test3.txt
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout a629a22974b9232523701e66e6e2bcdf8ffc8ad1 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 2932db7 first commit
+        |
+        o 01523cc temp(split): test2.txt (+1)
+        |
+        @ a629a22 create test3.txt
+        ");
     }
 
     {
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~2"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+)
+        test1.txt | 1 +
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+)
         ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 1 +
-            1 file changed, 1 insertion(+)
+        test2.txt | 1 +
+        1 file changed, 1 insertion(+)
         ");
     }
 
@@ -1282,20 +1278,20 @@ fn test_split_undo_works() -> eyre::Result<()> {
         let (_stdout, _stderr) = git.branchless("undo", &["--yes"])?;
 
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o e48cdc5 first commit
-            |
-            @ 3d220e0 create test3.txt
-            "###);
+        insta::assert_snapshot!(stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o e48cdc5 first commit
+        |
+        @ 3d220e0 create test3.txt
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD~"])?;
         insta::assert_snapshot!(&stdout, @"
-            test1.txt | 1 +
-            test2.txt | 1 +
-            test3.txt | 1 +
-            3 files changed, 3 insertions(+)
+        test1.txt | 1 +
+        test2.txt | 1 +
+        test3.txt | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -1317,11 +1313,11 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 2998051 first commit
-        "###);
+        ");
     }
 
     {
@@ -1335,22 +1331,22 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout d9d41a308e25a71884831c865c356da43cc5294e --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ d9d41a3 first commit
-            |
-            o 98da165 temp(split): subdir/test3.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout d9d41a308e25a71884831c865c356da43cc5294e --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ d9d41a3 first commit
+        |
+        o 98da165 temp(split): subdir/test3.txt (+1)
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            subdir/test1.txt | 1 +
-            test1.txt        | 1 +
-            test2.txt        | 1 +
-            3 files changed, 3 insertions(+)
+        subdir/test1.txt | 1 +
+        test1.txt        | 1 +
+        test2.txt        | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -1367,22 +1363,22 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 0cb81546d386a2064603c05ce7dc9759591f5a93 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 0cb8154 first commit
-            |
-            o 89564a0 temp(split): subdir/test1.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 0cb81546d386a2064603c05ce7dc9759591f5a93 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 0cb8154 first commit
+        |
+        o 89564a0 temp(split): subdir/test1.txt (+1)
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            subdir/test3.txt | 1 +
-            test1.txt        | 1 +
-            test2.txt        | 1 +
-            3 files changed, 3 insertions(+)
+        subdir/test3.txt | 1 +
+        test1.txt        | 1 +
+        test2.txt        | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -1399,22 +1395,22 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 912204674dfda3ab5fe089dddd1c9bf17b3c2965 --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 9122046 first commit
-            |
-            o c3d37e6 temp(split): test2.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 912204674dfda3ab5fe089dddd1c9bf17b3c2965 --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 9122046 first commit
+        |
+        o c3d37e6 temp(split): test2.txt (+1)
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            subdir/test1.txt | 1 +
-            subdir/test3.txt | 1 +
-            test1.txt        | 1 +
-            3 files changed, 3 insertions(+)
+        subdir/test1.txt | 1 +
+        subdir/test3.txt | 1 +
+        test1.txt        | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -1431,22 +1427,22 @@ fn test_split_supports_absolute_relative_and_repo_relative_paths() -> eyre::Resu
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stdout, @r###"
-            branchless: running command: <git-executable> checkout 6d0cd9b8fb1938e50250f30427a0d4865b351f2f --
-            Nothing to restack.
-            O f777ecc (master) create initial.txt
-            |
-            @ 6d0cd9b first commit
-            |
-            o 9eeb11b temp(split): test1.txt (+1)
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        branchless: running command: <git-executable> checkout 6d0cd9b8fb1938e50250f30427a0d4865b351f2f --
+        Nothing to restack.
+        O f777ecc (master) create initial.txt
+        |
+        @ 6d0cd9b first commit
+        |
+        o 9eeb11b temp(split): test1.txt (+1)
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            subdir/test1.txt | 1 +
-            subdir/test3.txt | 1 +
-            test2.txt        | 1 +
-            3 files changed, 3 insertions(+)
+        subdir/test1.txt | 1 +
+        subdir/test3.txt | 1 +
+        test2.txt        | 1 +
+        3 files changed, 3 insertions(+)
         ");
     }
 
@@ -1465,11 +1461,11 @@ fn test_split_unchanged_file() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 8e5c74b first commit
-        "###);
+        ");
     }
 
     {
@@ -1481,9 +1477,7 @@ fn test_split_unchanged_file() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stderr, @r###"
-            Aborting: file 'initial.txt' was not changed in commit 8e5c74b.
-        "###);
+        insta::assert_snapshot!(&stderr, @"Aborting: file 'initial.txt' was not changed in commit 8e5c74b.");
     }
 
     Ok(())
@@ -1501,11 +1495,11 @@ fn test_split_will_not_split_to_empty_commit() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ 8e5c74b first commit
-        "###);
+        ");
     }
 
     {
@@ -1517,9 +1511,7 @@ fn test_split_will_not_split_to_empty_commit() -> eyre::Result<()> {
                 ..Default::default()
             },
         )?;
-        insta::assert_snapshot!(&stderr, @r###"
-            Aborting: refusing to split all changes out of commit 8e5c74b.
-        "###);
+        insta::assert_snapshot!(&stderr, @"Aborting: refusing to split all changes out of commit 8e5c74b.");
     }
 
     Ok(())
@@ -1545,13 +1537,13 @@ fn test_split_does_not_unhide_obsolete_children() -> eyre::Result<()> {
 
         // verify initial state
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o 4d11d02 first commit
-            |
-            @ 61d094b second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o 4d11d02 first commit
+        |
+        @ 61d094b second commit
+        ");
     }
 
     {
@@ -1560,13 +1552,13 @@ fn test_split_does_not_unhide_obsolete_children() -> eyre::Result<()> {
         git.branchless("amend", &[])?;
 
         let (stdout, _stderr) = git.branchless("smartlog", &[])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            O f777ecc (master) create initial.txt
-            |
-            o 4d11d02 first commit
-            |
-            @ 6698c7b second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        O f777ecc (master) create initial.txt
+        |
+        o 4d11d02 first commit
+        |
+        @ 6698c7b second commit
+        ");
     }
 
     {
@@ -1575,26 +1567,26 @@ fn test_split_does_not_unhide_obsolete_children() -> eyre::Result<()> {
         // There should be only 1 child. split should not unhide previously
         // hidden/rewritten/obsolete commits.
         let (stdout, _stderr) = git.branchless("split", &["HEAD~", "test2.txt"])?;
-        insta::assert_snapshot!(&stdout, @r###"
-            Attempting rebase in-memory...
-            [1/1] Committed as: ae95d4c second commit
-            branchless: processing 1 rewritten commit
-            branchless: running command: <git-executable> checkout ae95d4c54730973107527df675e53de5aec4f855 --
-            In-memory rebase succeeded.
-            O f777ecc (master) create initial.txt
-            |
-            o 8e5c74b first commit
-            |
-            o a55d783 temp(split): test2.txt (+1)
-            |
-            @ ae95d4c second commit
-        "###);
+        insta::assert_snapshot!(&stdout, @"
+        Attempting rebase in-memory...
+        [1/1] Committed as: ae95d4c second commit
+        branchless: processing 1 rewritten commit
+        branchless: running command: <git-executable> checkout ae95d4c54730973107527df675e53de5aec4f855 --
+        In-memory rebase succeeded.
+        O f777ecc (master) create initial.txt
+        |
+        o 8e5c74b first commit
+        |
+        o a55d783 temp(split): test2.txt (+1)
+        |
+        @ ae95d4c second commit
+        ");
 
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "HEAD"])?;
         insta::assert_snapshot!(&stdout, @"
-            test2.txt | 2 +-
-            test3.txt | 1 +
-            2 files changed, 2 insertions(+), 1 deletion(-)
+        test2.txt | 2 +-
+        test3.txt | 1 +
+        2 files changed, 2 insertions(+), 1 deletion(-)
         ");
     }
 

--- a/git-branchless/tests/test_sync.rs
+++ b/git-branchless/tests/test_sync.rs
@@ -27,7 +27,7 @@ fn test_sync_basic() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -39,20 +39,20 @@ fn test_sync_basic() -> eyre::Result<()> {
         | o 2b633ed create test4.txt
         |
         @ 117e086 (> master) create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("sync", &[])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Switched to branch 'master'
         branchless: processing checkout
         branchless: creating working copy snapshot
         Switched to branch 'master'
         branchless: processing checkout
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 87c7a36 create test1.txt
         [2/2] Committed as: 8ee4f26 create test2.txt
@@ -66,12 +66,12 @@ fn test_sync_basic() -> eyre::Result<()> {
         In-memory rebase succeeded.
         Synced 62fc20d create test1.txt
         Synced 2b633ed create test4.txt
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         @ 117e086 (> master) create test5.txt
         |\
@@ -80,7 +80,7 @@ fn test_sync_basic() -> eyre::Result<()> {
         | o 8ee4f26 create test2.txt
         |
         o d7e7e6c create test4.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -104,8 +104,7 @@ fn test_sync_up_to_date() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.branchless("sync", &[])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @"Not moving up-to-date stack at 70deb1e create test3.txt
-");
+        insta::assert_snapshot!(stdout, @"Not moving up-to-date stack at 70deb1e create test3.txt");
     }
 
     Ok(())
@@ -142,7 +141,7 @@ fn test_sync_pull() -> eyre::Result<()> {
 
     {
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O 96d1c37 (master) create test2.txt
         |
@@ -151,13 +150,13 @@ fn test_sync_pull() -> eyre::Result<()> {
         o 355e173 create test4.txt
         |
         @ 6ac5566 create test6.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = cloned_repo.branchless("sync", &["-p"])?;
         let stdout: String = remove_nondeterministic_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> fetch --all
         Fast-forwarding branch master to f81d55c create test5.txt
         Attempting rebase in-memory...
@@ -166,27 +165,27 @@ fn test_sync_pull() -> eyre::Result<()> {
         branchless: running command: <git-executable> checkout 2831fb5864ee099dc3e448a38dcb3c8527149510 --
         In-memory rebase succeeded.
         Synced 6ac5566 create test6.txt
-        "###);
+        ");
     }
 
     {
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         O f81d55c (master) create test5.txt
         |
         @ 2831fb5 create test6.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = cloned_repo.branchless("sync", &["-p"])?;
         let stdout: String = remove_nondeterministic_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> fetch --all
         Not updating branch master at f81d55c create test5.txt
         Not moving up-to-date stack at 2831fb5 create test6.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -216,7 +215,7 @@ fn test_sync_reparent() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -228,19 +227,19 @@ fn test_sync_reparent() -> eyre::Result<()> {
         | o 2b633ed create test4.txt
         |
         @ 117e086 (> master) create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, stderr) = git.branchless("sync", &["--reparent"])?;
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: creating working copy snapshot
         Switched to branch 'master'
         branchless: processing checkout
         branchless: creating working copy snapshot
         Switched to branch 'master'
         branchless: processing checkout
-        "###);
+        ");
         insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 9343a7d create test1.txt
@@ -275,7 +274,7 @@ fn test_sync_reparent() -> eyre::Result<()> {
     {
         // the reparented test1 will effectively undo test3 & test5
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "9343a7d"])?;
-        insta::assert_snapshot!(&stdout, @r"
+        insta::assert_snapshot!(&stdout, @"
         test1.txt | 1 +
         test3.txt | 1 -
         test5.txt | 1 -
@@ -284,7 +283,7 @@ fn test_sync_reparent() -> eyre::Result<()> {
 
         // similar the reparented test4 will effectively undo test5
         let (stdout, _stderr) = git.run(&["show", "--pretty=format:", "--stat", "e8f8c47"])?;
-        insta::assert_snapshot!(&stdout, @r"
+        insta::assert_snapshot!(&stdout, @"
         test4.txt | 1 +
         test5.txt | 1 -
         2 files changed, 1 insertion(+), 1 deletion(-)
@@ -315,7 +314,7 @@ fn test_sync_stack_from_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 96d1c37 create test2.txt
         |\
@@ -326,12 +325,12 @@ fn test_sync_stack_from_commit() -> eyre::Result<()> {
         | o f57e36f (bar) create test4.txt
         |
         @ d2e18e3 (> master) create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("sync", &["foo"])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         [1/2] Committed as: 8e521a1 create test3.txt
         [2/2] Committed as: 11bfd99 create test3-1.txt
@@ -340,12 +339,12 @@ fn test_sync_stack_from_commit() -> eyre::Result<()> {
         branchless: running command: <git-executable> checkout master --
         In-memory rebase succeeded.
         Synced 70deb1e create test3.txt
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         :
         O 96d1c37 create test2.txt
         |\
@@ -356,7 +355,7 @@ fn test_sync_stack_from_commit() -> eyre::Result<()> {
         o 8e521a1 create test3.txt
         |
         o 11bfd99 (foo) create test3-1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -389,16 +388,16 @@ fn test_sync_divergent_main_branch() -> eyre::Result<()> {
 
     {
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ d2e18e3 (> master) create test5.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = cloned_repo.branchless("sync", &["-p"])?;
         let stdout = remove_nondeterministic_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         branchless: running command: <git-executable> fetch --all
         Syncing branch master
         Attempting rebase in-memory...
@@ -410,15 +409,15 @@ fn test_sync_divergent_main_branch() -> eyre::Result<()> {
           (use "git push" to publish your local commits)
         In-memory rebase succeeded.
         Synced d2e18e3 create test5.txt
-        "###);
+        "#);
     }
 
     {
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ f81d55c (> master) create test5.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -459,7 +458,7 @@ fn test_sync_no_delete_main_branch() -> eyre::Result<()> {
         let (stdout, stderr) = cloned_repo.branchless("sync", &["-p", "--on-disk"])?;
         let stdout = remove_nondeterministic_lines(stdout);
         let stderr = remove_nondeterministic_lines(stderr);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         branchless: processing 1 update: ref HEAD
         Executing: git branchless hook-skip-upstream-applied-commit 6ffd720862b7ae71cbe30d66ed27ea8579e24b0f
         Executing: git branchless hook-register-extra-post-rewrite-hook
@@ -471,8 +470,8 @@ fn test_sync_no_delete_main_branch() -> eyre::Result<()> {
         :
         @ 96d1c37 (> master) create test2.txt
         Successfully rebased and updated detached HEAD.
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> fetch --all
         Syncing branch master
         branchless: running command: <git-executable> diff --quiet
@@ -480,15 +479,15 @@ fn test_sync_no_delete_main_branch() -> eyre::Result<()> {
         branchless: running command: <git-executable> rebase --continue
         Skipping commit (was already applied upstream): 6ffd720 updated commit message
         Synced 6ffd720 updated commit message
-        "###);
+        ");
     }
 
     {
         let stdout = cloned_repo.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 96d1c37 (> master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -514,7 +513,7 @@ fn test_sync_merge_commit() -> eyre::Result<()> {
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc create initial.txt
         |\
         | o 62fc20d create test1.txt
@@ -529,17 +528,17 @@ fn test_sync_merge_commit() -> eyre::Result<()> {
         | o 5cedb02 Merge branch 'foo' into HEAD
         |
         @ 8f7aef5 (> master) create test4.txt
-        "###);
+        ");
     }
 
     {
         let (stdout, _stderr) = git.branchless("sync", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Attempting rebase in-memory...
         Attempting rebase in-memory...
         Can't rebase merge commit in-memory: 62fc20d create test1.txt
         Can't rebase merge commit in-memory: 98b9119 create test3.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -570,21 +569,21 @@ fn test_sync_checked_out_main_branch() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = cloned_repo.branchless("sync", &["--pull"])?;
         let stdout: String = remove_nondeterministic_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
-            branchless: running command: <git-executable> fetch --all
-            Fast-forwarding branch master to 96d1c37 create test2.txt
-            branchless: running command: <git-executable> rebase 96d1c37a3d4363611c49f7e52186e189a04c531f
-            "###);
+        insta::assert_snapshot!(stdout, @"
+        branchless: running command: <git-executable> fetch --all
+        Fast-forwarding branch master to 96d1c37 create test2.txt
+        branchless: running command: <git-executable> rebase 96d1c37a3d4363611c49f7e52186e189a04c531f
+        ");
     }
 
     {
         let (stdout, _stderr) = cloned_repo.run(&["status"])?;
-        insta::assert_snapshot!(stdout, @r###"
-            On branch master
-            Your branch is up to date with 'origin/master'.
+        insta::assert_snapshot!(stdout, @"
+        On branch master
+        Your branch is up to date with 'origin/master'.
 
-            nothing to commit, working tree clean
-            "###);
+        nothing to commit, working tree clean
+        ");
     }
 
     Ok(())
@@ -621,15 +620,15 @@ fn test_sync_checked_out_main_with_dirty_working_copy() -> eyre::Result<()> {
             },
         )?;
         let stdout: String = remove_nondeterministic_lines(stdout);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @"
         error: cannot rebase: You have unstaged changes.
         error: Please commit or stash them.
-        "###);
-        insta::assert_snapshot!(stdout, @r###"
+        ");
+        insta::assert_snapshot!(stdout, @"
         branchless: running command: <git-executable> fetch --all
         Not updating branch master at 62fc20d create test1.txt
         branchless: running command: <git-executable> rebase 62fc20d2a290daea0d52bdc2ed2ad4be6491010e
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_undo.rs
+++ b/git-branchless/tests/test_undo.rs
@@ -101,7 +101,7 @@ fn test_undo_help() -> eyre::Result<()> {
                 CursiveTestingEvent::Event('q'.into()),
             ],
         )?;
-        insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+        insta::assert_snapshot!(screen_to_string(&screenshot1), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │O f777ecc (master) create initial.txt                                                                                 │
         │                                                                                                                      │
@@ -126,7 +126,7 @@ fn test_undo_help() -> eyre::Result<()> {
         ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
         │There are no previous available events.                                                                               │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
+        ");
     }
 
     Ok(())
@@ -157,14 +157,14 @@ fn test_undo_navigate() -> eyre::Result<()> {
                 CursiveTestingEvent::Event(Key::Enter.into()),
             ],
         )?;
-        insta::assert_debug_snapshot!(event_cursor, @r###"
-            Some(
-                EventCursor {
-                    event_id: 6,
-                },
-            )
-            "###);
-        insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+        insta::assert_debug_snapshot!(event_cursor, @"
+        Some(
+            EventCursor {
+                event_id: 6,
+            },
+        )
+        ");
+        insta::assert_snapshot!(screen_to_string(&screenshot1), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
         │@ 96d1c37 (master) create test2.txt                                                                                   │
@@ -189,8 +189,8 @@ fn test_undo_navigate() -> eyre::Result<()> {
         │2. Move branch master from 62fc20d create test1.txt                                                                   │
         │                        to 96d1c37 create test2.txt                                                                   │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
-        insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
+        ");
+        insta::assert_snapshot!(screen_to_string(&screenshot2), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │:                                                                                                                     │
         │@ 96d1c37 (master) create test2.txt                                                                                   │
@@ -215,7 +215,7 @@ fn test_undo_navigate() -> eyre::Result<()> {
         │1. Commit 96d1c37 create test2.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
+        ");
     };
 
     Ok(())
@@ -247,7 +247,7 @@ fn test_go_to_event() -> eyre::Result<()> {
         ],
     )?;
 
-    insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+    insta::assert_snapshot!(screen_to_string(&screenshot1), @"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
     │@ 96d1c37 (master) create test2.txt                                                                                   │
@@ -272,8 +272,8 @@ fn test_go_to_event() -> eyre::Result<()> {
     │1. Commit 96d1c37 create test2.txt                                                                                    │
     │                                                                                                                      │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-    "###);
-    insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
+    ");
+    insta::assert_snapshot!(screen_to_string(&screenshot2), @"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
     │@ 62fc20d create test1.txt                                                                                            │
@@ -298,7 +298,7 @@ fn test_go_to_event() -> eyre::Result<()> {
     │1. Check out from f777ecc create initial.txt                                                                          │
     │               to 62fc20d create test1.txt                                                                            │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-    "###);
+    ");
 
     Ok(())
 }
@@ -321,11 +321,11 @@ fn test_undo_hide() -> eyre::Result<()> {
     {
         let (stdout, stderr) = git.run(&["smartlog"])?;
         insta::assert_snapshot!(stderr, @"");
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         O f777ecc (master) create initial.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     let event_cursor = run_select_past_event(
@@ -336,37 +336,37 @@ fn test_undo_hide() -> eyre::Result<()> {
             CursiveTestingEvent::Event('y'.into()),
         ],
     )?;
-    insta::assert_debug_snapshot!(event_cursor, @r###"
-        Some(
-            EventCursor {
-                event_id: 9,
-            },
-        )
-        "###);
+    insta::assert_debug_snapshot!(event_cursor, @"
+    Some(
+        EventCursor {
+            event_id: 9,
+        },
+    )
+    ");
     let event_cursor = event_cursor.unwrap();
 
     {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Create branch test1 at 62fc20d create test1.txt
 
         2. Unhide commit 62fc20d create test1.txt
 
         Confirm? [yN] Applied 2 inverse events.
-        "###);
+        ");
         assert_eq!(exit_code, 0);
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         O f777ecc (master) create initial.txt
         |\
         | o 62fc20d (test1) create test1.txt
         |
         @ fe65c1f create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -393,18 +393,18 @@ fn test_undo_move_refs() -> eyre::Result<()> {
             CursiveTestingEvent::Event('y'.into()),
         ],
     )?;
-    insta::assert_debug_snapshot!(event_cursor, @r###"
-        Some(
-            EventCursor {
-                event_id: 3,
-            },
-        )
-        "###);
+    insta::assert_debug_snapshot!(event_cursor, @"
+    Some(
+        EventCursor {
+            event_id: 3,
+        },
+    )
+    ");
     let event_cursor = event_cursor.unwrap();
 
     {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Hide commit 96d1c37 create test2.txt
 
@@ -414,16 +414,16 @@ fn test_undo_move_refs() -> eyre::Result<()> {
                        to 62fc20d create test1.txt
         Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         Applied 3 inverse events.
-        "###);
+        ");
         assert_eq!(exit_code, 0);
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -455,7 +455,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
     )?;
 
     if git.supports_reference_transactions()? {
-        insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+        insta::assert_snapshot!(screen_to_string(&screenshot1), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │O f777ecc (master) create initial.txt                                                                                 │
         │|                                                                                                                     │
@@ -480,8 +480,8 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         │1. Hide commit 62fc20d create test1.txt                                                                               │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
-        insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
+        ");
+        insta::assert_snapshot!(screen_to_string(&screenshot2), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │O f777ecc (master) create initial.txt                                                                                 │
         │|                                                                                                                     │
@@ -506,9 +506,9 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         │1. Commit 62fc20d create test1.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
+        ");
     } else {
-        insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+        insta::assert_snapshot!(screen_to_string(&screenshot1), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │O f777ecc (master) create initial.txt                                                                                 │
         │|                                                                                                                     │
@@ -533,8 +533,8 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         │1. Hide commit 62fc20d create test1.txt                                                                               │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
-        insta::assert_snapshot!(screen_to_string(&screenshot2), @r###"
+        ");
+        insta::assert_snapshot!(screen_to_string(&screenshot2), @"
         ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
         │O f777ecc (master) create initial.txt                                                                                 │
         │|                                                                                                                     │
@@ -559,7 +559,7 @@ fn test_historical_smartlog_visibility() -> eyre::Result<()> {
         │1. Commit 62fc20d create test1.txt                                                                                    │
         │                                                                                                                      │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-        "###);
+        ");
     }
 
     Ok(())
@@ -594,7 +594,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
             CursiveTestingEvent::Event(Key::Enter.into()),
         ],
     )?;
-    insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+    insta::assert_snapshot!(screen_to_string(&screenshot1), @"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
     │O 62fc20d (master) create test1.txt                                                                                   │
@@ -619,7 +619,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
     ┌──────────────────────────────────────────────────────┤ Events ├──────────────────────────────────────────────────────┐
     │There are no previous available events.                                                                               │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-    "###);
+    ");
 
     // If there are no dirty files in the repository prior to the `undo`,
     // then there should still be no dirty files after the `undo`.
@@ -630,7 +630,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
     }
     {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Delete branch bar at 62fc20d create test1.txt
 
@@ -644,7 +644,7 @@ fn test_undo_doesnt_make_working_dir_dirty() -> eyre::Result<()> {
 
         Confirm? [yN] branchless: running command: <git-executable> checkout master --detach --
         Applied 5 inverse events.
-        "###);
+        ");
         assert_eq!(exit_code, 0);
     }
     {
@@ -686,7 +686,7 @@ fn test_git_bisect_produces_empty_event() -> eyre::Result<()> {
             CursiveTestingEvent::Event(Key::Enter.into()),
         ],
     )?;
-    insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+    insta::assert_snapshot!(screen_to_string(&screenshot1), @"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
     │@ 62fc20d (master) create test1.txt                                                                                   │
@@ -711,7 +711,7 @@ fn test_git_bisect_produces_empty_event() -> eyre::Result<()> {
     │1. Empty event for BISECT_HEAD                                                                                        │
     │   This may be an unsupported use-case; see https://github.com/arxanas/git-branchless/issues/57                       │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-    "###);
+    ");
 
     Ok(())
 }
@@ -740,19 +740,19 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
 
     {
         let (stdout, _stderr) = git.branchless("gc", &[])?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         branchless: collecting garbage
         branchless: 1 dangling reference deleted
-        "###);
+        ");
     }
     git.run(&["gc", "--prune=now"])?;
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 62fc20d (master) create test1.txt
-        "###);
+        ");
     }
 
     let screenshot1 = Default::default();
@@ -767,7 +767,7 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
             CursiveTestingEvent::Event(Key::Enter.into()),
         ],
     )?;
-    insta::assert_snapshot!(screen_to_string(&screenshot1), @r###"
+    insta::assert_snapshot!(screen_to_string(&screenshot1), @"
     ┌───────────────────────────────────────────────────┤ Commit graph ├───────────────────────────────────────────────────┐
     │:                                                                                                                     │
     │O 62fc20d (master) create test1.txt                                                                                   │
@@ -792,12 +792,12 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
     │1. Hide commit <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>                                       │
     │                                                                                                                      │
     └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-    "###);
+    ");
 
     let event_cursor = event_cursor.unwrap();
     {
         let (exit_code, stdout) = run_undo_events(&git, event_cursor)?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Move branch master from 62fc20d create test1.txt
                                 to 62fc20d create test1.txt
@@ -807,7 +807,7 @@ fn test_undo_garbage_collected_commit() -> eyre::Result<()> {
                        to <commit not available: 96d1c37a3d4363611c49f7e52186e189a04c531f>
         Confirm? [yN] branchless: running command: <git-executable> checkout 96d1c37a3d4363611c49f7e52186e189a04c531f --detach --
         Failed to check out commit: 96d1c37a3d4363611c49f7e52186e189a04c531f
-        "###);
+        ");
         assert!(exit_code > 0);
     }
 
@@ -838,7 +838,7 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
             },
         )?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Rewrite commit 9ed8f9a bad message
                       as 96d1c37 create test2.txt
@@ -849,15 +849,15 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         4. Check out from 9ed8f9a bad message
                        to 96d1c37 create test2.txt
         Confirm? [yN] Aborted.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 9ed8f9a (> master) bad message
-        "###);
+        ");
     }
 
     {
@@ -870,7 +870,7 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
             },
         )?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Rewrite commit 9ed8f9a bad message
                       as 96d1c37 create test2.txt
@@ -884,15 +884,15 @@ fn test_undo_noninteractive() -> eyre::Result<()> {
         :
         @ 96d1c37 (master) create test2.txt
         Applied 4 inverse events.
-        "###);
+        ");
     }
 
     {
         let stdout = git.smartlog()?;
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         :
         @ 96d1c37 (master) create test2.txt
-        "###);
+        ");
     }
 
     Ok(())
@@ -912,12 +912,12 @@ fn test_undo_no_confirm() -> eyre::Result<()> {
     {
         let (stdout, _stderr) = git.branchless("undo", &["--yes"])?;
         let stdout = trim_lines(stdout);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @"
         Will apply these actions:
         1. Hide commit 62fc20d create test1.txt
 
         Applied 1 inverse event.
-        "###);
+        ");
     }
 
     Ok(())

--- a/git-branchless/tests/test_wrap.rs
+++ b/git-branchless/tests/test_wrap.rs
@@ -174,7 +174,7 @@ fn test_wrap_rebase_in_transaction() -> eyre::Result<()> {
         ]
         "###);
     } else if git_version < GitVersion(2, 35, 0) {
-        insta::assert_debug_snapshot!(events, @r###"
+        insta::assert_debug_snapshot!(events, @r#"
         [
             RefUpdateEvent {
                 timestamp: 0.0,
@@ -311,7 +311,7 @@ fn test_wrap_rebase_in_transaction() -> eyre::Result<()> {
                 message: None,
             },
         ]
-        "###);
+        "#);
     }
 
     Ok(())

--- a/scm-bisect/src/basic.rs
+++ b/scm-bisect/src/basic.rs
@@ -399,7 +399,7 @@ mod tests {
         let mut search = Search::new(graph, nodes);
 
         search.notify(4, Status::Success).unwrap();
-        insta::assert_debug_snapshot!(search.notify(3, Status::Failure), @r###"
+        insta::assert_debug_snapshot!(search.notify(3, Status::Failure), @"
         Err(
             InconsistentStateTransition {
                 ancestor_node: 3,
@@ -408,9 +408,9 @@ mod tests {
                 descendant_status: Success,
             },
         )
-        "###);
+        ");
 
-        insta::assert_debug_snapshot!(search.notify(4, Status::Indeterminate), @r###"
+        insta::assert_debug_snapshot!(search.notify(4, Status::Indeterminate), @"
         Err(
             IllegalStateTransition {
                 node: 4,
@@ -418,10 +418,10 @@ mod tests {
                 to: Indeterminate,
             },
         )
-        "###);
+        ");
 
         search.notify(5, Status::Failure).unwrap();
-        insta::assert_debug_snapshot!(search.notify(6, Status::Success), @r###"
+        insta::assert_debug_snapshot!(search.notify(6, Status::Success), @"
         Err(
             InconsistentStateTransition {
                 ancestor_node: 5,
@@ -430,7 +430,7 @@ mod tests {
                 descendant_status: Success,
             },
         )
-        "###);
+        ");
     }
 
     #[test]


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1686


---

tests: upgrade `insta` from 1.47 to 1.48

The snapshot format apparently changed, so it can sometimes produce errors of this form:

```text
Snapshot test passes but the existing value is in a legacy format. Please run `cargo insta test --force-update-snapshots` to update to a newer format. Snapshot contents:
```

This commit upgrades `insta` and applies the changes resulting from:

```console
$ cargo insta test --workspace force-update-snapshots
```

