### PR TITLE
[1/1] fix(docs): fix warnings for private items

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Run `cargo doc`
         env:
           RUSTDOCFLAGS: "--deny warnings"
-        run: cargo doc --workspace --no-deps
+        run: cargo doc --workspace --no-deps --document-private-items

--- a/git-branchless-hook/src/lib.rs
+++ b/git-branchless-hook/src/lib.rs
@@ -233,8 +233,8 @@ mod reference_transaction {
         /// The string is expected to be one field from a reference transaction
         /// line, which can be one of the following values:
         ///
-        /// ref:<symbolic ref name>
-        /// <commit hash>
+        /// - `ref:<symbolic ref name>`
+        /// - `<commit hash>`
         fn from_str(value: &str) -> Result<Self, Self::Err> {
             match value.strip_prefix("ref:") {
                 Some(refname) => Ok(ReferenceTarget::Symbolic {
@@ -426,10 +426,10 @@ mod reference_transaction {
         }
     }
     /// As per the discussion at
-    /// https://public-inbox.org/git/CAKjfCeBcuYC3OXRVtxxDGWRGOxC38Fb7CNuSh_dMmxpGVip_9Q@mail.gmail.com/,
+    /// <https://public-inbox.org/git/CAKjfCeBcuYC3OXRVtxxDGWRGOxC38Fb7CNuSh_dMmxpGVip_9Q@mail.gmail.com/>,
     /// the OIDs passed to the reference transaction can't actually be trusted
     /// when dealing with packed references, so we need to look up their actual
-    /// values on disk again. See https://git-scm.com/docs/git-pack-refs for
+    /// values on disk again. See <https://git-scm.com/docs/git-pack-refs> for
     /// details about packed references.
     ///
     /// Supposing we have a ref named `refs/heads/foo` pointing to an OID

--- a/git-branchless-lib/src/core/effects.rs
+++ b/git-branchless-lib/src/core/effects.rs
@@ -190,7 +190,7 @@ impl RootOperation {
     }
 
     /// Re-render all operation progress bars. This does not change their
-    /// ordering like [`refresh_multi_progress`] does.
+    /// ordering like [`Self::refresh_multi_progress`] does.
     pub fn tick(&mut self) {
         let operations = {
             let mut acc = Vec::new();

--- a/git-branchless-lib/src/core/eventlog.rs
+++ b/git-branchless-lib/src/core/eventlog.rs
@@ -955,7 +955,7 @@ impl EventReplayer {
         };
     }
 
-    /// See https://github.com/arxanas/git-branchless/issues/7.
+    /// See <https://github.com/arxanas/git-branchless/issues/7>.
     fn fix_event_git_v2_31(&self, event: Event) -> Option<Event> {
         let event = match event {
             // Git v2.31 will sometimes fail to set the `old_ref` field when

--- a/git-branchless-lib/src/testing.rs
+++ b/git-branchless-lib/src/testing.rs
@@ -756,7 +756,7 @@ impl Deref for GitWrapper {
     }
 }
 
-/// From https://stackoverflow.com/a/65192210
+/// From <https://stackoverflow.com/a/65192210>
 /// License: CC-BY-SA 4.0
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
     fs::create_dir_all(&dst)?;


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/git-branchless/pull/1690


---

fix(docs): fix warnings for private items

Test plan
---------

```scrut
$ RUSTDOCFLAGS='--deny warnings' cargo doc --workspace --no-deps --document-private-items
```

