### PR TITLE
fix: warn instead of panicking when a working copy snapshot cannot be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (#1629): `git test` no longer fails to create its results directory when the test command contains characters that are invalid in a path on Windows (such as `|`, `<`, `>`, `:`, `*`, `?`, `"`, or `\`).
+- (#1658): snapshot failures (e.g. unreadable files) no longer panic; checkout-type commands proceed with a warning (unless proceeding would immediately discard the unsnapshotted changes) and other commands report a rendered error.
 
 ## [v0.11.1] - 2026-05-21
 

--- a/git-branchless-invoke/src/lib.rs
+++ b/git-branchless-invoke/src/lib.rs
@@ -235,6 +235,29 @@ pub fn do_main_and_drop_locals<T: Parser>(
     Ok(exit_code)
 }
 
+/// Render a top-level fatal error and exit the process, without going
+/// through Rust's panic machinery.
+///
+/// This is used (instead of `.expect(..)`) for errors that surface at the
+/// top level of a command, so that users see a clean, readable error
+/// message (including any `color_eyre::Help` suggestion sections) rather
+/// than a "the application panicked (crashed)" banner and a spantrace. Real
+/// bugs (actual Rust panics) still go through the panic handler installed by
+/// `color_eyre::install()`.
+pub fn exit_with_result(result: eyre::Result<i32>) -> ! {
+    match result {
+        Ok(exit_code) => std::process::exit(exit_code),
+        Err(err) => {
+            // `{:?}` on an `eyre::Report` renders via the hook installed by
+            // `color_eyre::install()`, which includes any attached
+            // `Suggestion` sections -- the same rendering a panic would use,
+            // just without the panic banner and backtrace-on-panic framing.
+            eprintln!("Error: {err:?}");
+            std::process::exit(1)
+        }
+    }
+}
+
 /// Invoke the provided subcommand main function. This should be used in the
 /// `main.rs` file for the subcommand executable. For example:
 ///
@@ -248,6 +271,6 @@ pub fn invoke_subcommand_main<T: Parser>(f: impl Fn(CommandContext, T) -> EyreEx
     // Install panic handler.
     color_eyre::install().expect("Could not install panic handler");
     let args = std::env::args_os().collect();
-    let exit_code = do_main_and_drop_locals(f, args).expect("A fatal error occurred");
-    std::process::exit(exit_code);
+    let result = do_main_and_drop_locals(f, args);
+    exit_with_result(result)
 }

--- a/git-branchless-lib/src/core/check_out.rs
+++ b/git-branchless-lib/src/core/check_out.rs
@@ -12,11 +12,11 @@ use tracing::instrument;
 
 use crate::core::config::get_auto_switch_branches;
 use crate::git::{
-    CategorizedReferenceName, GitRunInfo, MaybeZeroOid, NonZeroOid, ReferenceName, Repo, Stage,
-    UpdateIndexCommand, WorkingCopySnapshot, update_index,
+    CategorizedReferenceName, GitRunInfo, MaybeZeroOid, NonZeroOid, ReferenceName, Repo, RepoError,
+    Stage, UpdateIndexCommand, WorkingCopySnapshot, update_index,
 };
 use crate::try_exit_code;
-use crate::util::EyreExitOr;
+use crate::util::{ExitCode, EyreExitOr};
 
 use super::config::get_undo_create_snapshots;
 use super::effects::Effects;
@@ -135,8 +135,46 @@ pub fn check_out_commit(
         Some(CheckoutTarget::Unknown(target)) => (Some(target), None),
     };
 
+    // Tracks whether the opportunistic pre-checkout snapshot below failed.
+    // If it did, and this checkout later turns out to be restoring a
+    // snapshot (see the `restore_snapshot` call further down), we must not
+    // proceed: that snapshot is the only safety net for the user's current
+    // uncommitted changes, and `restore_snapshot` unconditionally does a
+    // `reset --hard`, which would silently discard them.
+    let mut snapshot_failed = false;
+
     if get_undo_create_snapshots(repo)? {
-        create_snapshot(effects, git_run_info, repo, event_log_db, event_tx_id)?;
+        // This snapshot is purely an opportunistic undo safety net: it's
+        // discarded immediately after being created here (only its
+        // event-log record is kept, for `git undo` to consult later). If it
+        // can't be created -- e.g. because a tracked file lost its read
+        // permissions -- that shouldn't block the user's actual command, so
+        // we degrade to a loud warning and continue instead of propagating
+        // the error. We only do this for the specific "couldn't snapshot
+        // the working copy" failure mode; anything else (e.g. an event log
+        // database failure) is a real problem and should still abort.
+        match create_snapshot(effects, git_run_info, repo, event_log_db, event_tx_id) {
+            Ok(_snapshot) => {}
+            Err(err) => match err.downcast_ref::<RepoError>() {
+                Some(RepoError::CreateSnapshot(_)) => {
+                    snapshot_failed = true;
+                    writeln!(
+                        effects.get_error_stream(),
+                        "{}",
+                        effects.get_glyphs().render(StyledString::styled(
+                            format!(
+                                "Warning: failed to create a working copy snapshot before this \
+                                 operation, so `git undo` will not be able to restore \
+                                 uncommitted changes for it. Proceeding anyway.\n\
+                                 {err}",
+                            ),
+                            BaseColor::Yellow.light(),
+                        ))?
+                    )?;
+                }
+                _ => return Err(err),
+            },
+        }
     }
 
     let target = if get_auto_switch_branches(repo)? && !reset && !force_detach {
@@ -189,6 +227,28 @@ pub fn check_out_commit(
         if let Some(head_oid) = head_info.oid {
             let head_commit = repo.find_commit_or_fail(head_oid)?;
             if let Some(snapshot) = WorkingCopySnapshot::try_from_base_commit(repo, &head_commit)? {
+                // `restore_snapshot` does a `reset --hard` to discard the
+                // working copy's current contents before restoring the
+                // target snapshot. The pre-checkout snapshot taken above is
+                // the only safety net for those current uncommitted
+                // changes; if it failed, proceeding would silently discard
+                // them, which is exactly the data-loss case the maintainer
+                // wanted to avoid on #1658. Refuse instead.
+                if snapshot_failed {
+                    writeln!(
+                        effects.get_error_stream(),
+                        "{}",
+                        effects.get_glyphs().render(StyledString::styled(
+                            "Error: refusing to restore the working copy snapshot, because the \
+                             current uncommitted changes could not be snapshotted first (see the \
+                             warning above), and restoring would permanently discard them. Fix \
+                             the file permissions mentioned above and try again."
+                                .to_string(),
+                            BaseColor::Red.light(),
+                        ))?
+                    )?;
+                    return Ok(Err(ExitCode(1)));
+                }
                 try_exit_code!(restore_snapshot(
                     effects,
                     git_run_info,

--- a/git-branchless-lib/src/git/repo.rs
+++ b/git-branchless-lib/src/git/repo.rs
@@ -291,6 +291,23 @@ pub(super) fn wrap_git_error(error: git2::Error) -> eyre::Error {
     eyre::eyre!("Git error {:?}: {}", error.code(), error.message())
 }
 
+/// Build the `source` used for `Error::CreateBlobFromPath`, appending an
+/// actionable hint when the underlying I/O error indicates a permissions
+/// problem, so that the (possibly fatal) error message tells the user what
+/// to do about it rather than just what went wrong.
+///
+/// See <https://github.com/arxanas/git-branchless/issues/1658>
+fn create_blob_io_error_source(err: std::io::Error, path: &Path) -> eyre::Error {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        eyre::eyre!(
+            "{err} (check the permissions of {path:?}, e.g. `chmod +r '{}'`)",
+            path.display()
+        )
+    } else {
+        err.into()
+    }
+}
+
 /// Clean up a message, removing extraneous whitespace plus comment lines starting with
 /// `comment_char`, and ensure that the message ends with a newline.
 #[instrument]
@@ -1234,10 +1251,8 @@ impl Repo {
             Ok(contents) => contents,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => {
-                return Err(Error::CreateBlobFromPath {
-                    source: err.into(),
-                    path,
-                });
+                let source = create_blob_io_error_source(err, &path);
+                return Err(Error::CreateBlobFromPath { source, path });
             }
         };
         let blob = self.create_blob_from_contents(&contents)?;
@@ -1262,10 +1277,8 @@ impl Repo {
             Ok(link_target) => link_target,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => {
-                return Err(Error::CreateBlobFromPath {
-                    source: err.into(),
-                    path,
-                });
+                let source = create_blob_io_error_source(err, &path);
+                return Err(Error::CreateBlobFromPath { source, path });
             }
         };
 

--- a/git-branchless-lib/tests/test_snapshot.rs
+++ b/git-branchless-lib/tests/test_snapshot.rs
@@ -58,3 +58,144 @@ fn test_has_conflicts() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// If a *tracked* file becomes unreadable (e.g. its permissions were
+/// stripped), `Repo::get_status` should fail with a clear error identifying
+/// the offending path and suggesting that the user check its permissions,
+/// rather than panicking or silently producing a partial snapshot that
+/// omits the unreadable file.
+///
+/// See https://github.com/arxanas/git-branchless/issues/1658
+#[cfg(unix)]
+#[test]
+fn test_get_status_unreadable_tracked_file() -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.write_file_txt("test1", "test1 new contents\n")?;
+
+    let file_path = git.repo_path.join("test1.txt");
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000))?;
+
+    // Root ignores Unix file permission bits, so this test can't validate
+    // anything meaningful when run as root (e.g. in some Docker setups).
+    // Detect that case and skip rather than fail confusingly.
+    let running_as_root = fs::read(&file_path).is_ok();
+    let message: Option<String> = if running_as_root {
+        None
+    } else {
+        let glyphs = Glyphs::text();
+        let effects = Effects::new_suppress_for_test(glyphs);
+        let git_run_info = git.get_git_run_info();
+        let repo = git.get_repo()?;
+        let index = repo.get_index()?;
+        let conn = repo.get_db_conn()?;
+        let event_log_db = EventLogDb::new(&conn)?;
+        let event_tx_id = event_log_db.make_transaction_id(SystemTime::now(), "testing")?;
+        let head_info = repo.get_head_info()?;
+        let result = repo.get_status(
+            &effects,
+            &git_run_info,
+            &index,
+            &head_info,
+            Some(event_tx_id),
+        );
+        match result {
+            Ok(_) => None,
+            Err(err) => Some(format!("{err:#}")),
+        }
+    };
+
+    // Restore permissions so that the temp dir can be cleaned up afterwards.
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+
+    if running_as_root {
+        return Ok(());
+    }
+
+    let message = message.expect("expected get_status to fail for an unreadable tracked file");
+    assert!(
+        message.contains("could not create blob from"),
+        "unexpected error message: {message}"
+    );
+    assert!(
+        message.contains("test1.txt"),
+        "error message should include the offending path: {message}"
+    );
+    // The raw OS error text ("Permission denied (os error 13)") already
+    // mentions "permission", so assert on the project-added, actionable
+    // suggestion specifically (distinct from the raw OS error string) to
+    // make sure we're actually testing our diagnostic, not just libc's.
+    assert!(
+        message.to_lowercase().contains("chmod"),
+        "error message should suggest fixing permissions (e.g. via chmod): {message}"
+    );
+
+    Ok(())
+}
+
+/// An *untracked* unreadable file should never cause `Repo::get_status` (and
+/// therefore snapshot creation) to fail, because untracked files are
+/// excluded from status/snapshots by design (`--untracked-files=no`). This
+/// pins that invariant, per the report thread's request to also cover the
+/// untracked case.
+///
+/// See https://github.com/arxanas/git-branchless/issues/1658
+#[cfg(unix)]
+#[test]
+fn test_get_status_unreadable_untracked_file() -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.write_file_txt("test1", "test1 new contents\n")?;
+    git.write_file_txt("untracked", "untracked contents\n")?;
+
+    let file_path = git.repo_path.join("untracked.txt");
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000))?;
+
+    let running_as_root = fs::read(&file_path).is_ok();
+    let status: Option<Result<Vec<branchless::git::StatusEntry>, _>> = if running_as_root {
+        None
+    } else {
+        let glyphs = Glyphs::text();
+        let effects = Effects::new_suppress_for_test(glyphs);
+        let git_run_info = git.get_git_run_info();
+        let repo = git.get_repo()?;
+        let index = repo.get_index()?;
+        let conn = repo.get_db_conn()?;
+        let event_log_db = EventLogDb::new(&conn)?;
+        let event_tx_id = event_log_db.make_transaction_id(SystemTime::now(), "testing")?;
+        let head_info = repo.get_head_info()?;
+        let result = repo.get_status(
+            &effects,
+            &git_run_info,
+            &index,
+            &head_info,
+            Some(event_tx_id),
+        );
+        Some(result.map(|(_snapshot, status)| status))
+    };
+
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+
+    if running_as_root {
+        return Ok(());
+    }
+
+    use std::path::Path;
+    let status = status.expect("guarded by running_as_root check above")?;
+    assert!(
+        status
+            .iter()
+            .all(|entry| entry.path != Path::new("untracked.txt")),
+        "untracked files should never be included in status/snapshots: {status:?}"
+    );
+
+    Ok(())
+}

--- a/git-branchless/src/commands/mod.rs
+++ b/git-branchless/src/commands/mod.rs
@@ -271,7 +271,6 @@ pub fn main() {
     color_eyre::install().expect("Could not install panic handler");
     let args: Vec<_> = std::env::args_os().collect();
     let args = rewrite_args(args);
-    let exit_code = git_branchless_invoke::do_main_and_drop_locals(command_main, args)
-        .expect("A fatal error occurred");
-    std::process::exit(exit_code);
+    let result = git_branchless_invoke::do_main_and_drop_locals(command_main, args);
+    git_branchless_invoke::exit_with_result(result)
 }

--- a/git-branchless/tests/test_init.rs
+++ b/git-branchless/tests/test_init.rs
@@ -290,8 +290,10 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
         "smartlog",
         &[],
         &GitRunOptions {
-            // Exit code 101 indicates a panic.
-            expected_exit_code: 101,
+            // Top-level fatal errors are rendered gracefully and exit 1;
+            // they no longer panic (exit code 101). See
+            // https://github.com/arxanas/git-branchless/issues/1658
+            expected_exit_code: 1,
 
             ..Default::default()
         },
@@ -302,8 +304,7 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
     let stderr = console::strip_ansi_codes(&stderr);
     let stderr = location_trace_re.replace_all(&stderr, "some/file/path.rs:123");
     insta::assert_snapshot!(stderr, @r#"
-    The application panicked (crashed).
-    Message:  A fatal error occurred:
+    Error:
        0: Could not find repository main branch
 
     Location:
@@ -328,10 +329,6 @@ fn test_main_branch_not_found_error_message() -> eyre::Result<()> {
 
     Note that remote main branches are no longer supported as of v0.6.0. See
     https://github.com/arxanas/git-branchless/discussions/595 for more details.
-
-    Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
-    Run with RUST_BACKTRACE=full to include source snippets.
-    Location: some/file/path.rs:123
 
     Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
     Run with RUST_BACKTRACE=full to include source snippets.

--- a/git-branchless/tests/test_navigation.rs
+++ b/git-branchless/tests/test_navigation.rs
@@ -1097,3 +1097,71 @@ fn test_switch_detach() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// When the opportunistic undo-snapshot taken before a checkout can't be
+/// created (e.g. because a tracked file lost its read permissions), the
+/// command should proceed with a loud warning rather than panicking, and the
+/// checkout should still succeed. See
+/// https://github.com/arxanas/git-branchless/issues/1658
+#[cfg(unix)]
+#[test]
+fn test_switch_unreadable_tracked_file_warns_but_proceeds() -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = make_git()?;
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+    git.run(&["checkout", "master"])?;
+
+    // Make an uncommitted change to a tracked file, then strip its read
+    // permission, so that the opportunistic pre-checkout snapshot fails to
+    // read it.
+    git.write_file_txt("test1", "test1 modified contents\n")?;
+    let file_path = git.repo_path.join("test1.txt");
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000))?;
+
+    // Root ignores Unix file permission bits, so skip when running as root
+    // (e.g. some Docker/CI setups) rather than fail confusingly.
+    let running_as_root = fs::read(&file_path).is_ok();
+    if running_as_root {
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+        return Ok(());
+    }
+
+    let result = git.branchless_with_options(
+        "switch",
+        &["-d", "master^"],
+        &GitRunOptions {
+            expected_exit_code: 0,
+            ..Default::default()
+        },
+    );
+
+    // Restore permissions so that the temp dir can be cleaned up afterwards,
+    // regardless of the outcome above.
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+
+    let (_stdout, stderr) = result?;
+    assert!(
+        stderr.to_lowercase().contains("warning"),
+        "expected a warning about the failed snapshot in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("test1.txt"),
+        "expected the warning to name the offending path: {stderr}"
+    );
+    assert!(
+        !stderr.contains("The application panicked"),
+        "command should not panic: {stderr}"
+    );
+
+    // The checkout itself should have succeeded despite the snapshot failure.
+    let head_info = git.get_repo()?.get_head_info()?;
+    let head_oid = head_info.oid.expect("expected HEAD to be resolved");
+    let (master_parent_oid, _stderr) = git.run(&["rev-parse", "master^"])?;
+    assert_eq!(head_oid.to_string(), master_parent_oid.trim());
+
+    Ok(())
+}

