### PR TITLE
build: set rust-toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 # Current minimum-supported Rust version
 channel = "1.86"
 profile = "default"
+components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
I was running into issues running RA in Zed in this repo because Zed was using their bundled and (very) current version of RA and it was panicing, presumably due to some version incompat between their newer RA and our older rust. Setting these components allows Zed to use the toolchain version of RA and Zed diagnostics are working again.

I don't think that this will affect CI, because we're already installing the tool chain with clippy & rustfmt, so this should just add rust-analyzer for local builds.