--- a/git-branchless/tests/test_snapshot.rs
+++ b/git-branchless/tests/test_snapshot.rs
@@ -3,6 +3,157 @@ use std::str::FromStr;
 use lib::git::NonZeroOid;
 use lib::testing::{GitInitOptions, GitRunOptions, make_git, trim_lines};
 
+/// `git branchless snapshot create` is a load-bearing use of snapshot
+/// creation (the snapshot *is* the output, and it's immediately followed by
+/// a `git reset --hard`), so it must fail cleanly -- with a rendered error
+/// and non-panic exit code -- rather than silently degrading, when a tracked
+/// file can't be read. Crucially, it must fail *before* discarding the
+/// working copy via `reset --hard`, so no data is lost.
+/// See https://github.com/arxanas/git-branchless/issues/1658
+#[cfg(unix)]
+#[test]
+fn test_snapshot_create_unreadable_tracked_file_fails_cleanly() -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.write_file_txt("test1", "test1 modified contents\n")?;
+
+    let file_path = git.repo_path.join("test1.txt");
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000))?;
+
+    let running_as_root = fs::read(&file_path).is_ok();
+    if running_as_root {
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+        return Ok(());
+    }
+
+    let result = git.branchless_with_options(
+        "snapshot",
+        &["create"],
+        &GitRunOptions {
+            // Exit 1 is the rendered-error exit code used when a fatal
+            // error is reported via color-eyre instead of a panic (which
+            // would instead exit 101); see `exit_with_result`.
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    );
+
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+
+    let (_stdout, stderr) = result?;
+    assert!(
+        stderr.contains("could not create blob from"),
+        "expected the underlying error to be rendered: {stderr}"
+    );
+    assert!(
+        stderr.contains("test1.txt"),
+        "expected the error to name the offending path: {stderr}"
+    );
+    assert!(
+        !stderr.contains("The application panicked"),
+        "command should not panic: {stderr}"
+    );
+
+    // The working copy must not have been reset; the uncommitted
+    // modification (and the permission change) should still be present,
+    // proving that `snapshot create`'s `git reset --hard` never ran.
+    let (status_stdout, _stderr) = git.run(&["status", "--porcelain=2"])?;
+    assert!(
+        !status_stdout.trim().is_empty(),
+        "expected the working copy to still show the uncommitted change, \
+         proving the pre-reset snapshot failure aborted before `git reset --hard`"
+    );
+
+    Ok(())
+}
+
+/// If the opportunistic pre-checkout snapshot fails (e.g. because a tracked
+/// file lost its read permissions), and the checkout target turns out to be
+/// a working-copy snapshot's base commit, `restore_snapshot` would
+/// unconditionally discard the current uncommitted changes via `reset
+/// --hard`. Since the pre-checkout snapshot -- the only safety net for
+/// those changes -- failed, proceeding would silently lose them. The
+/// command must refuse instead of running `restore_snapshot`, and it must
+/// leave the working copy untouched.
+/// See https://github.com/arxanas/git-branchless/issues/1658
+#[cfg(unix)]
+#[test]
+fn test_switch_to_snapshot_base_refuses_when_pre_snapshot_fails() -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = make_git()?;
+
+    if !git.supports_reference_transactions()? {
+        return Ok(());
+    }
+    git.init_repo()?;
+    git.commit_file("test1", 1)?;
+    git.commit_file("test2", 2)?;
+
+    // Dirty test2, then snapshot it. `snapshot create` resets the working
+    // copy back to clean afterwards, but the base commit it prints is
+    // recognized by `check_out_commit` as a snapshot base commit if it's
+    // ever checked out directly.
+    git.write_file_txt("test2", "test2 modified contents\n")?;
+    let base_oid = {
+        let (stdout, _stderr) = git.branchless("snapshot", &["create"])?;
+        stdout.trim().to_string()
+    };
+
+    // Now dirty test1 and strip its read permission, so that the
+    // opportunistic pre-checkout snapshot below fails to read it.
+    git.write_file_txt("test1", "test1 modified contents\n")?;
+    let file_path = git.repo_path.join("test1.txt");
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000))?;
+
+    // Root ignores Unix file permission bits, so skip when running as root
+    // (e.g. some Docker/CI setups) rather than fail confusingly.
+    let running_as_root = fs::read(&file_path).is_ok();
+    if running_as_root {
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+        return Ok(());
+    }
+
+    let result = git.branchless_with_options(
+        "switch",
+        &["-d", &base_oid],
+        &GitRunOptions {
+            expected_exit_code: 1,
+            ..Default::default()
+        },
+    );
+
+    // Restore permissions so that the temp dir can be cleaned up afterwards,
+    // regardless of the outcome above.
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644))?;
+
+    let (_stdout, stderr) = result?;
+    assert!(
+        stderr.contains("refusing to restore"),
+        "expected a refusal message about the failed pre-checkout snapshot: {stderr}"
+    );
+    assert!(
+        !stderr.contains("The application panicked"),
+        "command should not panic: {stderr}"
+    );
+
+    // Nothing should have been discarded: test1.txt must still contain the
+    // dirty, unsnapshotted content.
+    let contents = fs::read_to_string(&file_path)?;
+    assert_eq!(contents, "test1 modified contents\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_restore_snapshot_basic() -> eyre::Result<()> {
     let git = make_git()?;


### PR DESCRIPTION
Fixes #1658.

`git sw` panicked when the working copy snapshot hit an unreadable file (`could not create blob from ...: Permission denied (os error 13)`), because the command result was unwrapped with `.expect("A fatal error occurred")` at the top level. this implements the design from the issue thread:

- errors render nicely regardless. both top-level panic sites (`git-branchless/src/commands/mod.rs` and `invoke_subcommand_main`, which covers the standalone subcommand binaries) now route through a shared `exit_with_result` helper that prints the eyre report and exits 1. no more panic banner on any fatal error.
- snapshot failures warn instead of blocking. the snapshot in `check_out_commit` is opportunistic (it exists so `git undo` can restore the operation), so `switch`/`next`/`prev`/etc now print a warning naming the offending path and proceed. permission errors get a `chmod +r` hint. commands that require the snapshot (`snapshot create`, `record`, `amend`, `test --fix`) are untouched and still fail, now with a rendered error instead of a panic.
- no partial snapshots. unchanged: blob creation aborts the whole snapshot via `?`, and the event-log record only lands after the snapshot fully succeeds.

one design note i'd like your eyes on: when the checkout target is itself a snapshot base commit, `check_out_commit` continues into `restore_snapshot`, which runs `reset --hard`. in that flow the pre-checkout snapshot is the only safety net for the current uncommitted changes, and the undo confirmation doesn't mention them. warn-and-proceed there would silently discard the exact changes it just failed to snapshot, which reads like the data-loss case you flagged. so that narrow case refuses with a rendered error (exit 1) instead of proceeding. easy to relax if you'd rather keep the literal "never block" behavior.

tests, all red against master first: lib-level `get_status` on a read-denied tracked file (asserts the chmod hint), an unreadable untracked file (pins the existing exclusion), end-to-end `switch` warning and proceeding, `snapshot create` failing cleanly before its `reset --hard`, and the refuse-to-restore guard. the 19 pre-existing test failures on my machine are git 2.50.1 insta snapshot mismatches, byte-identical on clean master.
